### PR TITLE
enable-multiple-tmux-sessions

### DIFF
--- a/.agentmux/config.yaml
+++ b/.agentmux/config.yaml
@@ -2,8 +2,7 @@ version: 1
 
 defaults:
   session_name: multi-agent-mvp
-  #provider: claude
-  provider: codex
+  provider: claude
   profile: standard
   max_review_iterations: 3
 
@@ -19,10 +18,7 @@ roles:
     profile: standard
   designer:
     profile: standard
-  docs:
-    provider: codex
-    profile: standard
   code-researcher:
     profile: low
   web-researcher:
-    profile: standard
+    profile: low

--- a/agentmux/pipeline/application.py
+++ b/agentmux/pipeline/application.py
@@ -9,13 +9,18 @@ from ..integrations.github import GitHubBootstrapper, create_branch
 from ..integrations.mcp import McpAgentPreparer
 from ..runtime import TmuxRuntimeFactory
 from ..runtime.file_events import ensure_watchdog_available
-from ..runtime.tmux_control import tmux_session_exists
+from ..runtime.tmux_control import list_agentmux_sessions, tmux_session_exists
 from ..sessions import PreparedSession, PromptInput, SessionCreateRequest, SessionService
-from ..sessions.state_store import feature_slug_from_dir, load_runtime_files, load_state
+from ..sessions.state_store import feature_slug_from_dir, load_runtime_files, load_state, write_state
 from ..shared.models import WorkflowSettings
 from ..terminal_ui.console import ConsoleUI
 from ..workflow.interruptions import InterruptionService
 from ..workflow.orchestrator import PipelineOrchestrator
+
+
+def _derive_session_name(feature_dir: Path) -> str:
+    """Derive a unique tmux session name from the feature directory."""
+    return f"agentmux-{feature_dir.name}"
 
 
 class PipelineApplication:
@@ -48,9 +53,11 @@ class PipelineApplication:
         feature_dir = Path(args.orchestrate).resolve()
         agents = self._mcp_preparer().prepare_feature_agents(loaded.agents, feature_dir)
         files = load_runtime_files(self.project_dir, feature_dir)
