### PR TITLE
Let architect decide when documentation update is needed

### DIFF
--- a/agentmux/phases.py
+++ b/agentmux/phases.py
@@ -474,7 +474,13 @@ class ReviewingPhase(Phase):
         if event == "review_passed":
             ctx.runtime.finish_many("coder")
             ctx.runtime.kill_primary("coder")
-            next_phase = "documenting" if "docs" in ctx.agents else "completing"
+            meta = load_plan_meta(ctx.files.planning_dir)
+            needs_docs = bool(meta.get("needs_docs"))
+            if needs_docs and "docs" not in ctx.agents:
+                raise RuntimeError(
+                    "plan_meta.json requires docs phase (`needs_docs: true`) but no docs role is configured."
+                )
+            next_phase = "documenting" if needs_docs else "completing"
             write_phase(ctx, state, next_phase, "review_passed")
             return None
         if event != "review_failed":

--- a/agentmux/prompts.py
+++ b/agentmux/prompts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -51,6 +52,35 @@ def _build_coder_research_handoff(files: RuntimeFiles) -> str:
         "Research handoff (read before new exploration):",
         *references,
     ])
+
+
+def _load_docs_scope(files: RuntimeFiles) -> list[str]:
+    plan_meta_path = files.planning_dir / "plan_meta.json"
+    if not plan_meta_path.is_file():
+        raise RuntimeError("docs prompt requires 02_planning/plan_meta.json with needs_docs/doc_files metadata.")
+
+    try:
+        raw_meta = json.loads(plan_meta_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("docs prompt requires valid JSON in 02_planning/plan_meta.json.") from exc
+
+    if not isinstance(raw_meta, dict):
+        raise RuntimeError("docs prompt requires plan_meta.json to be a JSON object.")
+
+    if raw_meta.get("needs_docs") is not True:
+        raise RuntimeError("docs prompt requires plan_meta.json with needs_docs set to true.")
+
+    doc_files_raw = raw_meta.get("doc_files")
+    if not isinstance(doc_files_raw, list):
+        raise RuntimeError("docs prompt requires plan_meta.json doc_files to be a list of repository paths.")
+
+    if any(not isinstance(path, str) for path in doc_files_raw):
+        raise RuntimeError("docs prompt requires every doc_files entry to be a string path.")
+
+    doc_files = [path.strip() for path in doc_files_raw if path.strip()]
+    if not doc_files:
+        raise RuntimeError("docs prompt requires a non-empty doc_files list when needs_docs is true.")
+    return doc_files
 
 
 def build_architect_prompt(files: RuntimeFiles) -> str:
@@ -174,6 +204,9 @@ def build_fix_prompt(files: RuntimeFiles) -> str:
 
 
 def build_docs_prompt(files: RuntimeFiles) -> str:
+    doc_files = _load_docs_scope(files)
+    doc_targets = [str(files.project_dir / rel_path) for rel_path in doc_files]
+    doc_targets_block = "\n".join(f"- {target}" for target in doc_targets)
     return _load_template(
         "commands",
         "docs",
@@ -181,6 +214,7 @@ def build_docs_prompt(files: RuntimeFiles) -> str:
     ).format_map({
         "feature_dir": files.feature_dir,
         "project_dir": files.project_dir,
+        "doc_targets_block": doc_targets_block,
     })
 
 

--- a/agentmux/prompts/agents/architect.md
+++ b/agentmux/prompts/agents/architect.md
@@ -61,7 +61,10 @@ Do not poll for `done` yourself. AgentMux will notify you when `03_research/code
 9. Wait for the user to review. Incorporate any feedback and revise the draft as needed. Repeat until the user explicitly approves.
 10. Only after the user explicitly approves (e.g. says 'approved', 'looks good', 'go ahead'), write the final plan to `02_planning/plan.md`.
 11. After writing `02_planning/plan.md`, also write `02_planning/tasks.md` as a numbered checklist derived from the plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z"). If you created sub-plans, group tasks under the corresponding `## Sub-plan <N>: <title>` header.
-12. After writing `02_planning/plan.md` and `02_planning/tasks.md`, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false }}`. Set it to `true` only when the plan requires a dedicated design handoff before coding.
+12. After writing `02_planning/plan.md` and `02_planning/tasks.md`, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false, "needs_docs": true|false, "doc_files": ["path/to/doc.md", ...] }}`.
+Set `needs_design` to `true` only when the plan requires a dedicated design handoff before coding.
+Set `needs_docs` to `true` only when documentation updates are required for this feature scope.
+`doc_files` must list the documentation files expected to change when `needs_docs` is `true`, and must be an empty list when `needs_docs` is `false`.
 13. FINAL STEP ONLY — after writing the planning artifacts, stop. Do not update `state.json` or any workflow status from this step.
 
 {project_instructions}

