### PR TITLE
coder-prompt-must-include-relevant-research-file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ agentmux/state.py                   — state.json CRUD, feature-directory lifec
 agentmux/tmux.py                    — all tmux interaction (sessions, panes, send-keys, trust-prompt, env-prefixed launch command)
 agentmux/monitor.py                 — control pane status display (pipeline status, agent list, documents)
 agentmux/runtime.py                 — TmuxAgentRuntime, spawns agents with resolved trust_snippet
-agentmux/prompts.py                 — loads markdown templates and renders them with str.format_map()
+agentmux/prompts.py                 — loads markdown templates, renders them with str.format_map(), and injects coder research handoff references from completed `03_research/` topics
 agentmux/prompts/agents/            — role-level prompts (define what each agent is)
   product-manager.md           —   product management phase
   architect.md                 —   planning phase
@@ -148,5 +148,5 @@ Deeper context on specific subsystems:
 - `docs/research-dispatch.md` — Code-researcher and web-researcher task dispatch
 - `docs/completing-phase.md` — Approval flow, commit selection, cleanup
 - `docs/monitor.md` — Control pane display sections, constants, rendering
-- `docs/prompts.md` — Prompt templates, placeholders, rendering pipeline
+- `docs/prompts.md` — Prompt templates, placeholders, rendering pipeline, and coder research handoff injection
 - `docs/session-resumption.md` — Resume flag, phase inference, runtime rehydration

--- a/agentmux/mcp_research_server.py
+++ b/agentmux/mcp_research_server.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .models import SESSION_DIR_NAMES
+
 try:
     from mcp.server.fastmcp import FastMCP
 except ImportError:  # pragma: no cover - runtime dependency check
@@ -63,7 +65,7 @@ def _normalize_scope_hints(scope_hints: str | list[str] | None) -> list[str] | N
 
 
 def _research_dir(topic: str, research_type: str, feature_dir: str | None = None) -> Path:
-    return _feature_dir(feature_dir) / "research" / f"{research_type}-{topic}"
+    return _feature_dir(feature_dir) / SESSION_DIR_NAMES["research"] / f"{research_type}-{topic}"
 
 
 def _request_content(context: str, questions: list[str], scope_hints: list[str] | None) -> str:

--- a/agentmux/monitor.py
+++ b/agentmux/monitor.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 from .config import infer_project_dir, load_layered_config
+from .models import SESSION_DIR_NAMES
 from .tmux import MONITOR_WIDTH
 
 RESET = "\033[0m"
@@ -598,7 +599,7 @@ def _render_research_section(width: int, state: dict, feature_dir: Path) -> list
     if not code_tasks and not web_tasks:
         return []
 
-    research_dir = feature_dir / "research"
+    research_dir = feature_dir / SESSION_DIR_NAMES["research"]
     all_tasks: list[tuple[str, str, str]] = [
         ("c", topic, f"code-{topic}/done") for topic in code_tasks
     ] + [

--- a/agentmux/prompts.py
+++ b/agentmux/prompts.py
@@ -28,6 +28,31 @@ def write_prompt_file(feature_dir: Path, name: str, content: str) -> Path:
     return prompt_path
 
 
+def _build_coder_research_handoff(files: RuntimeFiles) -> str:
+    research_dir = files.research_dir
+    if not research_dir.is_dir():
+        return ""
+
+    references: list[str] = []
+    for topic_dir in sorted(path for path in research_dir.iterdir() if path.is_dir()):
+        done_path = topic_dir / "done"
+        summary_path = topic_dir / "summary.md"
+        detail_path = topic_dir / "detail.md"
+        if not done_path.is_file() or not summary_path.is_file():
+            continue
+        references.append(f"- `{files.relative_path(summary_path)}` (primary)")
+        if detail_path.is_file():
+            references.append(f"- `{files.relative_path(detail_path)}` (additional detail)")
+
+    if not references:
+        return ""
+
+    return "\n".join([
+        "Research handoff (read before new exploration):",
+        *references,
+    ])
+
+
 def build_architect_prompt(files: RuntimeFiles) -> str:
     return _load_template(
         "agents",
@@ -80,6 +105,7 @@ def build_coder_prompt(files: RuntimeFiles) -> str:
         "feature_dir": files.feature_dir,
         "project_dir": files.project_dir,
         "plan_file": files.relative_path(files.plan),
+        "research_handoff": _build_coder_research_handoff(files),
         "completion_instruction": completion_instruction,
         "completion_constraints": completion_constraints,
     })
