### PR TITLE
Name phase folders with phase numbers

### DIFF
--- a/agentmux/models.py
+++ b/agentmux/models.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+SESSION_DIR_NAMES: dict[str, str] = {
+    "product_management": "01_product_management",
+    "planning": "02_planning",
+    "research": "03_research",
+    "design": "04_design",
+    "implementation": "05_implementation",
+    "review": "06_review",
+    "docs": "07_docs",
+    "completion": "08_completion",
+}
+
 
 @dataclass(frozen=True)
 class AgentConfig:
@@ -27,6 +38,7 @@ class GitHubConfig:
 class RuntimeFiles:
     project_dir: Path
     feature_dir: Path
+    product_management_dir: Path
     planning_dir: Path
     research_dir: Path
     design_dir: Path
@@ -45,3 +57,6 @@ class RuntimeFiles:
     state: Path
     runtime_state: Path
     orchestrator_log: Path
+
+    def relative_path(self, path: Path) -> str:
+        return path.relative_to(self.feature_dir).as_posix()

--- a/agentmux/monitor.py
+++ b/agentmux/monitor.py
@@ -78,11 +78,11 @@ EVENT_LABELS: dict[str, str] = {
     "pm_completed": "pm done",
 }
 DOCUMENT_FILES = [
-    "planning/plan.md",
-    "planning/tasks.md",
-    "design/design.md",
-    "review/review.md",
-    "completion/changes.md",
+    "02_planning/plan.md",
+    "02_planning/tasks.md",
+    "04_design/design.md",
+    "06_review/review.md",
+    "08_completion/changes.md",
 ]
 
 

--- a/agentmux/phases.py
+++ b/agentmux/phases.py
@@ -154,7 +154,7 @@ class _ResearchDispatchMixin:
                     done_marker.unlink()
                 prompt_file = write_prompt_file(
                     ctx.files.feature_dir,
-                    f"research/code-{t}/prompt.md",
+                    ctx.files.relative_path(ctx.files.research_dir / f"code-{t}" / "prompt.md"),
                     build_code_researcher_prompt(t, ctx.files),
                 )
                 ctx.runtime.spawn_task("code-researcher", t, prompt_file)
@@ -174,8 +174,8 @@ class _ResearchDispatchMixin:
                     owner_pane,
                     (
                         f"Code-research on '{topic}' is complete. Read "
-                        f"research/code-{topic}/summary.md first, then "
-                        f"research/code-{topic}/detail.md if you need more detail, and continue from there."
+                        f"{ctx.files.relative_path(ctx.files.research_dir / f'code-{topic}' / 'summary.md')} first, then "
+                        f"{ctx.files.relative_path(ctx.files.research_dir / f'code-{topic}' / 'detail.md')} if you need more detail, and continue from there."
                     ),
                 )
             research_tasks = {
@@ -206,7 +206,7 @@ class _ResearchDispatchMixin:
                     done_marker.unlink()
                 prompt_file = write_prompt_file(
                     ctx.files.feature_dir,
-                    f"research/web-{t}/prompt.md",
+                    ctx.files.relative_path(ctx.files.research_dir / f"web-{t}" / "prompt.md"),
                     build_web_researcher_prompt(t, ctx.files),
                 )
                 ctx.runtime.spawn_task("web-researcher", t, prompt_file)
@@ -226,8 +226,8 @@ class _ResearchDispatchMixin:
                     owner_pane,
                     (
                         f"Web research on '{topic}' is complete. Read "
-                        f"research/web-{topic}/summary.md first, then "
-                        f"research/web-{topic}/detail.md if you need more detail, and continue from there."
+                        f"{ctx.files.relative_path(ctx.files.research_dir / f'web-{topic}' / 'summary.md')} first, then "
+                        f"{ctx.files.relative_path(ctx.files.research_dir / f'web-{topic}' / 'detail.md')} if you need more detail, and continue from there."
                     ),
                 )
             web_research_tasks = {
@@ -250,7 +250,7 @@ class ProductManagementPhase(_ResearchDispatchMixin, Phase):
         _ = state
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            "product_management/product_manager_prompt.md",
+            ctx.files.relative_path(ctx.files.product_management_dir / "product_manager_prompt.md"),
             build_product_manager_prompt(ctx.files),
         )
         send_to_role(ctx, "product-manager", prompt_file)
@@ -258,7 +258,7 @@ class ProductManagementPhase(_ResearchDispatchMixin, Phase):
     def snapshot_inputs(self, state: dict, ctx: PipelineContext) -> dict[str, str | None]:
         _ = state
         snapshot = {
-            "pm_done": file_signature(ctx.files.feature_dir / "product_management" / "done"),
+            "pm_done": file_signature(ctx.files.product_management_dir / "done"),
         }
         snapshot.update(self._research_snapshot(ctx))
         return snapshot
@@ -267,7 +267,7 @@ class ProductManagementPhase(_ResearchDispatchMixin, Phase):
         if phase_input_changed(
             ctx,
             "pm_done",
-            file_signature(ctx.files.feature_dir / "product_management" / "done"),
+            file_signature(ctx.files.product_management_dir / "done"),
         ):
             return "pm_completed"
         return self._detect_research_event(state, ctx)
@@ -288,7 +288,9 @@ class PlanningPhase(_ResearchDispatchMixin, Phase):
         is_replan = state.get("last_event") == "changes_requested" and ctx.files.changes.exists()
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            f"planning/{'changes_prompt.txt' if is_replan else 'architect_prompt.md'}",
+            ctx.files.relative_path(
+                ctx.files.planning_dir / ("changes_prompt.txt" if is_replan else "architect_prompt.md")
+            ),
             build_change_prompt(ctx.files) if is_replan else build_architect_prompt(ctx.files),
         )
         send_to_role(ctx, "architect", prompt_file)
@@ -344,7 +346,7 @@ class DesigningPhase(Phase):
         _ = state
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            "design/designer_prompt.md",
+            ctx.files.relative_path(ctx.files.design_dir / "designer_prompt.md"),
             build_designer_prompt(ctx.files),
         )
         send_to_role(ctx, "designer", prompt_file)
@@ -372,6 +374,7 @@ class ImplementingPhase(Phase):
 
     def on_enter(self, state: dict, ctx: PipelineContext) -> None:
         reset_markers(ctx.files.implementation_dir, "done_*")
+        ctx.runtime.kill_primary("coder")
 
         subplan_paths = split_plan_into_subplans(ctx.files.plan, ctx.files.planning_dir)
         subplan_count = len(subplan_paths)
@@ -383,7 +386,7 @@ class ImplementingPhase(Phase):
         if subplan_count == 1:
             prompt_file = write_prompt_file(
                 ctx.files.feature_dir,
-                "implementation/coder_prompt.md",
+                ctx.files.relative_path(ctx.files.implementation_dir / "coder_prompt.md"),
                 build_coder_prompt(ctx.files),
             )
             send_to_role(ctx, "coder", prompt_file)
@@ -394,7 +397,9 @@ class ImplementingPhase(Phase):
             prompt_files.append(
                 write_prompt_file(
                     ctx.files.feature_dir,
-                    f"implementation/coder_prompt_{subplan_index}.txt",
+                    ctx.files.relative_path(
+                        ctx.files.implementation_dir / f"coder_prompt_{subplan_index}.txt"
+                    ),
                     build_coder_subplan_prompt(
                         ctx.files,
                         subplan_path=subplan_path,
@@ -446,7 +451,7 @@ class ReviewingPhase(Phase):
             ctx.files.review.unlink()
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            "review/review_prompt.md",
+            ctx.files.relative_path(ctx.files.review_dir / "review_prompt.md"),
             build_reviewer_prompt(ctx.files, is_review=True),
         )
         send_to_role(ctx, "reviewer", prompt_file)
@@ -496,9 +501,10 @@ class FixingPhase(Phase):
     def on_enter(self, state: dict, ctx: PipelineContext) -> None:
         _ = state
         reset_markers(ctx.files.implementation_dir, "done_*")
+        ctx.runtime.kill_primary("coder")
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            "review/fix_prompt.txt",
+            ctx.files.relative_path(ctx.files.review_dir / "fix_prompt.txt"),
             build_fix_prompt(ctx.files),
         )
         send_to_role(ctx, "coder", prompt_file)
@@ -545,7 +551,7 @@ class DocumentingPhase(Phase):
             docs_done.unlink()
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            "docs/docs_prompt.txt",
+            ctx.files.relative_path(ctx.files.docs_dir / "docs_prompt.txt"),
             build_docs_prompt(ctx.files),
         )
         send_to_role(ctx, "docs", prompt_file)
@@ -578,7 +584,7 @@ class CompletingPhase(Phase):
             approval_path.unlink()
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
-            "completion/confirmation_prompt.md",
+            ctx.files.relative_path(ctx.files.completion_dir / "confirmation_prompt.md"),
             build_confirmation_prompt(ctx.files),
         )
         send_to_role(ctx, "reviewer", prompt_file)

--- a/agentmux/prompts.py
+++ b/agentmux/prompts.py
@@ -62,9 +62,10 @@ def build_reviewer_prompt(files: RuntimeFiles, is_review: bool = False) -> str:
 
 
 def build_coder_prompt(files: RuntimeFiles) -> str:
+    completion_marker = files.relative_path(files.implementation_dir / "done_1")
     completion_instruction = (
         "FINAL STEP ONLY — once all code is written and nothing else remains, "
-        "create the completion marker file `implementation/done_1` in the session directory "
+        f"create the completion marker file `{completion_marker}` in the session directory "
         "and leave it empty. This must be the very last action you take."
     )
     completion_constraints = "\n".join([
@@ -78,7 +79,7 @@ def build_coder_prompt(files: RuntimeFiles) -> str:
     ).format_map({
         "feature_dir": files.feature_dir,
         "project_dir": files.project_dir,
-        "plan_file": "planning/plan.md",
+        "plan_file": files.relative_path(files.plan),
         "completion_instruction": completion_instruction,
         "completion_constraints": completion_constraints,
     })
@@ -111,9 +112,10 @@ def build_coder_subplan_prompt(
     subplan_index: int,
 ) -> str:
     marker_name = f"done_{subplan_index}"
+    completion_marker = files.relative_path(files.implementation_dir / marker_name)
     completion_instruction = (
         "FINAL STEP ONLY — once all code is written and nothing else remains, "
-        f"create the completion marker file `implementation/{marker_name}` in the session directory "
+        f"create the completion marker file `{completion_marker}` in the session directory "
         "and leave it empty. This must be the very last action you take."
     )
     completion_constraints = "\n".join([
@@ -127,7 +129,7 @@ def build_coder_subplan_prompt(
     ).format_map({
         "feature_dir": files.feature_dir,
         "project_dir": files.project_dir,
-        "plan_file": f"planning/{subplan_path.name}",
+        "plan_file": files.relative_path(subplan_path),
         "completion_instruction": completion_instruction,
         "completion_constraints": completion_constraints,
     })
@@ -209,7 +211,7 @@ def build_initial_prompts(files: RuntimeFiles) -> dict[str, Path]:
     return {
         "architect": write_prompt_file(
             files.feature_dir,
-            "planning/architect_prompt.md",
+            files.relative_path(files.planning_dir / "architect_prompt.md"),
             build_architect_prompt(files),
         ),
     }

--- a/agentmux/prompts/agents/architect.md
+++ b/agentmux/prompts/agents/architect.md
@@ -17,12 +17,12 @@ Before drafting the plan, assess what you need to know about the codebase or ext
 1. Call `agentmux_research_dispatch_code` with your topic, context, `questions=[...]`, `feature_dir="{feature_dir}"`, and `scope_hints=[...]`.
 2. After dispatching, stop and wait idle. Do not poll and do not call another MCP wait tool.
 3. AgentMux will send you a follow-up message when research is complete.
-4. When that message arrives, read `research/code-<topic>/summary.md` first and `research/code-<topic>/detail.md` only if needed.
+4. When that message arrives, read `03_research/code-<topic>/summary.md` first and `03_research/code-<topic>/detail.md` only if needed.
 
 **Delegate to web-researcher** for external information — library APIs, version compatibility, ecosystem best practices:
 1. Call `agentmux_research_dispatch_web` with your topic, context, `questions=[...]`, `feature_dir="{feature_dir}"`, and `scope_hints=[...]`.
 2. After dispatching, stop and wait idle for AgentMux to notify you that the result files are ready.
-3. Then read `research/web-<topic>/summary.md` first and `research/web-<topic>/detail.md` if needed.
+3. Then read `03_research/web-<topic>/summary.md` first and `03_research/web-<topic>/detail.md` if needed.
 
 You can dispatch multiple topics before going idle. Research tasks run in parallel.
 
@@ -31,7 +31,7 @@ Use a JSON-style array for `scope_hints`, not a single string. Example:
 
 **IMPORTANT:** Do NOT use your built-in tools (web search, code exploration sub-agents, etc.) for research. Use the MCP research tools described above. Your built-in tools bypass the pipeline's agent coordination.
 
-**Fallback:** If the MCP research tools are not available, create `research/code-<topic>/request.md` or `research/web-<topic>/request.md` manually. Format each request file as:
+**Fallback:** If the MCP research tools are not available, create `03_research/code-<topic>/request.md` or `03_research/web-<topic>/request.md` manually. Format each request file as:
 
 ```
 ## Context
@@ -46,7 +46,7 @@ What you are planning and why you need this information.
 - What to ignore (if relevant)
 ```
 
-Do not poll for `done` yourself. AgentMux will notify you when `research/code-<topic>/done` or `research/web-<topic>/done` appears. After that, read `research/code-<topic>/summary.md` or `research/web-<topic>/summary.md`; detailed artifacts are `research/code-<topic>/detail.md` and `research/web-<topic>/detail.md`.
+Do not poll for `done` yourself. AgentMux will notify you when `03_research/code-<topic>/done` or `03_research/web-<topic>/done` appears. After that, read `03_research/code-<topic>/summary.md` or `03_research/web-<topic>/summary.md`; detailed artifacts are `03_research/code-<topic>/detail.md` and `03_research/web-<topic>/detail.md`.
 
 ## Your job
 
@@ -59,9 +59,9 @@ Do not poll for `done` yourself. AgentMux will notify you when `research/code-<t
 7. If not parallelizable, write a single implementation plan without sub-plan headers.
 8. Do not implement code, run implementation validation, or produce UI design artifacts.
 9. Wait for the user to review. Incorporate any feedback and revise the draft as needed. Repeat until the user explicitly approves.
-10. Only after the user explicitly approves (e.g. says 'approved', 'looks good', 'go ahead'), write the final plan to `planning/plan.md`.
-11. After writing `planning/plan.md`, also write `planning/tasks.md` as a numbered checklist derived from the plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z"). If you created sub-plans, group tasks under the corresponding `## Sub-plan <N>: <title>` header.
-12. After writing `planning/plan.md` and `planning/tasks.md`, write `planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false }}`. Set it to `true` only when the plan requires a dedicated design handoff before coding.
+10. Only after the user explicitly approves (e.g. says 'approved', 'looks good', 'go ahead'), write the final plan to `02_planning/plan.md`.
+11. After writing `02_planning/plan.md`, also write `02_planning/tasks.md` as a numbered checklist derived from the plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z"). If you created sub-plans, group tasks under the corresponding `## Sub-plan <N>: <title>` header.
+12. After writing `02_planning/plan.md` and `02_planning/tasks.md`, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false }}`. Set it to `true` only when the plan requires a dedicated design handoff before coding.
 13. FINAL STEP ONLY — after writing the planning artifacts, stop. Do not update `state.json` or any workflow status from this step.
 
 {project_instructions}
@@ -69,7 +69,7 @@ Do not poll for `done` yourself. AgentMux will notify you when `research/code-<t
 Constraints:
 - Keep the plan actionable and implementation-oriented.
 - Keep the plan focused on what should be built and how it should be validated.
-- Do not write to `planning/plan.md`/`planning/tasks.md`/`planning/plan_meta.json` before the user approves.
+- Do not write to `02_planning/plan.md`/`02_planning/tasks.md`/`02_planning/plan_meta.json` before the user approves.
 - Do not update `state.json` from the architect planning step.
 - When a topic requires reading more than 3 project files or exploring code patterns you are unfamiliar with, delegate to code-researcher instead of exploring directly.
 - Never use built-in web search or code-exploration tools for research.

--- a/agentmux/prompts/agents/code-researcher.md
+++ b/agentmux/prompts/agents/code-researcher.md
@@ -7,14 +7,14 @@ Topic: {topic}
 Read these files first:
 - context.md
 - requirements.md
-- research/code-{topic}/request.md
+- 03_research/code-{topic}/request.md
 
 Your job:
-1. Analyze the request in `research/code-{topic}/request.md`. Note the context, questions, and scope hints.
+1. Analyze the request in `03_research/code-{topic}/request.md`. Note the context, questions, and scope hints.
 2. Investigate relevant code and documentation in the project directory.
-3. Write `research/code-{topic}/summary.md` for the architect (see format below).
-4. Write `research/code-{topic}/detail.md` for designer/coder agents (see format below).
-5. FINAL STEP ONLY — create the completion marker file `research/code-{topic}/done` in the session directory and leave it empty.
+3. Write `03_research/code-{topic}/summary.md` for the architect (see format below).
+4. Write `03_research/code-{topic}/detail.md` for designer/coder agents (see format below).
+5. FINAL STEP ONLY — create the completion marker file `03_research/code-{topic}/done` in the session directory and leave it empty.
 
 ## Output format
 

--- a/agentmux/prompts/agents/coder.md
+++ b/agentmux/prompts/agents/coder.md
@@ -6,23 +6,23 @@ Read these files first:
 - context.md
 - requirements.md
 - {plan_file}
-- planning/tasks.md
-- design/design.md (if present)
+- 02_planning/tasks.md
+- 04_design/design.md (if present)
 - state.json
 
 Your job:
 1. You must at first create tests that implement the requirements.
 2. Implement the plan in the project directory {project_dir}.
-3. Keep the implementation aligned with `requirements.md`, `{plan_file}`, and `planning/tasks.md`.
-4. Use `planning/tasks.md` as implementation guidance and check off items as completed.
-5. If `design/design.md` is present, follow it for UI-related work.
+3. Keep the implementation aligned with `requirements.md`, `{plan_file}`, and `02_planning/tasks.md`.
+4. Use `02_planning/tasks.md` as implementation guidance and check off items as completed.
+5. If `04_design/design.md` is present, follow it for UI-related work.
 6. Change only task-relevant files and avoid drive-by cleanup or formatting outside the requested work.
 7. Run at least the relevant validation steps for the change. This includes tests and any other appropriate checks such as lint, build, or typecheck when they are relevant to the changed code.
 8. Do not write the review.
 9. If you hit an ambiguity or blocker that prevents correct implementation, record it clearly in the shared feature directory instead of guessing.
 10. You are only finished when the required validation passes.
 11. Record any notable risks, follow-ups, or breaking changes in the shared feature directory if they remain after implementation.
-12. If implementation reveals that requirements or the plan need adjustment (e.g. a requirement turns out to be infeasible as written, or a task needs to be split or reordered), update `requirements.md` and `{plan_file}` / `planning/tasks.md` accordingly so they stay in sync with reality.
+12. If implementation reveals that requirements or the plan need adjustment (e.g. a requirement turns out to be infeasible as written, or a task needs to be split or reordered), update `requirements.md` and `{plan_file}` / `02_planning/tasks.md` accordingly so they stay in sync with reality.
 13. {completion_instruction}
 
 {project_instructions}

--- a/agentmux/prompts/agents/designer.md
+++ b/agentmux/prompts/agents/designer.md
@@ -6,12 +6,12 @@ The project codebase is at `{project_dir}`; reference it for existing patterns a
 Read these files first:
 - context.md
 - requirements.md
-- planning/plan.md
+- 02_planning/plan.md
 - state.json
 
 Your job:
 1. First run `/frontend-design` to load the frontend design skill.
-2. Create a detailed design handoff in `design/design.md` for any new UI views/components.
+2. Create a detailed design handoff in `04_design/design.md` for any new UI views/components.
 3. The design handoff must cover component structure, layout behavior, visual system details, interaction states, accessibility expectations, and any notable design decisions the coder must preserve.
 4. Respect the existing product styles, patterns, and design system unless the plan explicitly calls for a new direction.
 5. You may create presentational design artifacts in the session directory (for example `.css`, `.html`, `.svg`) when useful.

--- a/agentmux/prompts/agents/product-manager.md
+++ b/agentmux/prompts/agents/product-manager.md
@@ -25,7 +25,7 @@ Example:
 
 **IMPORTANT:** Do NOT use your built-in tools (web search, code exploration sub-agents, etc.) for research. Use the MCP research tools above so the pipeline can coordinate researcher agents.
 
-**Fallback:** If MCP research tools are unavailable, write `research/code-<topic>/request.md` or `research/web-<topic>/request.md` manually.
+**Fallback:** If MCP research tools are unavailable, write `03_research/code-<topic>/request.md` or `03_research/web-<topic>/request.md` manually.
 Format each request as:
 
 ```
@@ -41,7 +41,7 @@ What you are analyzing and why.
 - What to ignore (if relevant)
 ```
 
-Do not poll for completion markers yourself. AgentMux will notify you when `research/code-<topic>/done` or `research/web-<topic>/done` appears, then you should read `research/code-<topic>/summary.md` or `research/web-<topic>/summary.md` first, and `research/code-<topic>/detail.md` / `research/web-<topic>/detail.md` when needed.
+Do not poll for completion markers yourself. AgentMux will notify you when `03_research/code-<topic>/done` or `03_research/web-<topic>/done` appears, then you should read `03_research/code-<topic>/summary.md` or `03_research/web-<topic>/summary.md` first, and `03_research/code-<topic>/detail.md` / `03_research/web-<topic>/detail.md` when needed.
 
 ## Your perspective
 
@@ -57,12 +57,12 @@ You represent the customer. Your primary lens is usability: how easy and intuiti
 6. Present your analysis in chat for review and discussion before writing files.
 7. Wait for explicit user approval before writing final artifacts.
 8. After approval, write:
-   - `product_management/analysis.md` (usability assessment, integration fit, alternatives)
+   - `01_product_management/analysis.md` (usability assessment, integration fit, alternatives)
    - updated `requirements.md` (refined requirements)
-   - optionally `design/design.md` when the feature needs UI direction
-   - `product_management/done` as completion marker
-9. If you produce UI design, use `/frontend-design` style guidance and write the design artifact to `design/design.md`.
-10. FINAL STEP ONLY — create `product_management/done` and stop.
+   - optionally `04_design/design.md` when the feature needs UI direction
+   - `01_product_management/done` as completion marker
+9. If you produce UI design, use `/frontend-design` style guidance and write the design artifact to `04_design/design.md`.
+10. FINAL STEP ONLY — create `01_product_management/done` and stop.
 
 {project_instructions}
 

--- a/agentmux/prompts/agents/reviewer.md
+++ b/agentmux/prompts/agents/reviewer.md
@@ -7,4 +7,4 @@ You review implementations against requirements and plans, and handle user confi
 {project_instructions}
 
 Constraints:
-- Keep review and confirmation guidance aligned with `requirements.md` and `planning/plan.md`.
+- Keep review and confirmation guidance aligned with `requirements.md` and `02_planning/plan.md`.

--- a/agentmux/prompts/agents/web-researcher.md
+++ b/agentmux/prompts/agents/web-researcher.md
@@ -7,16 +7,16 @@ Topic: {topic}
 Read these files first:
 - context.md
 - requirements.md
-- research/web-{topic}/request.md
+- 03_research/web-{topic}/request.md
 
 Your job:
-1. Analyze the assignment in `research/web-{topic}/request.md`. Note the context, questions, and scope.
+1. Analyze the assignment in `03_research/web-{topic}/request.md`. Note the context, questions, and scope.
 2. Research the requested topics on the web via WebSearch/WebFetch.
 3. Be exact about version numbers and compatibility details. Cite source URLs for each concrete version claim.
 4. If you cannot verify something, say explicitly that you could not find reliable information.
-5. Write `research/web-{topic}/summary.md` for the architect (see format below).
-6. Write `research/web-{topic}/detail.md` for coder/designer agents (see format below).
-7. FINAL STEP ONLY — create the completion marker file `research/web-{topic}/done` in the session directory and leave it empty.
+5. Write `03_research/web-{topic}/summary.md` for the architect (see format below).
+6. Write `03_research/web-{topic}/detail.md` for coder/designer agents (see format below).
+7. FINAL STEP ONLY — create the completion marker file `03_research/web-{topic}/done` in the session directory and leave it empty.
 
 ## Output format
 

--- a/agentmux/prompts/commands/change.md
+++ b/agentmux/prompts/commands/change.md
@@ -4,16 +4,16 @@ Session directory: {feature_dir}
 
 Read these files first:
 - requirements.md
-- planning/plan.md
-- planning/tasks.md
-- completion/changes.md
+- 02_planning/plan.md
+- 02_planning/tasks.md
+- 08_completion/changes.md
 
 Your job:
 1. Revise requirements/plan as needed based on the change feedback.
 2. Present the revised implementation plan in chat for user approval.
 3. Iterate with the user until explicit approval.
-4. After writing `planning/plan.md`, also write `planning/tasks.md` as a numbered checklist derived from the plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z"). If you created sub-plans, group tasks under the corresponding `## Sub-plan <N>: <title>` header.
-5. After writing `planning/plan.md` and `planning/tasks.md`, write `planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false }}`.
+4. After writing `02_planning/plan.md`, also write `02_planning/tasks.md` as a numbered checklist derived from the plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z"). If you created sub-plans, group tasks under the corresponding `## Sub-plan <N>: <title>` header.
+5. After writing `02_planning/plan.md` and `02_planning/tasks.md`, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false }}`.
 6. FINAL STEP ONLY — after writing the planning artifacts, stop. Do not update `state.json` or any workflow status from this step.
 
 {project_instructions}
@@ -21,4 +21,4 @@ Your job:
 Constraints:
 - Do not implement code.
 - Do not update `state.json` from the replanning step.
-- Do not write to `planning/plan.md`/`planning/tasks.md`/`planning/plan_meta.json` before explicit user approval.
+- Do not write to `02_planning/plan.md`/`02_planning/tasks.md`/`02_planning/plan_meta.json` before explicit user approval.

--- a/agentmux/prompts/commands/confirmation.md
+++ b/agentmux/prompts/commands/confirmation.md
@@ -5,8 +5,8 @@ Session directory: {feature_dir}
 Read these files first:
 - context.md
 - requirements.md
-- planning/plan.md
-- review/review.md
+- 02_planning/plan.md
+- 06_review/review.md
 - state.json
 
 Your job:
@@ -16,15 +16,15 @@ Your job:
    ```
    {changed_files}
    ```
-4. If the user approves, write `completion/approval.json` with this exact JSON shape:
+4. If the user approves, write `08_completion/approval.json` with this exact JSON shape:
    - `{{"action": "approve", "commit_message": "...", "exclude_files": ["relative/path"]}}`
    - `exclude_files` is optional and defaults to `[]` (commit all changed files).
 5. Ask for exclusions only. Do not ask the user to enumerate all commit files.
-6. If the user requests changes, write the user feedback to `completion/changes.md`.
+6. If the user requests changes, write the user feedback to `08_completion/changes.md`.
 
 {project_instructions}
 
 Constraints:
 - Keep this step focused on user confirmation.
-- Do not revise `planning/plan.md` in this step.
+- Do not revise `02_planning/plan.md` in this step.
 - Do not update `state.json` from the confirmation step.

--- a/agentmux/prompts/commands/docs.md
+++ b/agentmux/prompts/commands/docs.md
@@ -4,15 +4,15 @@ Session directory: {feature_dir}
 
 Read these files first:
 - requirements.md
-- planning/plan.md
+- 02_planning/plan.md
 - state.json
 - {project_dir}/CLAUDE.md
 
 Your job:
-1. Read `requirements.md`, `planning/plan.md` to confirm what was implemented.
+1. Read `requirements.md`, `02_planning/plan.md` to confirm what was implemented.
 2. Update {project_dir}/CLAUDE.md and any other relevant documentation files that is referenced there in the repository so docs match the implemented changes.
 3. Keep documentation changes focused and accurate to what is already implemented.
-4. FINAL STEP ONLY — once all documentation updates are complete, create the completion marker file `docs/docs_done` in the session directory and leave it empty. This must be the very last action you take.
+4. FINAL STEP ONLY — once all documentation updates are complete, create the completion marker file `07_docs/docs_done` in the session directory and leave it empty. This must be the very last action you take.
 
 {project_instructions}
 

--- a/agentmux/prompts/commands/fix.md
+++ b/agentmux/prompts/commands/fix.md
@@ -5,15 +5,15 @@ Session directory: {feature_dir}
 Read these files first:
 - context.md
 - requirements.md
-- planning/plan.md
-- review/fix_request.md
+- 02_planning/plan.md
+- 06_review/fix_request.md
 - state.json
 
 Your job:
-1. Read the review findings in `review/fix_request.md` carefully.
+1. Read the review findings in `06_review/fix_request.md` carefully.
 2. Fix each finding in the project directory {project_dir}.
 3. Do NOT re-implement from scratch — only address the listed findings.
-4. FINAL STEP ONLY — once all fixes are applied, create the completion marker file `implementation/done_1` in the session directory and leave it empty.
+4. FINAL STEP ONLY — once all fixes are applied, create the completion marker file `05_implementation/done_1` in the session directory and leave it empty.
 
 {project_instructions}
 

--- a/agentmux/prompts/commands/review.md
+++ b/agentmux/prompts/commands/review.md
@@ -9,13 +9,13 @@ Then inspect the current repository state and compare the implementation against
 
 Your job:
 1. Review the implementation against requirements and plan.
-2. Always write `review/review.md`.
-3. The first line of `review/review.md` must be exactly one of:
+2. Always write `06_review/review.md`.
+3. The first line of `06_review/review.md` must be exactly one of:
    - `verdict: pass`
    - `verdict: fail`
 4. On pass, keep the body brief and summarize what was validated.
 5. On fail, include concrete findings, regressions, gaps, or residual risks.
-6. FINAL STEP ONLY — once `review/review.md` is fully written and nothing else remains, stop. Do not update `state.json` or any workflow status from review.
+6. FINAL STEP ONLY — once `06_review/review.md` is fully written and nothing else remains, stop. Do not update `state.json` or any workflow status from review.
 
 {project_instructions}
 

--- a/agentmux/prompts/context.md
+++ b/agentmux/prompts/context.md
@@ -14,8 +14,8 @@ pipeline handles through its file protocol. Use the file protocol instead.
 
 - **product-manager** — clarifies business requirements and proposes a design direction (optional phase)
 - **architect** — tightens requirements, creates the plan, dispatches research tasks
-- **code-researcher** — explores the codebase on architect request (file: `research/code-<topic>/request.md`)
-- **web-researcher** — searches the web on architect request (file: `research/web-<topic>/request.md`)
+- **code-researcher** — explores the codebase on architect request (file: `03_research/code-<topic>/request.md`)
+- **web-researcher** — searches the web on architect request (file: `03_research/web-<topic>/request.md`)
 - **coder** — implements the plan in the project directory
 - **reviewer** — reviews the implementation and handles final user confirmation
 

--- a/agentmux/state.py
+++ b/agentmux/state.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from .models import RuntimeFiles
+from .models import RuntimeFiles, SESSION_DIR_NAMES
 
 STATE_FILE_NAME = "state.json"
 
@@ -65,16 +65,18 @@ def update_phase(
 
 
 def _make_runtime_files(project_dir: Path, feature_dir: Path) -> RuntimeFiles:
-    planning_dir = feature_dir / "planning"
-    research_dir = feature_dir / "research"
-    design_dir = feature_dir / "design"
-    implementation_dir = feature_dir / "implementation"
-    review_dir = feature_dir / "review"
-    docs_dir = feature_dir / "docs"
-    completion_dir = feature_dir / "completion"
+    product_management_dir = feature_dir / SESSION_DIR_NAMES["product_management"]
+    planning_dir = feature_dir / SESSION_DIR_NAMES["planning"]
+    research_dir = feature_dir / SESSION_DIR_NAMES["research"]
+    design_dir = feature_dir / SESSION_DIR_NAMES["design"]
+    implementation_dir = feature_dir / SESSION_DIR_NAMES["implementation"]
+    review_dir = feature_dir / SESSION_DIR_NAMES["review"]
+    docs_dir = feature_dir / SESSION_DIR_NAMES["docs"]
+    completion_dir = feature_dir / SESSION_DIR_NAMES["completion"]
     return RuntimeFiles(
         project_dir=project_dir,
         feature_dir=feature_dir,
+        product_management_dir=product_management_dir,
         planning_dir=planning_dir,
         research_dir=research_dir,
         design_dir=design_dir,
@@ -105,17 +107,6 @@ def create_feature_files(
 ) -> RuntimeFiles:
     feature_dir.mkdir(parents=True, exist_ok=False)
     files = _make_runtime_files(project_dir, feature_dir)
-    for directory in (
-        feature_dir / "product_management",
-        files.planning_dir,
-        files.research_dir,
-        files.design_dir,
-        files.implementation_dir,
-        files.review_dir,
-        files.docs_dir,
-        files.completion_dir,
-    ):
-        directory.mkdir(parents=True, exist_ok=True)
 
     _context_template = (Path(__file__).resolve().parent / "prompts" / "context.md").read_text(encoding="utf-8")
     files.context.write_text(
@@ -178,7 +169,7 @@ def infer_resume_phase(feature_dir: Path, state: dict[str, Any]) -> str:
                 if str(status) != "dispatched"
             }
 
-    product_management_done = feature_dir / "product_management" / "done"
+    product_management_done = feature_dir / SESSION_DIR_NAMES["product_management"] / "done"
     if bool(state.get("product_manager")) and not product_management_done.exists():
         return "product_management"
 
@@ -186,10 +177,10 @@ def infer_resume_phase(feature_dir: Path, state: dict[str, Any]) -> str:
     if phase != "failed":
         return phase
 
-    planning_dir = feature_dir / "planning"
-    implementation_dir = feature_dir / "implementation"
-    review_dir = feature_dir / "review"
-    docs_dir = feature_dir / "docs"
+    planning_dir = feature_dir / SESSION_DIR_NAMES["planning"]
+    implementation_dir = feature_dir / SESSION_DIR_NAMES["implementation"]
+    review_dir = feature_dir / SESSION_DIR_NAMES["review"]
+    docs_dir = feature_dir / SESSION_DIR_NAMES["docs"]
 
     plan_path = planning_dir / "plan.md"
     if not plan_path.exists():
@@ -201,7 +192,7 @@ def infer_resume_phase(feature_dir: Path, state: dict[str, Any]) -> str:
             plan_meta = json.loads(plan_meta_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             plan_meta = {}
-        if bool(plan_meta.get("needs_design")) and not (feature_dir / "design" / "design.md").exists():
+        if bool(plan_meta.get("needs_design")) and not (feature_dir / SESSION_DIR_NAMES["design"] / "design.md").exists():
             return "designing"
 
     subplan_count_raw = state.get("subplan_count")

--- a/docs/completing-phase.md
+++ b/docs/completing-phase.md
@@ -8,9 +8,9 @@ When the review passes, the workflow first terminates all `coder` panes (primary
 
 1. **Confirmation prompt displays changed files** — The confirmation prompt shows all files detected by `git status --porcelain` from the project directory. This gives the architect full visibility into what will be committed.
 
-2. **Architect specifies exclusions (not inclusions)** — Instead of manually enumerating files to commit, the architect simply lists any files to **exclude** from the commit in the `completion/approval.json` response. By default, an empty `exclude_files` list means commit all detected changes.
+2. **Architect specifies exclusions (not inclusions)** — Instead of manually enumerating files to commit, the architect simply lists any files to **exclude** from the commit in the `08_completion/approval.json` response. By default, an empty `exclude_files` list means commit all detected changes.
 
-3. **`completion/approval.json` schema**:
+3. **`08_completion/approval.json` schema**:
    ```json
    {
      "action": "approve",
@@ -21,10 +21,10 @@ When the review passes, the workflow first terminates all `coder` panes (primary
 
 4. **Auto-detection and filtering** — The completing phase handler (`CompletingPhase.handle_event()`) reads git status again when processing the approval, removes any files listed in `exclude_files`, and passes the remaining file list to `commit_changes()`.
 
-5. **Branch + PR creation (best effort)** — If startup state indicates GitHub is available (`gh_available: true`), the completing handler creates a branch (`<github.branch_prefix><feature-slug>`), pushes it, and runs `gh pr create` against `github.base_branch`. PRs default to draft (`github.draft: true`). The PR body is assembled from `requirements.md`, `planning/plan.md`, and `review/review.md`, and includes `Closes #<N>` when the run started with `--issue`.
+5. **Branch + PR creation (best effort)** — If startup state indicates GitHub is available (`gh_available: true`), the completing handler creates a branch (`<github.branch_prefix><feature-slug>`), pushes it, and runs `gh pr create` against `github.base_branch`. PRs default to draft (`github.draft: true`). The PR body is assembled from `requirements.md`, `02_planning/plan.md`, and `06_review/review.md`, and includes `Closes #<N>` when the run started with `--issue`.
 
 6. **Cleanup only on success** — The feature directory is deleted only if the commit succeeds (commit hash is not `None`). If the commit fails, the feature directory is preserved so the user can investigate and retry. GitHub branch/PR failures do not roll back the local commit.
 
 ## Changes requested
 
-If the architect sets `"action": "changes_requested"`, the workflow writes `completion/changes.md` with feedback and transitions back to `planning` for replanning.
+If the architect sets `"action": "changes_requested"`, the workflow writes `08_completion/changes.md` with feedback and transitions back to `planning` for replanning.

--- a/docs/file-protocol.md
+++ b/docs/file-protocol.md
@@ -11,42 +11,42 @@ Agents communicate via files in `.multi-agent/<feature-name>/`. Files are groupe
 - `context.md` — auto-generated rules/session info injected into prompts
 - `runtime_state.json` / `orchestrator.log` — runtime tracking and orchestrator logs
 
-## Product Management (`product_management/`)
+## Product Management (`01_product_management/`)
 
 - `product_manager_prompt.md` — prompt for PM analysis phase
 - `analysis.md` — PM write-up (business case, integration assessment, alternatives)
 - `done` — completion marker for PM handoff to planning
 
-## Planning (`planning/`)
+## Planning (`02_planning/`)
 
 - `architect_prompt.md` / `changes_prompt.txt` — architect prompts
 - `plan.md` / `tasks.md` / `plan_meta.json` — architect planning artifacts
 - `plan_*.md` — subplan files for parallel coder runs
 
-## Research (`research/`)
+## Research (`03_research/`)
 
 - `code-<topic>/request.md` / `summary.md` / `detail.md` / `done` / `prompt.md`
 - `web-<topic>/request.md` / `summary.md` / `detail.md` / `done` / `prompt.md`
 
-## Design (`design/`)
+## Design (`04_design/`)
 
 - `designer_prompt.md` / `design.md`
 
-## Implementation (`implementation/`)
+## Implementation (`05_implementation/`)
 
 - `coder_prompt.md` / `coder_prompt_*.txt`
-- `done_*` — coder completion markers for single or parallel implementation/fixing
+- `done_*` — coder completion markers for single or parallel implementation/fixing runs
 
-## Review (`review/`)
+## Review (`06_review/`)
 
 - `review_prompt.md` / `review.md`
 - `fix_prompt.txt` / `fix_request.md`
 
-## Docs (`docs/`)
+## Docs (`07_docs/`)
 
 - `docs_prompt.txt` / `docs_done`
 
-## Completion (`completion/`)
+## Completion (`08_completion/`)
 
 - `confirmation_prompt.md` / `approval.json`
 - `changes.md`

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -14,7 +14,7 @@ The control pane renders a live status box with the following sections:
   - Inactive agents are filtered out of the AGENTS section
   - For parallel coder mode, only non-inactive `coder_<n>` workers are shown
 - **Research tasks** — progress on code and web research (if any)
-- **Documents** — workflow output files present: `planning/plan.md`, `planning/tasks.md`, `design/design.md`, `review/review.md`, `completion/changes.md` (shown with ✓ when present)
+- **Documents** — workflow output files present: `02_planning/plan.md`, `02_planning/tasks.md`, `04_design/design.md`, `06_review/review.md`, `08_completion/changes.md` (shown with ✓ when present)
 - **Event log** — recent phase transitions with timestamps
 
 ## Key constants

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -11,7 +11,7 @@
 
 Placeholders use `{name}` syntax, rendered via `str.format_map`.
 
-Every template receives `{feature_dir}` as the session directory and references workflow files with phase subpaths (for example `planning/plan.md`, `review/review.md`, `state.json`).
+Every template receives `{feature_dir}` as the session directory and references workflow files with phase subpaths (for example `02_planning/plan.md`, `06_review/review.md`, `state.json`).
 Templates that need project-level context (for example product manager and coder) also receive `{project_dir}`.
 All built-in agent and command templates also include a `{project_instructions}` injection point.
 
@@ -38,7 +38,7 @@ Prompts are not injected as full text. Instead, `send_prompt()` in `agentmux/tmu
 Read and follow the instructions in /full/path/to/prompt_file.md
 ```
 
-Agents read the referenced file themselves, reducing keystroke overhead and allowing agents to reuse file content without re-transmission. All prompt templates use file references (e.g., `requirements.md`, `planning/plan.md`) — agents fetch what they need.
+Agents read the referenced file themselves, reducing keystroke overhead and allowing agents to reuse file content without re-transmission. All prompt templates use file references (e.g., `requirements.md`, `02_planning/plan.md`) — agents fetch what they need.
 
 ## Lazy build
 

--- a/docs/research-dispatch.md
+++ b/docs/research-dispatch.md
@@ -17,7 +17,7 @@ Validation and behavior:
 - `questions` must include at least one non-empty item
 - `feature_dir` should be the session directory shown in the architect or product-manager prompt
 - `scope_hints` may be omitted, passed as a single string, or passed as a list of strings; list form is preferred
-- dispatch writes `research/<type>-<topic>/request.md` with `## Context`, `## Questions`, and `## Scope hints`
+- dispatch writes `03_research/<type>-<topic>/request.md` with `## Context`, `## Questions`, and `## Scope hints`
 
 Typical flow:
 
@@ -31,8 +31,8 @@ Research completion stays file-driven: the orchestrator detects `done`, updates 
 
 If MCP tools are unavailable, the legacy file protocol still works:
 
-- Write `research/code-<topic>/request.md` or `research/web-<topic>/request.md`
-- Wait for `research/<type>-<topic>/done`
+- Write `03_research/code-<topic>/request.md` or `03_research/web-<topic>/request.md`
+- Wait for `03_research/<type>-<topic>/done`
 - Read `summary.md` and optionally `detail.md`
 
 Request files should include:

--- a/docs/session-resumption.md
+++ b/docs/session-resumption.md
@@ -15,7 +15,8 @@ python3 pipeline.py --resume <feature-dir-or-name>  # Resume specific session by
 
 1. `list_resumable_sessions(project_dir)` scans `.multi-agent/` for all feature directories with `state.json` and returns them sorted by recency
 2. `select_session(sessions)` presents an interactive menu (or auto-selects if only one exists)
-3. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`product_management/done`, `planning/plan.md`, `implementation/done_*`, `review/review.md`, etc.) to determine the correct phase to resume into
-4. If `"product_manager": true` in state and `product_management/done` is missing, resume returns `product_management`; once `done` exists, resume falls through to normal planning/implementation inference
+3. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `05_implementation/done_*`, `06_review/review.md`, etc.) to determine the correct phase to resume into
+4. If `"product_manager": true` in state and `01_product_management/done` is missing, resume returns `product_management`; once `done` exists, resume falls through to normal `02_planning` / `05_implementation` inference
 5. On resume, the phase is updated in `state.json`, `last_event` is set to `"resumed"`, and any research tasks with `"dispatched"` status are cleaned up (allowing re-request)
 6. The orchestrator picks up the updated state and injects the appropriate phase prompt to resume work