+        state = load_state(feature_dir / "state.json")
+        session_name = str(state.get("session_name") or loaded.session_name)
         runtime = self.runtime_factory.attach(
             feature_dir=feature_dir,
-            session_name=loaded.session_name,
+            session_name=session_name,
             agents=agents,
         )
         ctx = self.orchestrator.create_context(
@@ -94,17 +101,29 @@ class PipelineApplication:
     def _run_launcher(self, args, loaded) -> int:
         if args.resume and getattr(args, "issue", None):
             raise SystemExit("--issue cannot be used with --resume.")
-        if tmux_session_exists(loaded.session_name):
-            raise SystemExit(
-                f"tmux session `{loaded.session_name}` already exists. Stop it or change the resolved session name in your config."
-            )
 
         mcp = self._mcp_preparer()
         mcp.ensure_project_config(loaded.agents)
 
         prepared = self._prepare_session(args, loaded)
+        if args.resume:
+            state = load_state(prepared.files.state)
+            session_name = str(state.get("session_name") or loaded.session_name)
+            if tmux_session_exists(session_name):
+                raise SystemExit(
+                    f"tmux session `{session_name}` is still active. Detach or kill it before resuming."
+                )
+        else:
+            session_name = _derive_session_name(prepared.feature_dir)
+            state = load_state(prepared.files.state)
+            state["session_name"] = session_name
+            write_state(prepared.files.state, state)
+            existing_sessions = [name for name in list_agentmux_sessions() if name != session_name]
+            if existing_sessions:
+                self.ui.print(f"Warning: Other agentmux session(s) running: {', '.join(existing_sessions)}")
+
         agents = mcp.prepare_feature_agents(loaded.agents, prepared.feature_dir)
-        return self._launch_attached_session(args, loaded, prepared, agents)
+        return self._launch_attached_session(args, prepared, agents, session_name=session_name)
 
     def _prepare_session(self, args, loaded) -> PreparedSession:
         if args.resume:
@@ -169,7 +188,7 @@ class PipelineApplication:
             return 130 if report.category == "canceled" else 1
         return 0
 
-    def _launch_attached_session(self, args, loaded, prepared: PreparedSession, agents) -> int:
+    def _launch_attached_session(self, args, prepared: PreparedSession, agents, session_name: str) -> int:
         files = prepared.files
         feature_dir = prepared.feature_dir
         initial_role = "product-manager" if prepared.product_manager and "product-manager" in agents else "architect"
@@ -177,15 +196,15 @@ class PipelineApplication:
         try:
             self.runtime_factory.create(
                 feature_dir=feature_dir,
-                session_name=loaded.session_name,
+                session_name=session_name,
                 agents=agents,
                 config_path=self.config_path,
                 initial_role=initial_role,
             )
             self._start_background_orchestrator(feature_dir, args.keep_session, prepared.product_manager)
             self.ui.print(f"Feature directory: {feature_dir}")
-            self.ui.print(f"tmux session: {loaded.session_name}")
-            subprocess.run(["tmux", "attach-session", "-t", loaded.session_name], check=True)
+            self.ui.print(f"tmux session: {session_name}")
+            subprocess.run(["tmux", "attach-session", "-t", session_name], check=True)
             return self._post_attach_result(files=files, feature_dir=feature_dir)
         except KeyboardInterrupt:
             report = self.interruptions.build_canceled(

--- a/agentmux/runtime/tmux_control.py
+++ b/agentmux/runtime/tmux_control.py
@@ -39,6 +39,26 @@ def tmux_session_exists(session_name: str) -> bool:
     return result.returncode == 0
 
 
+def list_agentmux_sessions() -> list[str]:
+    """Return names of active tmux sessions starting with ``agentmux-``."""
+    try:
+        result = run_command(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, KeyboardInterrupt):
+        return []
+    if result is None or not hasattr(result, "returncode"):
+        return []
+    if result.returncode != 0:
+        return []
+    return [
+        name.strip()
+        for name in result.stdout.splitlines()
+        if name.strip().startswith("agentmux-")
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Debug logging
 # ---------------------------------------------------------------------------

--- a/agentmux/sessions/state_store.py
+++ b/agentmux/sessions/state_store.py
@@ -135,6 +135,7 @@ def create_feature_files(
     )
     state = {
         "feature_dir": str(feature_dir),
+        "session_name": session_name,
         "phase": "product_management" if product_manager else "planning",
         "product_manager": bool(product_manager),
         "last_event": "feature_created",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ roles:
 
 ## Config structure
 
-- `defaults.session_name` — tmux session name
+- `defaults.session_name` — legacy fallback used only when resuming old sessions that do not yet persist `state.json.session_name`; new runs derive tmux names from the feature directory (`agentmux-<feature_dir_name>`)
 - `defaults.provider` — default provider/launcher name for roles that do not override it
 - `defaults.profile` — default profile name, usually `max`, `standard`, or `low`
 - `defaults.max_review_iterations` — caps automatic reviewer→coder fix loops

--- a/docs/session-resumption.md
+++ b/docs/session-resumption.md
@@ -22,8 +22,10 @@ agentmux --resume <feature-dir-or-name>  # Resume specific session by name or pa
    - `needs_design: true` resumes into `designing` when `04_design/design.md` is still missing
    - `needs_docs`/`doc_files` remain planning metadata and do not create a dedicated resume phase
    - a passed review resumes directly into `completing`
-7. On resume, the phase is updated in `state.json`, `last_event` is set to `"resumed"`, and any research tasks with `"dispatched"` status are cleaned up (allowing re-request)
-8. Orchestrator/monitor entrypoints infer the project directory from session paths under `.agentmux/.sessions/<id>`
-9. The orchestrator picks up the updated state and injects the appropriate phase prompt to resume work
-10. `implementing` and `fixing` explicitly clear the primary `coder` pane before dispatch so resume never reuses an old shell after the prior coder CLI has exited
-11. If the prior run failed because a registered tmux agent pane disappeared, the interruption metadata in `state.json` is cleared on resume and a fresh pane is created only when the resumed phase next needs that role
+7. Session identity is persisted in `state.json` as `session_name`; resume reads that value and falls back to `defaults.session_name` only for legacy states that do not yet have the field
+8. Resume hard-blocks if that recovered tmux session is still active (`tmux session <name> is still active. Detach or kill it before resuming.`)
+9. On resume, the phase is updated in `state.json`, `last_event` is set to `"resumed"`, and any research tasks with `"dispatched"` status are cleaned up (allowing re-request)
+10. Orchestrator/monitor entrypoints infer the project directory from session paths under `.agentmux/.sessions/<id>`
+11. The orchestrator picks up the updated state and injects the appropriate phase prompt to resume work
+12. `implementing` and `fixing` explicitly clear the primary `coder` pane before dispatch so resume never reuses an old shell after the prior coder CLI has exited
+13. If the prior run failed because a registered tmux agent pane disappeared, the interruption metadata in `state.json` is cleared on resume and a fresh pane is created only when the resumed phase next needs that role

--- a/docs/tmux-layout.md
+++ b/docs/tmux-layout.md
@@ -2,6 +2,19 @@
 
 > Related source files: `agentmux/runtime/tmux_control.py`, `agentmux/runtime/__init__.py`, `agentmux/runtime/interruption_sources.py`, `agentmux/monitor/__init__.py`, `agentmux/terminal_ui/layout.py`
 
+## Session naming
+
+Tmux sessions are named from the feature directory:
+
+- `agentmux-<feature_dir_name>`
+
+Example:
+
+- Feature directory `.agentmux/.sessions/20260328-075309-enable-multiple-tmux-sessions`
+- Tmux session `agentmux-20260328-075309-enable-multiple-tmux-sessions`
+
+When launching a new session, AgentMux also warns if other active `agentmux-*` sessions already exist.
+
 ## Content zone
 
 The tmux layout is split into two zones:

--- a/tests/test_unique_session_names.py
+++ b/tests/test_unique_session_names.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import agentmux.pipeline.application as application
+from agentmux.runtime.tmux_control import list_agentmux_sessions
+from agentmux.shared.models import GitHubConfig
+from agentmux.sessions import PreparedSession
+from agentmux.sessions.state_store import create_feature_files
+from agentmux.terminal_ui.console import ConsoleUI
+
+
+class UniqueSessionNamesTests(unittest.TestCase):
+    def test_list_agentmux_sessions_filters_prefix(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["tmux", "list-sessions", "-F", "#{session_name}"],
+            returncode=0,
+            stdout="agentmux-a\nlegacy\nagentmux-b\n",
+            stderr="",
+        )
+
+        with patch("agentmux.runtime.tmux_control.run_command", return_value=completed):
+            sessions = list_agentmux_sessions()
+
+        self.assertEqual(["agentmux-a", "agentmux-b"], sessions)
+
+    def test_create_feature_files_persists_session_name_in_state(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "20260328-000000-demo"
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="implement unique session names",
+                session_name="agentmux-20260328-000000-demo",
+            )
+            state = json.loads(files.state.read_text(encoding="utf-8"))
+            self.assertEqual("agentmux-20260328-000000-demo", state.get("session_name"))
+
+    def test_derive_session_name_uses_feature_directory_name(self) -> None:
+        feature_dir = Path("/tmp/project/.agentmux/.sessions/20260328-000000-demo")
+        self.assertEqual(
+            "agentmux-20260328-000000-demo",
+            application._derive_session_name(feature_dir),
+        )
+
+    def test_run_launcher_does_not_block_non_resume_when_default_session_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            app = application.PipelineApplication(project_dir)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="prompt",
+                session_name="legacy-name",
+            )
+            prepared = PreparedSession(feature_dir=feature_dir, files=files, product_manager=False)
+            args = SimpleNamespace(resume=None, issue=None)
+            loaded = SimpleNamespace(agents={}, session_name="multi-agent-mvp")
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app, "_prepare_session", return_value=prepared
+            ), patch.object(
+                app, "_launch_attached_session", return_value=0
+            ) as launch_mock, patch(
+                "agentmux.pipeline.application.tmux_session_exists",
+                return_value=True,
+            ):
+                result = app._run_launcher(args, loaded)
+
+            self.assertEqual(0, result)
+            launch_mock.assert_called_once()
+
+    def test_run_launcher_derives_and_persists_session_name_with_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            messages: list[str] = []
+            app = application.PipelineApplication(project_dir, ui=ConsoleUI(output_fn=messages.append))
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="prompt",
+                session_name="legacy-name",
+            )
+            prepared = PreparedSession(feature_dir=feature_dir, files=files, product_manager=False)
+            args = SimpleNamespace(resume=None, issue=None)
+            loaded = SimpleNamespace(agents={}, session_name="multi-agent-mvp")
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app, "_prepare_session", return_value=prepared
+            ), patch.object(
+                app, "_launch_attached_session", return_value=0
+            ), patch(
+                "agentmux.pipeline.application.list_agentmux_sessions",
+                return_value=["agentmux-existing"],
+            ):
+                result = app._run_launcher(args, loaded)
+
+            self.assertEqual(0, result)
+            state = json.loads(files.state.read_text(encoding="utf-8"))
+            self.assertEqual("agentmux-demo", state.get("session_name"))
+            self.assertTrue(
+                any("Warning: Other agentmux session(s) running: agentmux-existing" in message for message in messages)
+            )
+
+    def test_run_launcher_passes_resolved_session_name_to_launch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            app = application.PipelineApplication(project_dir)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="prompt",
+                session_name="legacy-name",
+            )
+            prepared = PreparedSession(feature_dir=feature_dir, files=files, product_manager=False)
+            args = SimpleNamespace(resume=None, issue=None)
+            loaded = SimpleNamespace(agents={}, session_name="multi-agent-mvp")
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app, "_prepare_session", return_value=prepared
+            ), patch.object(
+                app, "_launch_attached_session", return_value=0
+            ) as launch_mock, patch(
+                "agentmux.pipeline.application.list_agentmux_sessions",
+                return_value=[],
+            ):
+                result = app._run_launcher(args, loaded)
+
+            self.assertEqual(0, result)
+            self.assertEqual("agentmux-demo", launch_mock.call_args.kwargs.get("session_name"))
+
+    def test_background_orchestrator_uses_session_name_from_state(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "state.json").write_text(
+                json.dumps({"session_name": "agentmux-demo"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            app = application.PipelineApplication(project_dir)
+            args = SimpleNamespace(orchestrate=str(feature_dir), keep_session=False)
+            loaded = SimpleNamespace(
+                agents={},
+                max_review_iterations=3,
+                github=GitHubConfig(),
+                session_name="multi-agent-mvp",
+            )
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app.runtime_factory,
+                "attach",
+                return_value=object(),
+            ) as attach_mock, patch.object(
+                app.orchestrator,
+                "create_context",
+                return_value=object(),
+            ), patch.object(
+                app.orchestrator,
+                "run",
+                return_value=0,
+            ):
+                result = app._run_background_orchestrator(args, loaded)
+
+            self.assertEqual(0, result)
+            self.assertEqual("agentmux-demo", attach_mock.call_args.kwargs.get("session_name"))
+
+    def test_background_orchestrator_falls_back_to_loaded_session_name(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "state.json").write_text(
+                json.dumps({"phase": "planning"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            app = application.PipelineApplication(project_dir)
+            args = SimpleNamespace(orchestrate=str(feature_dir), keep_session=False)
+            loaded = SimpleNamespace(
+                agents={},
+                max_review_iterations=3,
+                github=GitHubConfig(),
+                session_name="multi-agent-mvp",
+            )
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app.runtime_factory,
+                "attach",
+                return_value=object(),
+            ) as attach_mock, patch.object(
+                app.orchestrator,
+                "create_context",
+                return_value=object(),
+            ), patch.object(
+                app.orchestrator,
+                "run",
+                return_value=0,
+            ):
+                result = app._run_background_orchestrator(args, loaded)
+
+            self.assertEqual(0, result)
+            self.assertEqual("multi-agent-mvp", attach_mock.call_args.kwargs.get("session_name"))
+
+    def test_run_launcher_resume_blocks_when_recovered_session_is_active(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            app = application.PipelineApplication(project_dir)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="prompt",
+                session_name="legacy-name",
+            )
+            state = json.loads(files.state.read_text(encoding="utf-8"))
+            state["session_name"] = "agentmux-demo"
+            files.state.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+            prepared = PreparedSession(feature_dir=feature_dir, files=files, product_manager=False)
+            args = SimpleNamespace(resume="demo", issue=None)
+            loaded = SimpleNamespace(agents={}, session_name="multi-agent-mvp")
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app, "_prepare_session", return_value=prepared
+            ), patch.object(
+                app, "_launch_attached_session", return_value=0
+            ), patch(
+                "agentmux.pipeline.application.tmux_session_exists",
+                return_value=True,
+            ), self.assertRaises(SystemExit) as ctx:
+                app._run_launcher(args, loaded)
+
+            self.assertIn("tmux session `agentmux-demo` is still active", str(ctx.exception))
+
+    def test_run_launcher_resume_uses_loaded_session_name_for_legacy_state(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td)
+            app = application.PipelineApplication(project_dir)
+            feature_dir = project_dir / ".agentmux" / ".sessions" / "demo"
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="prompt",
+                session_name="legacy-name",
+            )
+            state = json.loads(files.state.read_text(encoding="utf-8"))
+            state.pop("session_name", None)
+            files.state.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+            prepared = PreparedSession(feature_dir=feature_dir, files=files, product_manager=False)
+            args = SimpleNamespace(resume="demo", issue=None)
+            loaded = SimpleNamespace(agents={}, session_name="multi-agent-mvp")
+            mcp = Mock()
+            mcp.prepare_feature_agents.return_value = {}
+
+            with patch.object(app, "_mcp_preparer", return_value=mcp), patch.object(
+                app, "_prepare_session", return_value=prepared
+            ), patch.object(
+                app, "_launch_attached_session", return_value=0
+            ), patch(
+                "agentmux.pipeline.application.tmux_session_exists",
+                return_value=True,
+            ), self.assertRaises(SystemExit) as ctx:
+                app._run_launcher(args, loaded)
+
+            self.assertIn("tmux session `multi-agent-mvp` is still active", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Initial Request

Aktuell kann man keine zweite Session starten: `tmux session `multi-agent-mvp` already exists. Stop it or change the resolved session name in your config.`

Die session muss eine eindeutige kennung, aber auhc eine Warnung falls in diesem Verzeichnis gerade eine Session läuft.

## Plan Summary

Problem

The tmux session name is static (`multi-agent-mvp` from config). Starting a second pipeline instance fails with a hard error because the session already exists. Users need to run concurrent pipelines in the same project.

## Review Verdict

verdict: pass



Closes #42