@@ -130,6 +156,7 @@ def build_coder_subplan_prompt(
         "feature_dir": files.feature_dir,
         "project_dir": files.project_dir,
         "plan_file": files.relative_path(subplan_path),
+        "research_handoff": _build_coder_research_handoff(files),
         "completion_instruction": completion_instruction,
         "completion_constraints": completion_constraints,
     })

--- a/agentmux/prompts/agents/coder.md
+++ b/agentmux/prompts/agents/coder.md
@@ -10,6 +10,8 @@ Read these files first:
 - 04_design/design.md (if present)
 - state.json
 
+{research_handoff}
+
 Your job:
 1. You must at first create tests that implement the requirements.
 2. Implement the plan in the project directory {project_dir}.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -44,8 +44,23 @@ Agents read the referenced file themselves, reducing keystroke overhead and allo
 
 Prompt files are built lazily by handlers just before injection, not pre-generated. Each `build_*_prompt()` function in `agentmux/prompts.py` loads and renders the markdown template for its phase.
 
+## Coder research handoff
+
+Coder prompt rendering injects a `Research handoff` block into `agentmux/prompts/agents/coder.md` via the `{research_handoff}` placeholder.
+
+Behavior contract:
+
+- Applies to both `build_coder_prompt()` and `build_coder_subplan_prompt()`
+- Scans topic directories under `03_research/` in sorted (deterministic) order
+- Includes a topic only when both `done` and `summary.md` are present
+- Lists `summary.md` as the primary reference
+- Adds `detail.md` as an additional reference only when present
+- Uses feature-relative paths (for example `03_research/code-auth/summary.md`)
+- Omits the entire handoff section when no completed research topics are available
+
 Current split:
 - `build_architect_prompt()` renders planning prompts only
 - `build_product_manager_prompt()` renders the PM analysis prompt
+- `build_coder_prompt()` / `build_coder_subplan_prompt()` render coder implementation prompts with completion marker instructions and optional research handoff references
 - `build_reviewer_prompt(..., is_review=True)` renders the review command prompt
 - `build_confirmation_prompt()` renders the confirmation command prompt used in completion

--- a/docs/research-dispatch.md
+++ b/docs/research-dispatch.md
@@ -1,6 +1,6 @@
 # Research Task Dispatch
 
-> Related source files: `agentmux/mcp_research_server.py`, `agentmux/mcp_config.py`, `agentmux/pipeline.py`, `agentmux/defaults/config.yaml`, `agentmux/prompts/agents/architect.md`, `agentmux/prompts/agents/product-manager.md`
+> Related source files: `agentmux/mcp_research_server.py`, `agentmux/mcp_config.py`, `agentmux/pipeline.py`, `agentmux/defaults/config.yaml`, `agentmux/prompts.py`, `agentmux/prompts/agents/architect.md`, `agentmux/prompts/agents/product-manager.md`, `agentmux/prompts/agents/coder.md`
 
 Research dispatch is now MCP-first. The architect and product-manager should call MCP tools to create research requests, then wait for AgentMux to push a completion message.
 
@@ -26,6 +26,8 @@ Typical flow:
 3. Read `summary.md` first and `detail.md` only when needed.
 
 Research completion stays file-driven: the orchestrator detects `done`, updates task state, and sends a follow-up message telling the owner agent which `summary.md` / `detail.md` files to read. AgentMux passes the active session directory explicitly as `feature_dir`, so the server does not rely on provider-specific environment propagation.