+7. `implementing` and `fixing` explicitly clear the primary `coder` pane before dispatch so resume never reuses an old shell after the prior coder CLI has exited

--- a/tests/test_code_researcher_requirements.py
+++ b/tests/test_code_researcher_requirements.py
@@ -7,12 +7,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 import agentmux.pipeline as pipeline
-from agentmux.models import AgentConfig
+from agentmux.models import AgentConfig, SESSION_DIR_NAMES
 from agentmux.phases import PlanningPhase
 from agentmux.prompts import build_code_researcher_prompt
 from agentmux.runtime import TmuxAgentRuntime
 from agentmux.state import create_feature_files, load_state, write_state
 from agentmux.transitions import PipelineContext
+
+PLANNING_DIR = SESSION_DIR_NAMES["planning"]
+RESEARCH_DIR = SESSION_DIR_NAMES["research"]
 
 
 class FakeRuntime:
@@ -75,7 +78,7 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
         project_dir.mkdir(parents=True, exist_ok=True)
         files = create_feature_files(project_dir, feature_dir, "add code researcher", "session-x")
 
-        prompts = {"architect": feature_dir / "planning" / "architect_prompt.md"}
+        prompts = {"architect": feature_dir / PLANNING_DIR / "architect_prompt.md"}
         for prompt in prompts.values():
             prompt.parent.mkdir(parents=True, exist_ok=True)
             prompt.write_text(prompt.name, encoding="utf-8")
