### PR TITLE
product-manager-must-require-ui-design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist/
 build/
 
 # Multi-agent working directory
-.multi-agent/
+.agentmux/.sessions
 .claude/
 
 # OS

--- a/agentmux/prompts/agents/product-manager.md
+++ b/agentmux/prompts/agents/product-manager.md
@@ -59,10 +59,9 @@ You represent the customer. Your primary lens is usability: how easy and intuiti
 8. After approval, write:
    - `01_product_management/analysis.md` (usability assessment, integration fit, alternatives)
    - updated `requirements.md` (refined requirements)
-   - optionally `04_design/design.md` when the feature needs UI direction
    - `01_product_management/done` as completion marker
-9. If you produce UI design, use `/frontend-design` style guidance and write the design artifact to `04_design/design.md`.
-10. FINAL STEP ONLY — create `01_product_management/done` and stop.
+   - if UI design is needed, state this clearly in `01_product_management/analysis.md` so the architect can set `needs_design: true`; the product manager must not create design artifacts itself
+9. FINAL STEP ONLY — create `01_product_management/done` and stop.
 
 {project_instructions}
 

--- a/tests/test_product_manager_requirements.py
+++ b/tests/test_product_manager_requirements.py
@@ -122,7 +122,7 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             self.assertEqual("product_management", state["phase"])
             self.assertTrue(state["product_manager"])
 
-    def test_build_product_manager_prompt_renders_paths_and_outputs(self) -> None:
+    def test_build_product_manager_prompt_renders_paths_and_design_handoff_rules(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project_dir = Path(td) / "project"
             feature_dir = Path(td) / "feature"
@@ -135,7 +135,10 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             self.assertIn(str(project_dir), prompt)
             self.assertIn("01_product_management/analysis.md", prompt)
             self.assertIn("01_product_management/done", prompt)
-            self.assertIn("04_design/design.md", prompt)
+            self.assertNotIn("04_design/design.md", prompt)
+            self.assertNotIn("/frontend-design", prompt)
+            self.assertIn("needs_design: true", prompt)
+            self.assertIn("must not create design artifacts itself", prompt)
 
     def test_product_management_phase_entry_and_completion_transition(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Initial Request

Currently the product manager creates UI design itself. It should only require UI design and let this the design agent do.

## Plan Summary

(not available)

## Review Verdict

(not available)



Closes #20