--- a/agentmux/prompts/commands/change.md
+++ b/agentmux/prompts/commands/change.md
@@ -13,7 +13,9 @@ Your job:
 2. Present the revised implementation plan in chat for user approval.
 3. Iterate with the user until explicit approval.
 4. After writing `02_planning/plan.md`, also write `02_planning/tasks.md` as a numbered checklist derived from the plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z"). If you created sub-plans, group tasks under the corresponding `## Sub-plan <N>: <title>` header.
-5. After writing `02_planning/plan.md` and `02_planning/tasks.md`, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false }}`.
+5. After writing `02_planning/plan.md` and `02_planning/tasks.md`, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false, "needs_docs": true|false, "doc_files": ["path/to/doc.md", ...] }}`.
+Set `needs_docs` based on whether docs updates are required by the revised plan scope.
+`doc_files` must list expected docs updates when `needs_docs` is `true`, and must be an empty list when `needs_docs` is `false`.
 6. FINAL STEP ONLY — after writing the planning artifacts, stop. Do not update `state.json` or any workflow status from this step.
 
 {project_instructions}

--- a/agentmux/prompts/commands/docs.md
+++ b/agentmux/prompts/commands/docs.md
@@ -5,15 +5,17 @@ Session directory: {feature_dir}
 Read these files first:
 - requirements.md
 - 02_planning/plan.md
+- 02_planning/plan_meta.json
 - state.json
-- {project_dir}/README.md
-- {project_dir}/CLAUDE.md
+{doc_targets_block}
 
 Your job:
 1. Read `requirements.md`, `02_planning/plan.md` to confirm what was implemented.
-2. Update {project_dir}/README.md, {project_dir}/CLAUDE.md, and any other relevant documentation files referenced there in the repository so docs match the implemented changes.
+2. Update only the architect-declared documentation scope from `02_planning/plan_meta.json` so docs match the implemented changes:
+{doc_targets_block}
 3. Keep documentation changes focused and accurate to what is already implemented.
-4. FINAL STEP ONLY — once all documentation updates are complete, create the completion marker file `07_docs/docs_done` in the session directory and leave it empty. This must be the very last action you take.
+4. Do not update `README.md` or `CLAUDE.md` unless they are explicitly listed in `doc_files`.
+5. FINAL STEP ONLY — once all documentation updates are complete, create the completion marker file `07_docs/docs_done` in the session directory and leave it empty. This must be the very last action you take.
 
 {project_instructions}
 

--- a/agentmux/state.py
+++ b/agentmux/state.py
@@ -188,6 +188,7 @@ def infer_resume_phase(feature_dir: Path, state: dict[str, Any]) -> str:
         return "planning"
 
     plan_meta_path = planning_dir / "plan_meta.json"
+    plan_meta: dict[str, Any] = {}
     if plan_meta_path.exists():
         try:
             plan_meta = json.loads(plan_meta_path.read_text(encoding="utf-8"))
@@ -227,7 +228,8 @@ def infer_resume_phase(feature_dir: Path, state: dict[str, Any]) -> str:
     if verdict is None:
         return "reviewing"
 
-    if verdict == "pass" and not (docs_dir / "docs_done").exists():
+    needs_docs = bool(plan_meta.get("needs_docs"))
+    if verdict == "pass" and needs_docs and not (docs_dir / "docs_done").exists():
         return "documenting"
 
     return "completing"

--- a/docs/completing-phase.md
+++ b/docs/completing-phase.md
@@ -2,7 +2,11 @@
 
 > Related source files: `agentmux/phases.py` (CompletingPhase), `agentmux/prompts/commands/confirmation.md`, `agentmux/state.py`
 
-When the review passes, the workflow first terminates all `coder` panes (primary and parallel workers), then enters the `documenting` phase (if docs updates are needed) and finally transitions to `completing`.
+When the review passes, the workflow first terminates all `coder` panes (primary and parallel workers), then checks `02_planning/plan_meta.json`:
+- if `needs_docs` is `true`, it enters `documenting` (and requires a configured `docs` role)
+- if `needs_docs` is `false`, it transitions directly to `completing`
+
+In `documenting`, the docs prompt is scoped only to `plan_meta.json` `doc_files`. `README.md` and `CLAUDE.md` are updated only if explicitly listed there.
 
 ## Flow
 