@@ -129,8 +132,8 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
 
             self.assertIn(str(feature_dir), prompt)
             self.assertIn(str(project_dir), prompt)
-            self.assertIn("research/code-auth-module/request.md", prompt)
-            self.assertIn("research/code-auth-module/done", prompt)
+            self.assertIn("03_research/code-auth-module/request.md", prompt)
+            self.assertIn("03_research/code-auth-module/done", prompt)
 
     def test_runtime_supports_string_task_keys_and_spawn_finish_task(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -196,10 +199,10 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             state["research_tasks"] = {"auth-module": "dispatched"}
             write_state(state_path, state)
 
-            (feature_dir / "research" / "code-db-schema").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "code-auth-module").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "code-db-schema" / "request.md").write_text("look at db", encoding="utf-8")
-            (feature_dir / "research" / "code-auth-module" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "code-db-schema").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "code-auth-module").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "code-db-schema" / "request.md").write_text("look at db", encoding="utf-8")
+            (feature_dir / RESEARCH_DIR / "code-auth-module" / "done").touch()
 
             phase = PlanningPhase()
             event = phase.detect_event(load_state(state_path), ctx)
@@ -208,7 +211,7 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["research_tasks"] = {}
             write_state(state_path, state)
-            (feature_dir / "research" / "code-auth-module" / "done").unlink()
+            (feature_dir / RESEARCH_DIR / "code-auth-module" / "done").unlink()
             event = phase.detect_event(load_state(state_path), ctx)
             self.assertEqual("code_batch_requested", event)
 