+
+Completed research topics are also used for coder handoff: coder prompts include references to `03_research/<type>-<topic>/summary.md` (and `detail.md` when present) for topics that have a `done` marker.
 
 ## File protocol fallback
 

--- a/tests/test_mcp_research_server_requirements.py
+++ b/tests/test_mcp_research_server_requirements.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 
 import agentmux.mcp_research_server as mcp_research_server
+from agentmux.models import SESSION_DIR_NAMES
 
 
 class McpResearchServerRequirementsTests(unittest.TestCase):
@@ -19,7 +20,7 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints=["agentmux/", "tests/"],
             )
 
-            request_path = feature_dir / "research" / "code-auth-module" / "request.md"
+            request_path = feature_dir / SESSION_DIR_NAMES["research"] / "code-auth-module" / "request.md"
             request = request_path.read_text(encoding="utf-8")
             self.assertEqual("Code research on 'auth-module' dispatched.", result)
             self.assertIn("## Context", request)
@@ -42,7 +43,7 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints=None,
             )
 
-            request_path = feature_dir / "research" / "web-sdk-compat" / "request.md"
+            request_path = feature_dir / SESSION_DIR_NAMES["research"] / "web-sdk-compat" / "request.md"
             request = request_path.read_text(encoding="utf-8")
             self.assertEqual("Web research on 'sdk-compat' dispatched.", result)
             self.assertIn("## Scope hints", request)
@@ -59,7 +60,9 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints="Start with prompts and planning tests.",
             )
 
-            request = (feature_dir / "research" / "code-planning-conventions" / "request.md").read_text(encoding="utf-8")
+            request = (
+                feature_dir / SESSION_DIR_NAMES["research"] / "code-planning-conventions" / "request.md"
+            ).read_text(encoding="utf-8")
             self.assertIn("- Start with prompts and planning tests.", request)
 
     def test_dispatch_code_treats_blank_scope_hints_string_as_none(self) -> None:
@@ -73,7 +76,9 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints="   ",
             )
 
-            request = (feature_dir / "research" / "code-feature-surface" / "request.md").read_text(encoding="utf-8")
+            request = (
+                feature_dir / SESSION_DIR_NAMES["research"] / "code-feature-surface" / "request.md"
+            ).read_text(encoding="utf-8")
             self.assertIn("- (none provided)", request)
 
     def test_dispatch_rejects_invalid_topic_slug(self) -> None:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from agentmux import monitor
+from agentmux.models import SESSION_DIR_NAMES
 
 
 class MonitorTests(unittest.TestCase):
@@ -144,6 +145,26 @@ class MonitorTests(unittest.TestCase):
             self.assertIn("› design …", output)
             self.assertIn("✓ 02_planning", output)
             self.assertIn("✓ 04_design", output)