--- a/docs/file-protocol.md
+++ b/docs/file-protocol.md
@@ -21,7 +21,11 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 ## Planning (`02_planning/`)
 
 - `architect_prompt.md` / `changes_prompt.txt` — architect prompts
-- `plan.md` / `tasks.md` / `plan_meta.json` — architect planning artifacts
+- `plan.md` / `tasks.md` — architect planning artifacts
+- `plan_meta.json` — architect workflow-intent metadata:
+  - `needs_design` (`true`/`false`) — whether to run a dedicated design handoff
+  - `needs_docs` (`true`/`false`) — whether review-pass must enter docs before completion
+  - `doc_files` (`string[]`) — expected docs update targets when `needs_docs` is `true`; must be `[]` when `needs_docs` is `false`
 - `plan_*.md` — subplan files for parallel coder runs
 
 ## Research (`03_research/`)
@@ -46,6 +50,7 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 ## Docs (`07_docs/`)
 
 - `docs_prompt.txt` / `docs_done`
+- `docs_prompt.txt` must be scoped by `02_planning/plan_meta.json` `doc_files`; no implicit `README.md`/`CLAUDE.md` targets are added
 
 ## Completion (`08_completion/`)
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -60,7 +60,9 @@ Behavior contract:
 
 Current split:
 - `build_architect_prompt()` renders planning prompts only
+- planning/replanning prompt contracts require `02_planning/plan_meta.json` with `needs_design`, `needs_docs`, and `doc_files` (empty list when `needs_docs` is `false`)
 - `build_product_manager_prompt()` renders the PM analysis prompt
 - `build_coder_prompt()` / `build_coder_subplan_prompt()` render coder implementation prompts with completion marker instructions and optional research handoff references
 - `build_reviewer_prompt(..., is_review=True)` renders the review command prompt
+- `build_docs_prompt()` requires `02_planning/plan_meta.json` with `needs_docs: true` and a non-empty `doc_files` list, then injects those file paths as the only docs-update scope
 - `build_confirmation_prompt()` renders the confirmation command prompt used in completion

--- a/docs/session-resumption.md
+++ b/docs/session-resumption.md
@@ -16,9 +16,13 @@ python3 pipeline.py --resume <feature-dir-or-name>  # Resume specific session by
 1. `list_resumable_sessions(project_dir)` scans `.agentmux/.sessions/` for all feature directories with `state.json` and returns them sorted by recency
 2. `select_session(sessions)` presents an interactive menu (or auto-selects if only one exists)
 3. For `--resume <feature-dir-or-name>`, non-absolute names are resolved against `.agentmux/.sessions/<name>` first, then `<project>/<name>` as a fallback
-4. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `05_implementation/done_*`, `06_review/review.md`, etc.) to determine the correct phase to resume into
+4. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `02_planning/plan_meta.json`, `05_implementation/done_*`, `06_review/review.md`, etc.) to determine the correct phase to resume into
 5. If `"product_manager": true` in state and `01_product_management/done` is missing, resume returns `product_management`; once `done` exists, resume falls through to normal `02_planning` / `05_implementation` inference