@@ -218,9 +221,9 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             ctx, state_path = self._make_ctx(feature_dir)
             _ = state_path
-            (feature_dir / "research" / "code-auth-module").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "code-auth-module" / "request.md").write_text("look at auth", encoding="utf-8")
-            (feature_dir / "research" / "code-auth-module" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "code-auth-module").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "code-auth-module" / "request.md").write_text("look at auth", encoding="utf-8")
+            (feature_dir / RESEARCH_DIR / "code-auth-module" / "done").touch()
 
             snapshot = PlanningPhase().snapshot_inputs({}, ctx)
 
@@ -236,12 +239,12 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             write_state(state_path, state)
 
-            (feature_dir / "research" / "code-auth-module").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "code-auth-module" / "request.md").write_text(
+            (feature_dir / RESEARCH_DIR / "code-auth-module").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "code-auth-module" / "request.md").write_text(
                 "investigate auth",
                 encoding="utf-8",
             )
-            stale_done = feature_dir / "research" / "code-auth-module" / "done"
+            stale_done = feature_dir / RESEARCH_DIR / "code-auth-module" / "done"
             stale_done.touch()
 
             phase = PlanningPhase()
@@ -250,7 +253,7 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             self.assertIsNone(result)
             self.assertFalse(stale_done.exists())
             self.assertEqual(("spawn_task", "code-researcher", "auth-module", "prompt.md"), ctx.runtime.calls[-1])
-            self.assertTrue((feature_dir / "research" / "code-auth-module" / "prompt.md").exists())
+            self.assertTrue((feature_dir / RESEARCH_DIR / "code-auth-module" / "prompt.md").exists())
             updated = load_state(state_path)
             self.assertEqual("dispatched", updated["research_tasks"]["auth-module"])
 
@@ -263,8 +266,8 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             state["research_tasks"] = {"auth-module": "dispatched"}
             write_state(state_path, state)
-            (feature_dir / "research" / "code-auth-module").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "code-auth-module" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "code-auth-module").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "code-auth-module" / "done").touch()
 
             phase = PlanningPhase()
             with patch("agentmux.phases.send_text") as send_text:
@@ -274,7 +277,7 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             self.assertEqual(("finish_task", "code-researcher", "auth-module"), ctx.runtime.calls[-1])
             send_text.assert_called_once_with(
                 "%1",
-                "Code-research on 'auth-module' is complete. Read research/code-auth-module/summary.md first, then research/code-auth-module/detail.md if you need more detail, and continue from there.",
+                "Code-research on 'auth-module' is complete. Read 03_research/code-auth-module/summary.md first, then 03_research/code-auth-module/detail.md if you need more detail, and continue from there.",
             )
             updated = load_state(state_path)
             self.assertEqual("done", updated["research_tasks"]["auth-module"])

--- a/tests/test_completion_commit_flow.py
+++ b/tests/test_completion_commit_flow.py
@@ -100,6 +100,7 @@ class CompletionCommitFlowTests(unittest.TestCase):
                 "commit_message": "test commit",
                 "exclude_files": ["tests/skip.py"],
             }
+            ctx.files.completion_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.completion_dir / "approval.json").write_text(json.dumps(approval), encoding="utf-8")
 
             with patch(
@@ -132,6 +133,7 @@ class CompletionCommitFlowTests(unittest.TestCase):
                 "commit_message": "test commit",
                 "exclude_files": [],
             }
+            ctx.files.completion_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.completion_dir / "approval.json").write_text(json.dumps(approval), encoding="utf-8")
 
             with patch(
@@ -161,6 +163,7 @@ class CompletionCommitFlowTests(unittest.TestCase):
                 "commit_message": "test commit",
                 "exclude_files": [],
             }
+            ctx.files.completion_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.completion_dir / "approval.json").write_text(json.dumps(approval), encoding="utf-8")
 
             with patch(
@@ -197,6 +200,7 @@ class CompletionCommitFlowTests(unittest.TestCase):
                 "commit_message": "test commit",
                 "exclude_files": [],
             }