+
+    def test_render_research_section_uses_numbered_research_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            state_path = feature_dir / "state.json"
+            runtime_state_path = feature_dir / "runtime_state.json"
+            research_dir = feature_dir / SESSION_DIR_NAMES["research"] / "code-auth-module"
+
+            state_path.write_text(
+                '{"phase": "planning", "research_tasks": {"auth-module": "dispatched"}}',
+                encoding="utf-8",
+            )
+            runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
+            research_dir.mkdir(parents=True, exist_ok=True)
+            (research_dir / "done").write_text("", encoding="utf-8")
+
+            output = self._strip_ansi(self._render(feature_dir, width=40, height=24))
+
+            self.assertIn(" RESEARCH 1/1", output)
+            self.assertIn("✓ c· auth-module", output)
 
     def test_append_status_change_logs_only_when_changed(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -29,6 +29,22 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
+    def _create_research_topic(
+        self,
+        feature_dir: Path,
+        topic_dir_name: str,
+        *,
+        done: bool,
+        include_detail: bool = True,
+    ) -> None:
+        topic_dir = feature_dir / "03_research" / topic_dir_name
+        topic_dir.mkdir(parents=True, exist_ok=True)
+        (topic_dir / "summary.md").write_text(f"# Summary for {topic_dir_name}\n", encoding="utf-8")
+        if include_detail:
+            (topic_dir / "detail.md").write_text(f"# Detail for {topic_dir_name}\n", encoding="utf-8")
+        if done:
+            (topic_dir / "done").write_text("", encoding="utf-8")
+
     def test_builtin_templates_expose_project_instruction_placeholder_before_constraints(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]
         template_paths = [
@@ -126,6 +142,68 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
 
             self.assertIn(injected, prompt)
             self.assertNotIn("{project_instructions}", prompt)
+
+    def test_coder_prompt_includes_completed_research_references(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            project_dir = tmp_path / "project"
+            feature_dir = tmp_path / "feature"
+            project_dir.mkdir()
+            files = create_feature_files(project_dir, feature_dir, "research handoff", "session")
+
+            self._create_research_topic(feature_dir, "web-openai-models", done=True, include_detail=False)
+            self._create_research_topic(feature_dir, "code-auth-module", done=True, include_detail=True)
+            self._create_research_topic(feature_dir, "code-incomplete-topic", done=False, include_detail=True)
+
+            prompt = build_coder_prompt(files)
+
+            self.assertIn("Research handoff (read before new exploration):", prompt)
+            self.assertIn("03_research/code-auth-module/summary.md", prompt)
+            self.assertIn("03_research/code-auth-module/detail.md", prompt)
+            self.assertIn("03_research/web-openai-models/summary.md", prompt)
+            self.assertNotIn("03_research/web-openai-models/detail.md", prompt)
+            self.assertNotIn("03_research/code-incomplete-topic/summary.md", prompt)
+            self.assertLess(
+                prompt.index("03_research/code-auth-module/summary.md"),
+                prompt.index("03_research/web-openai-models/summary.md"),
+            )
+
+    def test_coder_subplan_prompt_includes_completed_research_references(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            project_dir = tmp_path / "project"
+            feature_dir = tmp_path / "feature"
+            project_dir.mkdir()
+            files = create_feature_files(project_dir, feature_dir, "research handoff", "session")
+
+            self._create_research_topic(feature_dir, "web-routing", done=True, include_detail=True)
+            self._create_research_topic(feature_dir, "code-db-indexes", done=True, include_detail=True)
+
+            prompt = build_coder_subplan_prompt(files, feature_dir / "02_planning" / "plan_1.md", 1)
+
+            self.assertIn("Research handoff (read before new exploration):", prompt)
+            self.assertIn("03_research/code-db-indexes/summary.md", prompt)
+            self.assertIn("03_research/code-db-indexes/detail.md", prompt)
+            self.assertIn("03_research/web-routing/summary.md", prompt)
+            self.assertIn("03_research/web-routing/detail.md", prompt)
+
+    def test_coder_prompts_omit_research_handoff_when_no_completed_topics(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            project_dir = tmp_path / "project"
+            feature_dir = tmp_path / "feature"
+            project_dir.mkdir()
+            files = create_feature_files(project_dir, feature_dir, "research handoff", "session")
+
+            self._create_research_topic(feature_dir, "code-incomplete-topic", done=False, include_detail=True)
+
+            prompt = build_coder_prompt(files)
+            subplan_prompt = build_coder_subplan_prompt(files, feature_dir / "02_planning" / "plan_1.md", 1)
+
+            self.assertNotIn("Research handoff (read before new exploration):", prompt)
+            self.assertNotIn("Research handoff (read before new exploration):", subplan_prompt)
+            self.assertNotIn("03_research/code-incomplete-topic/summary.md", prompt)
+            self.assertNotIn("03_research/code-incomplete-topic/summary.md", subplan_prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Initial Request

When research was done during product management or planning the topic relevant files need to be given (as reference) to the coder in order to avoid duplicate research.

## Plan Summary

(not available)

## Review Verdict

(not available)



Closes #25