-6. On resume, the phase is updated in `state.json`, `last_event` is set to `"resumed"`, and any research tasks with `"dispatched"` status are cleaned up (allowing re-request)
-7. Orchestrator/monitor entrypoints infer the project directory from session paths under `.agentmux/.sessions/<id>` and also keep compatibility with legacy `.multi-agent/<id>` directories
-8. The orchestrator picks up the updated state and injects the appropriate phase prompt to resume work
-9. `implementing` and `fixing` explicitly clear the primary `coder` pane before dispatch so resume never reuses an old shell after the prior coder CLI has exited
+6. `plan_meta.json` is used as architect-authored intent metadata during inference:
+   - `needs_design: true` resumes into `designing` when `04_design/design.md` is still missing
+   - `needs_docs: true` with review verdict `pass` resumes into `documenting` until `07_docs/docs_done` exists
+   - otherwise a passed review resumes directly into `completing`
+7. On resume, the phase is updated in `state.json`, `last_event` is set to `"resumed"`, and any research tasks with `"dispatched"` status are cleaned up (allowing re-request)
+8. Orchestrator/monitor entrypoints infer the project directory from session paths under `.agentmux/.sessions/<id>` and also keep compatibility with legacy `.multi-agent/<id>` directories
+9. The orchestrator picks up the updated state and injects the appropriate phase prompt to resume work
+10. `implementing` and `fixing` explicitly clear the primary `coder` pane before dispatch so resume never reuses an old shell after the prior coder CLI has exited

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -76,6 +76,11 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "project-specific prompts", "session")
+            files.planning_dir.mkdir(parents=True, exist_ok=True)
+            (files.planning_dir / "plan_meta.json").write_text(
+                '{"needs_design": false, "needs_docs": true, "doc_files": ["docs/prompts.md"]}',
+                encoding="utf-8",
+            )
 
             cases: list[tuple[str, str, str, object]] = [
                 ("agents", "architect", "EXT-ARCHITECT", lambda runtime: build_architect_prompt(runtime)),
@@ -143,19 +148,41 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             self.assertIn(injected, prompt)
             self.assertNotIn("{project_instructions}", prompt)
 
-    def test_docs_prompt_reads_and_updates_readme_and_claude(self) -> None:
+    def test_docs_prompt_targets_architect_declared_doc_files(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             project_dir = tmp_path / "project"
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "docs prompt", "session")
+            files.planning_dir.mkdir(parents=True, exist_ok=True)
+            (files.planning_dir / "plan_meta.json").write_text(
+                '{"needs_design": false, "needs_docs": true, "doc_files": ["docs/file-protocol.md", "docs/prompts.md"]}',
+                encoding="utf-8",
+            )
 
             prompt = build_docs_prompt(files)
 
-            self.assertIn(f"- {project_dir}/README.md", prompt)
-            self.assertIn(f"- {project_dir}/CLAUDE.md", prompt)
-            self.assertIn(f"Update {project_dir}/README.md, {project_dir}/CLAUDE.md", prompt)
+            self.assertIn(f"- {project_dir}/docs/file-protocol.md", prompt)
+            self.assertIn(f"- {project_dir}/docs/prompts.md", prompt)
+            self.assertNotIn(f"- {project_dir}/README.md", prompt)
+            self.assertNotIn(f"- {project_dir}/CLAUDE.md", prompt)
+
+    def test_docs_prompt_fails_when_plan_meta_lacks_doc_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            project_dir = tmp_path / "project"
+            feature_dir = tmp_path / "feature"
+            project_dir.mkdir()
+            files = create_feature_files(project_dir, feature_dir, "docs prompt", "session")
+            files.planning_dir.mkdir(parents=True, exist_ok=True)
+            (files.planning_dir / "plan_meta.json").write_text(
+                '{"needs_design": false, "needs_docs": true}',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(RuntimeError):
+                build_docs_prompt(files)
 
     def test_coder_prompt_includes_completed_research_references(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -153,10 +153,30 @@ class InferResumePhaseTests(unittest.TestCase):
             (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
             (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
             (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            self._write_json(
+                feature_dir / PLANNING_DIR / "plan_meta.json",
+                '{"needs_design": false, "needs_docs": true, "doc_files": ["docs/file-protocol.md"]}',
+            )
             (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
             (feature_dir / REVIEW_DIR / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
             state = {"phase": "failed", "subplan_count": 1}
             self.assertEqual("documenting", infer_resume_phase(feature_dir, state))
+
+    def test_failed_review_pass_without_docs_requirement_resumes_completing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            self._write_json(
+                feature_dir / PLANNING_DIR / "plan_meta.json",
+                '{"needs_design": false, "needs_docs": false, "doc_files": []}',
+            )
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
+            (feature_dir / REVIEW_DIR / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
+            state = {"phase": "failed", "subplan_count": 1}
+            self.assertEqual("completing", infer_resume_phase(feature_dir, state))
 
     def test_failed_when_docs_done_resumes_completing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -166,6 +186,10 @@ class InferResumePhaseTests(unittest.TestCase):
             (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
             (feature_dir / DOCS_DIR).mkdir(parents=True, exist_ok=True)
             (feature_dir / PLANNING_DIR / "plan.md").write_text("# Plan", encoding="utf-8")
+            self._write_json(
+                feature_dir / PLANNING_DIR / "plan_meta.json",
+                '{"needs_design": false, "needs_docs": true, "doc_files": ["docs/file-protocol.md"]}',
+            )
             (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text("", encoding="utf-8")
             (feature_dir / REVIEW_DIR / "review.md").write_text("Verdict: pass\n", encoding="utf-8")
             (feature_dir / DOCS_DIR / "docs_done").write_text("", encoding="utf-8")

--- a/tests/test_review_pass_requirements.py
+++ b/tests/test_review_pass_requirements.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -67,6 +68,18 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         )
         return ctx, files.state
 
+    def _write_plan_meta(self, ctx: PipelineContext, *, needs_docs: bool, doc_files: list[str] | None = None) -> None:
+        ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        plan_meta = {
+            "needs_design": False,
+            "needs_docs": needs_docs,
+            "doc_files": doc_files if doc_files is not None else [],
+        }
+        (ctx.files.planning_dir / "plan_meta.json").write_text(
+            json.dumps(plan_meta) + "\n",
+            encoding="utf-8",
+        )
+
     def test_reviewer_prompt_requires_review_md_for_pass_and_fail(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
@@ -103,6 +116,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature", with_docs=True)
+            self._write_plan_meta(ctx, needs_docs=True, doc_files=["docs/file-protocol.md"])
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
@@ -115,10 +129,11 @@ class ReviewPassRequirementsTests(unittest.TestCase):
             self.assertEqual("documenting", updated["phase"])
             self.assertEqual("review_passed", updated["last_event"])
 
-    def test_handle_review_passed_moves_to_completing_without_docs_agent(self) -> None:
+    def test_handle_review_passed_moves_to_completing_when_docs_not_required(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
-            ctx, state_path = self._make_ctx(tmp_path / "feature", with_docs=False)
+            ctx, state_path = self._make_ctx(tmp_path / "feature", with_docs=True)
+            self._write_plan_meta(ctx, needs_docs=False, doc_files=[])
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
@@ -130,6 +145,20 @@ class ReviewPassRequirementsTests(unittest.TestCase):
             updated = load_state(state_path)
             self.assertEqual("completing", updated["phase"])
             self.assertEqual("review_passed", updated["last_event"])
+
+    def test_handle_review_passed_raises_when_docs_required_but_docs_agent_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            ctx, state_path = self._make_ctx(tmp_path / "feature", with_docs=False)
+            self._write_plan_meta(ctx, needs_docs=True, doc_files=["README.md"])
+
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            write_state(state_path, state)
+
+            phase = get_phase(load_state(state_path))
+            with self.assertRaises(RuntimeError):
+                phase.handle_event(load_state(state_path), "review_passed", ctx)
 
     def test_handle_review_failed_moves_to_fixing_before_limit(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_tasks_requirements.py
+++ b/tests/test_tasks_requirements.py
@@ -50,6 +50,10 @@ class TasksRequirementsTests(unittest.TestCase):
             self.assertIn("write the final plan to `02_planning/plan.md`", architect_prompt)
             self.assertIn("also write `02_planning/tasks.md`", architect_prompt)
             self.assertIn("write `02_planning/plan_meta.json`", architect_prompt)
+            self.assertIn("needs_design", architect_prompt)
+            self.assertIn("needs_docs", architect_prompt)
+            self.assertIn("doc_files", architect_prompt)
+            self.assertIn("empty list when `needs_docs` is `false`", architect_prompt)
             self.assertIn("05_implementation/done_1", coder_prompt)
             self.assertIn("Do not update state.json", coder_prompt)
 
@@ -75,6 +79,10 @@ class TasksRequirementsTests(unittest.TestCase):
             self.assertIn("- 02_planning/tasks.md", prompt)
             self.assertIn("- 08_completion/changes.md", prompt)
             self.assertIn("02_planning/plan_meta.json", prompt)
+            self.assertIn("needs_design", prompt)
+            self.assertIn("needs_docs", prompt)
+            self.assertIn("doc_files", prompt)
+            self.assertIn("empty list when `needs_docs` is `false`", prompt)
             self.assertNotIn("1. Example task", prompt)
 
     def test_architect_prompt_no_longer_accepts_review_mode_and_reviewer_prompt_handles_review(self) -> None:


### PR DESCRIPTION
## Summary
- add docs intent metadata to planning so architect decides whether a docs phase is required
- scope the docs prompt to architect-declared doc targets instead of implicit README/CLAUDE updates
- update resume/review flow and tests to honor needs_docs/doc_files

## Testing
- pytest -q

Closes #5