+            ctx.files.completion_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.completion_dir / "approval.json").write_text(json.dumps(approval), encoding="utf-8")
 
             with patch(

--- a/tests/test_designer_requirements.py
+++ b/tests/test_designer_requirements.py
@@ -6,11 +6,17 @@ import unittest
 from pathlib import Path
 
 import agentmux.pipeline as pipeline
-from agentmux.models import AgentConfig
+from agentmux.models import AgentConfig, SESSION_DIR_NAMES
 from agentmux.phases import PHASES, get_phase, run_phase_cycle
 from agentmux.prompts import build_coder_prompt, build_designer_prompt, build_initial_prompts
 from agentmux.state import create_feature_files, load_runtime_files, load_state, write_state
 from agentmux.transitions import PipelineContext
+
+PLANNING_DIR = SESSION_DIR_NAMES["planning"]
+DESIGN_DIR = SESSION_DIR_NAMES["design"]
+IMPLEMENTATION_DIR = SESSION_DIR_NAMES["implementation"]
+REVIEW_DIR = SESSION_DIR_NAMES["review"]
+COMPLETION_DIR = SESSION_DIR_NAMES["completion"]
 
 
 class FakeRuntime:
@@ -54,7 +60,7 @@ def _make_ctx(feature_dir: Path, with_designer: bool = True) -> tuple[PipelineCo
     project_dir.mkdir(parents=True, exist_ok=True)
     files = create_feature_files(project_dir, feature_dir, "add designer", "session-x")
 
-    prompts = {"architect": feature_dir / "planning" / "architect_prompt.md"}
+    prompts = {"architect": feature_dir / PLANNING_DIR / "architect_prompt.md"}
     for path in prompts.values():
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(path.name, encoding="utf-8")
@@ -102,8 +108,8 @@ class DesignerRequirementsTests(unittest.TestCase):
             files = create_feature_files(project_dir, feature_dir, "do ui", "session")
             loaded = load_runtime_files(project_dir, feature_dir)
 
-            self.assertEqual(feature_dir / "design" / "design.md", files.design)
-            self.assertEqual(feature_dir / "design" / "design.md", loaded.design)
+            self.assertEqual(feature_dir / DESIGN_DIR / "design.md", files.design)
+            self.assertEqual(feature_dir / DESIGN_DIR / "design.md", loaded.design)
             self.assertFalse(files.design.exists())
 
     def test_build_initial_prompts_only_writes_architect_prompt(self) -> None:
@@ -121,13 +127,13 @@ class DesignerRequirementsTests(unittest.TestCase):
 
             self.assertIn("done_1", coder_prompt)
             self.assertIn("frontend-design", designer_prompt)
-            self.assertIn("design/design.md", designer_prompt)
+            self.assertIn("04_design/design.md", designer_prompt)
             self.assertEqual(["architect"], list(initial_prompts.keys()))
             self.assertEqual("architect_prompt.md", initial_prompts["architect"].name)
-            self.assertFalse((feature_dir / "implementation" / "coder_prompt.md").exists())
-            self.assertFalse((feature_dir / "review" / "review_prompt.md").exists())
-            self.assertFalse((feature_dir / "design" / "designer_prompt.md").exists())
-            self.assertFalse((feature_dir / "completion" / "confirmation_prompt.md").exists())
+            self.assertFalse((feature_dir / IMPLEMENTATION_DIR / "coder_prompt.md").exists())
+            self.assertFalse((feature_dir / REVIEW_DIR / "review_prompt.md").exists())
+            self.assertFalse((feature_dir / DESIGN_DIR / "designer_prompt.md").exists())
+            self.assertFalse((feature_dir / COMPLETION_DIR / "confirmation_prompt.md").exists())
 
     def test_plan_written_moves_to_designing_when_plan_meta_requests_design(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -138,7 +144,8 @@ class DesignerRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "planning"
             write_state(state_path, state)
-            (feature_dir / "planning" / "plan_meta.json").write_text('{"needs_design": true}\n', encoding="utf-8")
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan_meta.json").write_text('{"needs_design": true}\n', encoding="utf-8")
 
             phase = get_phase(load_state(state_path))
             phase.handle_event(load_state(state_path), "plan_written", ctx)
@@ -161,7 +168,7 @@ class DesignerRequirementsTests(unittest.TestCase):
             run_phase_cycle(load_state(state_path), ctx)
 
             self.assertEqual([("send", "designer", "designer_prompt.md")], ctx.runtime.calls)
-            self.assertTrue((feature_dir / "design" / "designer_prompt.md").exists())
+            self.assertTrue((feature_dir / DESIGN_DIR / "designer_prompt.md").exists())
 
     def test_design_written_hands_off_to_implementing(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_mcp_pipeline_requirements.py
+++ b/tests/test_mcp_pipeline_requirements.py
@@ -249,8 +249,8 @@ class McpPipelineRequirementsTests(unittest.TestCase):
                 self.assertIn("stop and wait idle", prompt)
                 self.assertIn("summary.md", prompt)
                 self.assertIn("Fallback", prompt)
-                self.assertIn("research/code-<topic>/request.md", prompt)
-                self.assertIn("research/web-<topic>/request.md", prompt)
+                self.assertIn("03_research/code-<topic>/request.md", prompt)
+                self.assertIn("03_research/web-<topic>/request.md", prompt)
 
 
 if __name__ == "__main__":

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -47,7 +47,7 @@ class MonitorTests(unittest.TestCase):
             self.assertIn("╰───────────╯", output)
             self.assertIn("monitor soll auch", output)
             self.assertIn("beschreibung des features", output)
-            self.assertIn("⠋ implementing", output)
+            self.assertIn("▶ implementing", output)
 
     def test_render_falls_back_cleanly_when_monitor_is_narrow(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -68,7 +68,7 @@ class MonitorTests(unittest.TestCase):
             self.assertIn("╭───────────╮", output)
             self.assertIn("monitor soll", output)
             self.assertIn("auch…", output)
-            self.assertIn("⠋ implement", output)
+            self.assertIn("▶ implement", output)
 
     def test_render_hides_optional_phases_when_inactive(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -82,7 +82,7 @@ class MonitorTests(unittest.TestCase):
 
             self.assertIn("✓ planning", output)
             self.assertIn("reviewing", output)
-            self.assertIn("⠋ reviewing", output)
+            self.assertIn("▶ reviewing", output)
             self.assertIn("· completing", output)
             self.assertIn("· done", output)
             self.assertNotIn("designing", output)
@@ -103,10 +103,9 @@ class MonitorTests(unittest.TestCase):
             output = self._render(feature_dir, width=50, height=22)
             stripped = self._strip_ansi(output)
 
-            self.assertIn(f"{monitor.CYAN}⠋ designing", output)
-            self.assertIn("⠋ designing", stripped)
-            self.assertLess(stripped.index("✓ planning"), stripped.index("⠋ designing"))
-            self.assertLess(stripped.index("⠋ designing"), stripped.index("· implementing"))
+            self.assertIn("▶ designing", stripped)
+            self.assertLess(stripped.index("✓ planning"), stripped.index("▶ designing"))
+            self.assertLess(stripped.index("▶ designing"), stripped.index("· implementing"))
 
     def test_render_formats_last_event_label(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -134,17 +133,17 @@ class MonitorTests(unittest.TestCase):
                 encoding="utf-8",
             )
             runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "design").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# plan\n", encoding="utf-8")
-            (feature_dir / "design" / "design.md").write_text("# design\n", encoding="utf-8")
+            (feature_dir / "02_planning").mkdir(parents=True, exist_ok=True)
+            (feature_dir / "04_design").mkdir(parents=True, exist_ok=True)
+            (feature_dir / "02_planning" / "plan.md").write_text("# plan\n", encoding="utf-8")
+            (feature_dir / "04_design" / "design.md").write_text("# design\n", encoding="utf-8")
 
             output = self._strip_ansi(self._render(feature_dir, width=15, height=24))
 
             self.assertIn(" DOCUMENTS", output)
             self.assertIn("› design …", output)
-            self.assertIn("✓ planning/pl…", output)
-            self.assertIn("✓ design/desi…", output)
+            self.assertIn("✓ 02_planning", output)
+            self.assertIn("✓ 04_design", output)
 
     def test_append_status_change_logs_only_when_changed(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -200,8 +199,8 @@ class MonitorTests(unittest.TestCase):
             self.assertNotIn("architect", output)
             self.assertIn("reviewer", output)
             self.assertIn("coder", output)
-            self.assertIn("working", output)
-            self.assertIn("idle", output)
+            self.assertIn("WORKING", output)
+            self.assertIn("IDLE", output)
 
     def test_render_shows_log_section_without_box_frame(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_on_demand_prompt_handlers.py
+++ b/tests/test_on_demand_prompt_handlers.py
@@ -40,7 +40,7 @@ def _make_ctx(feature_dir: Path, with_docs: bool = True) -> tuple[PipelineContex
     project_dir = feature_dir.parent / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
     files = create_feature_files(project_dir, feature_dir, "on demand prompt generation", "session-x")
-    architect_prompt = feature_dir / "planning" / "architect_prompt.md"
+    architect_prompt = feature_dir / "02_planning" / "architect_prompt.md"
     architect_prompt.parent.mkdir(parents=True, exist_ok=True)
     architect_prompt.write_text("architect prompt", encoding="utf-8")
     agents = {
@@ -65,6 +65,7 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = _make_ctx(tmp_path / "feature")
+            ctx.files.plan.parent.mkdir(parents=True, exist_ok=True)
             ctx.files.plan.write_text("# Plan\n\n1. Implement\n", encoding="utf-8")
             state = load_state(state_path)
             state["phase"] = "implementing"
@@ -73,7 +74,10 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             run_phase_cycle(load_state(state_path), ctx)
 
             self.assertTrue((ctx.files.implementation_dir / "coder_prompt.md").exists())
-            self.assertEqual([("send", "coder", "coder_prompt.md")], ctx.runtime.calls)
+            self.assertEqual(
+                [("kill_primary", "coder"), ("send", "coder", "coder_prompt.md")],
+                ctx.runtime.calls,
+            )
 
     def test_enter_reviewing_builds_review_prompt_inline(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -87,6 +91,22 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
 
             self.assertTrue((ctx.files.review_dir / "review_prompt.md").exists())
             self.assertEqual([("send", "reviewer", "review_prompt.md")], ctx.runtime.calls)
+
+    def test_enter_fixing_kills_stale_coder_and_builds_fix_prompt_inline(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ctx, state_path = _make_ctx(tmp_path / "feature")
+            state = load_state(state_path)
+            state["phase"] = "fixing"
+            write_state(state_path, state)
+
+            run_phase_cycle(load_state(state_path), ctx)
+
+            self.assertTrue((ctx.files.review_dir / "fix_prompt.txt").exists())
+            self.assertEqual(
+                [("kill_primary", "coder"), ("send", "coder", "fix_prompt.txt")],
+                ctx.runtime.calls,
+            )
 
     def test_enter_completing_builds_confirmation_prompt_inline(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_phase_directories_requirements.py
+++ b/tests/test_phase_directories_requirements.py
@@ -39,7 +39,7 @@ class _FakeRuntime:
 
 
 class PhaseDirectoryRequirementsTests(unittest.TestCase):
-    def test_create_feature_files_initializes_phase_subdirectories_and_runtime_paths(self) -> None:
+    def test_create_feature_files_sets_numbered_runtime_paths_without_eager_subdirectories(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             project_dir = tmp_path / "project"
@@ -48,38 +48,39 @@ class PhaseDirectoryRequirementsTests(unittest.TestCase):
 
             files = create_feature_files(project_dir, feature_dir, "phase dirs", "session-x")
 
-            self.assertEqual(feature_dir / "planning", files.planning_dir)
-            self.assertEqual(feature_dir / "research", files.research_dir)
-            self.assertEqual(feature_dir / "design", files.design_dir)
-            self.assertEqual(feature_dir / "implementation", files.implementation_dir)
-            self.assertEqual(feature_dir / "review", files.review_dir)
-            self.assertEqual(feature_dir / "docs", files.docs_dir)
-            self.assertEqual(feature_dir / "completion", files.completion_dir)
-            self.assertTrue(files.planning_dir.is_dir())
-            self.assertTrue(files.research_dir.is_dir())
-            self.assertTrue(files.design_dir.is_dir())
-            self.assertTrue(files.implementation_dir.is_dir())
-            self.assertTrue(files.review_dir.is_dir())
-            self.assertTrue(files.docs_dir.is_dir())
-            self.assertTrue(files.completion_dir.is_dir())
-            self.assertEqual(feature_dir / "planning" / "plan.md", files.plan)
-            self.assertEqual(feature_dir / "planning" / "tasks.md", files.tasks)
-            self.assertEqual(feature_dir / "design" / "design.md", files.design)
-            self.assertEqual(feature_dir / "review" / "review.md", files.review)
-            self.assertEqual(feature_dir / "review" / "fix_request.md", files.fix_request)
-            self.assertEqual(feature_dir / "completion" / "changes.md", files.changes)
+            self.assertEqual(feature_dir / "02_planning", files.planning_dir)
+            self.assertEqual(feature_dir / "03_research", files.research_dir)
+            self.assertEqual(feature_dir / "04_design", files.design_dir)
+            self.assertEqual(feature_dir / "05_implementation", files.implementation_dir)
+            self.assertEqual(feature_dir / "06_review", files.review_dir)
+            self.assertEqual(feature_dir / "07_docs", files.docs_dir)
+            self.assertEqual(feature_dir / "08_completion", files.completion_dir)
+            self.assertFalse((feature_dir / "01_product_management").exists())
+            self.assertFalse(files.planning_dir.exists())
+            self.assertFalse(files.research_dir.exists())
+            self.assertFalse(files.design_dir.exists())
+            self.assertFalse(files.implementation_dir.exists())
+            self.assertFalse(files.review_dir.exists())
+            self.assertFalse(files.docs_dir.exists())
+            self.assertFalse(files.completion_dir.exists())
+            self.assertEqual(feature_dir / "02_planning" / "plan.md", files.plan)
+            self.assertEqual(feature_dir / "02_planning" / "tasks.md", files.tasks)
+            self.assertEqual(feature_dir / "04_design" / "design.md", files.design)
+            self.assertEqual(feature_dir / "06_review" / "review.md", files.review)
+            self.assertEqual(feature_dir / "06_review" / "fix_request.md", files.fix_request)
+            self.assertEqual(feature_dir / "08_completion" / "changes.md", files.changes)
 
     def test_write_prompt_file_creates_parent_directories(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            prompt_path = write_prompt_file(feature_dir, "research/code-auth/prompt.md", "hello")
-            self.assertEqual(feature_dir / "research" / "code-auth" / "prompt.md", prompt_path)
+            prompt_path = write_prompt_file(feature_dir, "03_research/code-auth/prompt.md", "hello")
+            self.assertEqual(feature_dir / "03_research" / "code-auth" / "prompt.md", prompt_path)
             self.assertEqual("hello", prompt_path.read_text(encoding="utf-8"))
 
     def test_load_plan_meta_reads_from_planning_directory(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            planning_dir = feature_dir / "planning"
+            planning_dir = feature_dir / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
             (planning_dir / "plan_meta.json").write_text('{"needs_design": true}', encoding="utf-8")
 
@@ -90,7 +91,7 @@ class PhaseDirectoryRequirementsTests(unittest.TestCase):
     def test_split_plan_into_subplans_writes_into_planning_directory(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            planning_dir = feature_dir / "planning"
+            planning_dir = feature_dir / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
             plan_path = planning_dir / "plan.md"
             plan_path.write_text(

--- a/tests/test_product_manager_requirements.py
+++ b/tests/test_product_manager_requirements.py
@@ -8,12 +8,16 @@ from unittest.mock import patch
 
 import agentmux.pipeline as pipeline
 from agentmux import monitor
-from agentmux.models import AgentConfig
+from agentmux.models import AgentConfig, SESSION_DIR_NAMES
 from agentmux.phases import PHASES, ProductManagementPhase
 from agentmux.prompts import build_product_manager_prompt
 from agentmux.runtime import TmuxAgentRuntime
 from agentmux.state import create_feature_files, infer_resume_phase, load_state, write_state
 from agentmux.transitions import PipelineContext
+
+PRODUCT_MANAGEMENT_DIR = SESSION_DIR_NAMES["product_management"]
+PLANNING_DIR = SESSION_DIR_NAMES["planning"]
+RESEARCH_DIR = SESSION_DIR_NAMES["research"]
 
 
 class FakeRuntime:
@@ -55,7 +59,7 @@ class ProductManagerRequirementsTests(unittest.TestCase):
         project_dir.mkdir(parents=True, exist_ok=True)
         files = create_feature_files(project_dir, feature_dir, "add product manager", "session-x")
 
-        prompts = {"architect": feature_dir / "planning" / "architect_prompt.md"}
+        prompts = {"architect": feature_dir / PLANNING_DIR / "architect_prompt.md"}
         for prompt in prompts.values():
             prompt.parent.mkdir(parents=True, exist_ok=True)
             prompt.write_text(prompt.name, encoding="utf-8")
@@ -129,9 +133,9 @@ class ProductManagerRequirementsTests(unittest.TestCase):
 
             self.assertIn(str(feature_dir), prompt)
             self.assertIn(str(project_dir), prompt)
-            self.assertIn("product_management/analysis.md", prompt)
-            self.assertIn("product_management/done", prompt)
-            self.assertIn("design/design.md", prompt)
+            self.assertIn("01_product_management/analysis.md", prompt)
+            self.assertIn("01_product_management/done", prompt)
+            self.assertIn("04_design/design.md", prompt)
 
     def test_product_management_phase_entry_and_completion_transition(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -146,8 +150,8 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             phase.on_enter(load_state(state_path), ctx)
             self.assertEqual(("send", "product-manager", "product_manager_prompt.md"), ctx.runtime.calls[-1])
 
-            (feature_dir / "product_management").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "product_management" / "done").touch()
+            (feature_dir / PRODUCT_MANAGEMENT_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PRODUCT_MANAGEMENT_DIR / "done").touch()
             event = phase.detect_event(load_state(state_path), ctx)
             self.assertEqual("pm_completed", event)
 
@@ -168,8 +172,8 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             state["research_tasks"] = {}
             write_state(state_path, state)
 
-            (feature_dir / "research" / "code-market-fit").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "code-market-fit" / "request.md").write_text("analyze", encoding="utf-8")
+            (feature_dir / RESEARCH_DIR / "code-market-fit").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "code-market-fit" / "request.md").write_text("analyze", encoding="utf-8")
 
             phase = ProductManagementPhase()
             self.assertEqual("code_batch_requested", phase.detect_event(load_state(state_path), ctx))
@@ -181,24 +185,24 @@ class ProductManagerRequirementsTests(unittest.TestCase):
 
             updated["research_tasks"] = {"market-fit": "dispatched"}
             write_state(state_path, updated)
-            (feature_dir / "research" / "code-market-fit" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "code-market-fit" / "done").touch()
             with patch("agentmux.phases.send_text") as send_text:
                 phase.handle_event(load_state(state_path), "task_completed:market-fit", ctx)
 
             send_text.assert_called_once_with(
                 "%7",
-                "Code-research on 'market-fit' is complete. Read research/code-market-fit/summary.md first, then research/code-market-fit/detail.md if you need more detail, and continue from there.",
+                "Code-research on 'market-fit' is complete. Read 03_research/code-market-fit/summary.md first, then 03_research/code-market-fit/detail.md if you need more detail, and continue from there.",
             )
 
     def test_infer_resume_phase_handles_product_management_marker(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "product_management").mkdir(parents=True, exist_ok=True)
+            (feature_dir / PRODUCT_MANAGEMENT_DIR).mkdir(parents=True, exist_ok=True)
 
             state = {"phase": "planning", "product_manager": True}
             self.assertEqual("product_management", infer_resume_phase(feature_dir, state))
 
-            (feature_dir / "product_management" / "done").touch()
+            (feature_dir / PRODUCT_MANAGEMENT_DIR / "done").touch()
             self.assertEqual("planning", infer_resume_phase(feature_dir, state))
 
     def test_runtime_create_uses_product_manager_as_initial_pane_when_selected(self) -> None:

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -71,7 +71,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
                     "agents",
                     "coder",
                     "EXT-CODER",
-                    lambda runtime: build_coder_subplan_prompt(runtime, Path("subplan_1.md"), 1),
+                    lambda runtime: build_coder_subplan_prompt(runtime, feature_dir / "02_planning" / "subplan_1.md", 1),
                 ),
                 (
                     "agents",

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 import agentmux.pipeline as pipeline
+from agentmux.models import SESSION_DIR_NAMES
 from agentmux.state import infer_resume_phase, write_state
+
+PLANNING_DIR = SESSION_DIR_NAMES["planning"]
+IMPLEMENTATION_DIR = SESSION_DIR_NAMES["implementation"]
+REVIEW_DIR = SESSION_DIR_NAMES["review"]
+DOCS_DIR = SESSION_DIR_NAMES["docs"]
 
 
 class ResumeCliAndSessionTests(unittest.TestCase):
@@ -93,67 +99,67 @@ class InferResumePhaseTests(unittest.TestCase):
     def test_failed_plan_with_design_required_resumes_designing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# Plan", encoding="utf-8")
-            self._write_json(feature_dir / "planning" / "plan_meta.json", '{"needs_design": true}')
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            self._write_json(feature_dir / PLANNING_DIR / "plan_meta.json", '{"needs_design": true}')
             state = {"phase": "failed"}
             self.assertEqual("designing", infer_resume_phase(feature_dir, state))
 
     def test_failed_fix_iteration_with_incomplete_done_markers_resumes_fixing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "review").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "implementation").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# Plan", encoding="utf-8")
-            (feature_dir / "review" / "fix_request.md").write_text("fix this", encoding="utf-8")
-            (feature_dir / "implementation" / "done_1").write_text("", encoding="utf-8")
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            (feature_dir / REVIEW_DIR / "fix_request.md").write_text("fix this", encoding="utf-8")
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
             state = {"phase": "failed", "review_iteration": 1, "subplan_count": 2}
             self.assertEqual("fixing", infer_resume_phase(feature_dir, state))
 
     def test_failed_with_incomplete_done_markers_resumes_implementing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "implementation").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# Plan", encoding="utf-8")
-            (feature_dir / "implementation" / "done_1").write_text("", encoding="utf-8")
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
             state = {"phase": "failed", "subplan_count": 2}
             self.assertEqual("implementing", infer_resume_phase(feature_dir, state))
 
     def test_failed_with_done_markers_and_no_review_resumes_reviewing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "implementation").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# Plan", encoding="utf-8")
-            (feature_dir / "implementation" / "done_1").write_text("", encoding="utf-8")
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
             state = {"phase": "failed", "subplan_count": 1}
             self.assertEqual("reviewing", infer_resume_phase(feature_dir, state))
 
     def test_failed_review_pass_without_docs_done_resumes_documenting(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "implementation").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "review").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# Plan", encoding="utf-8")
-            (feature_dir / "implementation" / "done_1").write_text("", encoding="utf-8")
-            (feature_dir / "review" / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
+            (feature_dir / REVIEW_DIR / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
             state = {"phase": "failed", "subplan_count": 1}
             self.assertEqual("documenting", infer_resume_phase(feature_dir, state))
 
     def test_failed_when_docs_done_resumes_completing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            (feature_dir / "planning").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "implementation").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "review").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "docs").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "planning" / "plan.md").write_text("# Plan", encoding="utf-8")
-            (feature_dir / "implementation" / "done_1").write_text("", encoding="utf-8")
-            (feature_dir / "review" / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
-            (feature_dir / "docs" / "docs_done").write_text("", encoding="utf-8")
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / DOCS_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
+            (feature_dir / REVIEW_DIR / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
+            (feature_dir / DOCS_DIR / "docs_done").write_text("", encoding="utf-8")
             state = {"phase": "failed", "subplan_count": 1}
             self.assertEqual("completing", infer_resume_phase(feature_dir, state))
 

--- a/tests/test_review_pass_requirements.py
+++ b/tests/test_review_pass_requirements.py
@@ -4,11 +4,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from agentmux.models import AgentConfig
+from agentmux.models import AgentConfig, SESSION_DIR_NAMES
 from agentmux.phases import PHASES, get_phase
 from agentmux.prompts import build_reviewer_prompt
 from agentmux.state import create_feature_files, load_state, write_state
 from agentmux.transitions import PipelineContext
+
+PLANNING_DIR = SESSION_DIR_NAMES["planning"]
 
 
 class FakeRuntime:
@@ -43,7 +45,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         project_dir.mkdir(parents=True, exist_ok=True)
         files = create_feature_files(project_dir, feature_dir, "review handling", "session-x")
 
-        prompts = {"architect": feature_dir / "planning" / "architect_prompt.md"}
+        prompts = {"architect": feature_dir / PLANNING_DIR / "architect_prompt.md"}
         for prompt in prompts.values():
             prompt.parent.mkdir(parents=True, exist_ok=True)
             prompt.write_text(prompt.name, encoding="utf-8")
@@ -72,7 +74,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
 
             prompt = build_reviewer_prompt(files, is_review=True)
 
-            self.assertIn("Always write `review/review.md`", prompt)
+            self.assertIn("Always write `06_review/review.md`", prompt)
             self.assertIn("verdict: pass", prompt)
             self.assertIn("verdict: fail", prompt)
             self.assertIn("Do not update `state.json`", prompt)
@@ -81,6 +83,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature", with_docs=False)
+            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
             ctx.files.review.write_text("verdict: pass\n", encoding="utf-8")
 
             state = load_state(state_path)
@@ -132,6 +135,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature", with_docs=False)
+            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
             ctx.files.review.write_text("verdict: fail\n- finding\n", encoding="utf-8")
 
             state = load_state(state_path)

--- a/tests/test_tasks_requirements.py
+++ b/tests/test_tasks_requirements.py
@@ -24,8 +24,8 @@ class TasksRequirementsTests(unittest.TestCase):
             files = create_feature_files(project_dir, feature_dir, "add tasks list", "session")
             loaded = load_runtime_files(project_dir, feature_dir)
 
-            self.assertEqual(feature_dir / "planning" / "tasks.md", files.tasks)
-            self.assertEqual(feature_dir / "planning" / "tasks.md", loaded.tasks)
+            self.assertEqual(feature_dir / "02_planning" / "tasks.md", files.tasks)
+            self.assertEqual(feature_dir / "02_planning" / "tasks.md", loaded.tasks)
             self.assertFalse(files.plan.exists())
             self.assertFalse(files.tasks.exists())
             self.assertFalse(files.design.exists())
@@ -44,10 +44,10 @@ class TasksRequirementsTests(unittest.TestCase):
             architect_prompt = build_architect_prompt(files)
             coder_prompt = build_coder_prompt(files)
 
-            self.assertIn("write the final plan to `planning/plan.md`", architect_prompt)
-            self.assertIn("also write `planning/tasks.md`", architect_prompt)
-            self.assertIn("write `planning/plan_meta.json`", architect_prompt)
-            self.assertIn("implementation/done_1", coder_prompt)
+            self.assertIn("write the final plan to `02_planning/plan.md`", architect_prompt)
+            self.assertIn("also write `02_planning/tasks.md`", architect_prompt)
+            self.assertIn("write `02_planning/plan_meta.json`", architect_prompt)
+            self.assertIn("05_implementation/done_1", coder_prompt)
             self.assertIn("Do not update state.json", coder_prompt)
 
     def test_change_prompt_references_files_instead_of_embedding_text(self) -> None:
@@ -58,6 +58,8 @@ class TasksRequirementsTests(unittest.TestCase):
             project_dir.mkdir()
 
             files = create_feature_files(project_dir, feature_dir, "add tasks list", "session")
+            files.changes.parent.mkdir(parents=True, exist_ok=True)
+            files.plan.parent.mkdir(parents=True, exist_ok=True)
             files.changes.write_text("change request", encoding="utf-8")
             files.plan.write_text("# Plan\n\n1. Example step\n", encoding="utf-8")
             files.tasks.write_text("# Tasks\n\n1. Example task\n", encoding="utf-8")
@@ -66,10 +68,10 @@ class TasksRequirementsTests(unittest.TestCase):
 
             self.assertIn("Read these files first:", prompt)
             self.assertIn("- requirements.md", prompt)
-            self.assertIn("- planning/plan.md", prompt)
-            self.assertIn("- planning/tasks.md", prompt)
-            self.assertIn("- completion/changes.md", prompt)
-            self.assertIn("planning/plan_meta.json", prompt)
+            self.assertIn("- 02_planning/plan.md", prompt)
+            self.assertIn("- 02_planning/tasks.md", prompt)
+            self.assertIn("- 08_completion/changes.md", prompt)
+            self.assertIn("02_planning/plan_meta.json", prompt)
             self.assertNotIn("1. Example task", prompt)
 
     def test_architect_prompt_no_longer_accepts_review_mode_and_reviewer_prompt_handles_review(self) -> None:

--- a/tests/test_web_researcher_requirements.py
+++ b/tests/test_web_researcher_requirements.py
@@ -7,11 +7,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import agentmux.pipeline as pipeline
-from agentmux.models import AgentConfig
+from agentmux.models import AgentConfig, SESSION_DIR_NAMES
 from agentmux.phases import PlanningPhase
 from agentmux.prompts import build_architect_prompt, build_web_researcher_prompt
 from agentmux.state import create_feature_files, load_state, write_state
 from agentmux.transitions import PipelineContext
+
+PLANNING_DIR = SESSION_DIR_NAMES["planning"]
+RESEARCH_DIR = SESSION_DIR_NAMES["research"]
 
 
 class FakeRuntime:
@@ -50,7 +53,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
         project_dir.mkdir(parents=True, exist_ok=True)
         files = create_feature_files(project_dir, feature_dir, "add web researcher", "session-x")
 
-        prompts = {"architect": feature_dir / "planning" / "architect_prompt.md"}
+        prompts = {"architect": feature_dir / PLANNING_DIR / "architect_prompt.md"}
         for prompt in prompts.values():
             prompt.parent.mkdir(parents=True, exist_ok=True)
             prompt.write_text(prompt.name, encoding="utf-8")
@@ -104,8 +107,8 @@ class WebResearcherRequirementsTests(unittest.TestCase):
 
             self.assertIn(str(feature_dir), prompt)
             self.assertIn(str(project_dir), prompt)
-            self.assertIn("research/web-openai-models/request.md", prompt)
-            self.assertIn("research/web-openai-models/done", prompt)
+            self.assertIn("03_research/web-openai-models/request.md", prompt)
+            self.assertIn("03_research/web-openai-models/done", prompt)
             self.assertIn("version", prompt.lower())
             self.assertTrue(
                 "fabricat" in prompt.lower() or "invent" in prompt.lower(),
@@ -122,10 +125,10 @@ class WebResearcherRequirementsTests(unittest.TestCase):
 
             prompt = build_architect_prompt(files)
 
-            self.assertIn("research/web-<topic>/request.md", prompt)
-            self.assertIn("research/web-<topic>/summary.md", prompt)
-            self.assertIn("research/web-<topic>/detail.md", prompt)
-            self.assertIn("research/web-<topic>/done", prompt)
+            self.assertIn("03_research/web-<topic>/request.md", prompt)
+            self.assertIn("03_research/web-<topic>/summary.md", prompt)
+            self.assertIn("03_research/web-<topic>/detail.md", prompt)
+            self.assertIn("03_research/web-<topic>/done", prompt)
 
     def test_planning_detects_web_task_requested_and_completed(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -138,10 +141,10 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             state["web_research_tasks"] = {"openai-models": "dispatched"}
             write_state(state_path, state)
 
-            (feature_dir / "research" / "web-react-19").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "web-openai-models").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "web-react-19" / "request.md").write_text("look at react", encoding="utf-8")
-            (feature_dir / "research" / "web-openai-models" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "web-react-19").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "web-openai-models").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "web-react-19" / "request.md").write_text("look at react", encoding="utf-8")
+            (feature_dir / RESEARCH_DIR / "web-openai-models" / "done").touch()
 
             phase = PlanningPhase()
             event = phase.detect_event(load_state(state_path), ctx)
@@ -150,7 +153,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["web_research_tasks"] = {}
             write_state(state_path, state)
-            (feature_dir / "research" / "web-openai-models" / "done").unlink()
+            (feature_dir / RESEARCH_DIR / "web-openai-models" / "done").unlink()
             event = phase.detect_event(load_state(state_path), ctx)
             self.assertEqual("web_batch_requested", event)
 
@@ -161,12 +164,12 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             ctx, state_path = self._make_ctx(feature_dir)
             _ = state_path
 
-            (feature_dir / "research" / "web-openai-models").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "web-openai-models" / "request.md").write_text(
+            (feature_dir / RESEARCH_DIR / "web-openai-models").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "web-openai-models" / "request.md").write_text(
                 "look at models",
                 encoding="utf-8",
             )
-            (feature_dir / "research" / "web-openai-models" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "web-openai-models" / "done").touch()
 
             snapshot = PlanningPhase().snapshot_inputs({}, ctx)
 
@@ -182,12 +185,12 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             write_state(state_path, state)
 
-            (feature_dir / "research" / "web-openai-models").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "web-openai-models" / "request.md").write_text(
+            (feature_dir / RESEARCH_DIR / "web-openai-models").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "web-openai-models" / "request.md").write_text(
                 "investigate models",
                 encoding="utf-8",
             )
-            stale_done = feature_dir / "research" / "web-openai-models" / "done"
+            stale_done = feature_dir / RESEARCH_DIR / "web-openai-models" / "done"
             stale_done.touch()
 
             phase = PlanningPhase()
@@ -199,7 +202,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
                 ("spawn_task", "web-researcher", "openai-models", "prompt.md"),
                 ctx.runtime.calls[-1],
             )
-            self.assertTrue((feature_dir / "research" / "web-openai-models" / "prompt.md").exists())
+            self.assertTrue((feature_dir / RESEARCH_DIR / "web-openai-models" / "prompt.md").exists())
             updated = load_state(state_path)
             self.assertEqual("dispatched", updated["web_research_tasks"]["openai-models"])
 
@@ -212,8 +215,8 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             state["web_research_tasks"] = {"openai-models": "dispatched"}
             write_state(state_path, state)
-            (feature_dir / "research" / "web-openai-models").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "research" / "web-openai-models" / "done").touch()
+            (feature_dir / RESEARCH_DIR / "web-openai-models").mkdir(parents=True, exist_ok=True)
+            (feature_dir / RESEARCH_DIR / "web-openai-models" / "done").touch()
 
             phase = PlanningPhase()
             with patch("agentmux.phases.send_text") as send_text:
@@ -223,7 +226,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             self.assertEqual(("finish_task", "web-researcher", "openai-models"), ctx.runtime.calls[-1])
             send_text.assert_called_once_with(
                 "%1",
-                "Web research on 'openai-models' is complete. Read research/web-openai-models/summary.md first, then research/web-openai-models/detail.md if you need more detail, and continue from there.",
+                "Web research on 'openai-models' is complete. Read 03_research/web-openai-models/summary.md first, then 03_research/web-openai-models/detail.md if you need more detail, and continue from there.",
             )
             updated = load_state(state_path)
             self.assertEqual("done", updated["web_research_tasks"]["openai-models"])


### PR DESCRIPTION
## Summary
- name phase folders using the phase number
- update prompts, docs, and state handling to match
- cover the new behavior with tests

Closes #12