### PR TITLE
add-onboarding-guide-for-new-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ agentmux --resume
 
 ```
 
+For a detailed walkthrough, see the [Getting Started guide](docs/getting-started.md).
+
 If `gh` is authenticated, AgentMux can bootstrap from issue content and open a pull request when the pipeline completes.
 
 ## Configuration
@@ -115,6 +117,7 @@ Profiles (`max`, `standard`, `low`) map to provider-specific models and launch a
 
 ## Documentation
 
+- [`docs/getting-started.md`](docs/getting-started.md) — installation, setup, and first pipeline run
 - [`docs/configuration.md`](docs/configuration.md) — layered launcher/profile configuration
 - [`docs/file-protocol.md`](docs/file-protocol.md) — shared file protocol between agents and orchestrator
 - [`docs/monitor.md`](docs/monitor.md) — monitor command, state view, and terminal rendering

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,172 @@
+# Getting Started
+
+This guide walks through a first-time setup of AgentMux: prerequisites, installation, `agentmux init`, and a first pipeline run.
+
+## Prerequisites Checklist
+
+Before you run AgentMux, verify each prerequisite:
+
+- Python 3.10+
+  ```bash
+  python3 --version
+  ```
+- tmux
+  ```bash
+  tmux -V
+  ```
+- At least one supported CLI tool (`claude`, `codex`, `gemini`, or `opencode`)
+  ```bash
+  claude --version
+  codex --version
+  gemini --version
+  opencode --version
+  ```
+
+Your chosen CLI tool must also be authenticated before running pipelines.
+
+## Installation
+
+Choose one install path:
+
+1. Install from GitHub with pip
+   ```bash
+   python3 -m pip install git+https://github.com/markuswondrak/AgentMux.git
+   ```
+2. Install as an isolated CLI with pipx
+   ```bash
+   pipx install git+https://github.com/markuswondrak/AgentMux.git
+   ```
+3. Upgrade a pipx Git install (recommended pattern for this repo)
+   ```bash
+   pipx install --force git+https://github.com/markuswondrak/AgentMux.git
+   ```
+4. Editable install for local development
+   ```bash
+   python3 -m pip install -e .
+   ```
+
+Verify the CLI is available:
+
+```bash
+agentmux --help
+```
+
+## Project Setup (`agentmux init`)
+
+Run:
+
+```bash
+agentmux init
+```
+
+In interactive mode, the wizard prompts for:
+
+- `Default provider` from detected CLIs
+- `Role setup` (use one provider for all roles, or customize per role)
+- Per-role settings when customizing (`architect`, `product-manager`, `reviewer`, `coder`, `designer`)
+- GitHub defaults:
+  - `Base branch`
+  - `Create draft PRs by default?`
+  - `Branch prefix`
+- `CLAUDE.md setup` (create from template, symlink an existing file, keep/skip)
+- `Select prompt stubs to create`
+- MCP research setup confirmation for supported providers
+
+After init, the project contains:
+
+- `.agentmux/config.yaml`
+- Optional role prompt stubs in `.agentmux/prompts/agents/<role>.md`
+- `CLAUDE.md` (created unless skipped or already present in defaults mode)
+
+For non-interactive setup with built-in defaults:
+
+```bash
+agentmux init --defaults
+```
+
+For full init behavior details, see [Configuration](configuration.md) and [Prompts](prompts.md).
+
+## First Pipeline Run
+
+Start with a simple feature request:
+
+```bash
+agentmux "Add a health check endpoint"
+```
+
+What you will see:
+
+- A tmux session with a monitor/control pane on the left and agent panes on the right
+- Session name printed at launch (for example: `agentmux-<feature-name>`)
+- Agents receiving prompt files and progressing by phase
+
+To attach from another terminal:
+
+```bash
+tmux attach -t <session-name>
+```
+
+High-level phase flow:
+
+1. Planning
+2. Implementing
+3. Reviewing
+4. Completing
+
+After review passes, AgentMux asks for approval (unless approval skipping is configured); you can approve or request changes before finalization:
+
+- Commits changes locally
+- Optionally opens a pull request if `gh` is available and configured
+
+For phase-level details, see [File Protocol](file-protocol.md) and [Completing Phase](completing-phase.md).
+
+## Tmux Essentials
+
+If you are new to tmux, these commands are enough to observe runs:
+
+- Attach to a running session:
+  ```bash
+  tmux attach -t <session>
+  ```
+- Detach without stopping agents: `Ctrl-b d`
+- Move between panes: `Ctrl-b <arrow>`
+
+Detaching does not stop the pipeline; agents keep running in the background.
+
+## Troubleshooting
+
+### tmux not installed
+
+Common symptom: `agentmux` exits early because `tmux` is missing.
+
+Install tmux, then retry:
+
+```bash
+# Debian/Ubuntu
+sudo apt install tmux
+
+# macOS (Homebrew)
+brew install tmux
+```
+
+### CLI tool not authenticated
+
+Common symptom: an agent pane hangs waiting for provider login, or the provider CLI returns an auth error.
+
+Fix:
+
+1. Run your provider CLI directly (for example `claude`) to complete authentication.
+2. Confirm auth with `claude --version` / `codex --version` / `gemini --version` / `opencode --version`.
+3. Re-run the pipeline.
+
+## Next Steps
+
+- Tune provider/profile settings in [Configuration](configuration.md)
+- Add a requirements-refinement phase with `--product-manager`
+- Bootstrap runs from GitHub issues with `--issue <number-or-url>`
+- Continue interrupted work with `--resume` (see [Session Resumption](session-resumption.md))
+- Use reference docs as needed:
+  - [Tmux Layout](tmux-layout.md)
+  - [Research Dispatch](research-dispatch.md)
+  - [Monitor](monitor.md)
+  - [Prompts](prompts.md)

--- a/tests/test_getting_started_guide_requirements.py
+++ b/tests/test_getting_started_guide_requirements.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class GettingStartedGuideRequirementsTests(unittest.TestCase):
+    def _read(self, relative_path: str) -> str:
+        return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+    def test_getting_started_guide_covers_required_sections_and_commands(self) -> None:
+        text = self._read("docs/getting-started.md")
+
+        self.assertIn("# Getting Started", text)
+        self.assertIn("## Prerequisites Checklist", text)
+        self.assertIn("python3 --version", text)
+        self.assertIn("tmux -V", text)
+        self.assertIn("claude --version", text)
+        self.assertIn("codex --version", text)
+        self.assertIn("gemini --version", text)
+        self.assertIn("opencode --version", text)
+        self.assertIn("authenticated", text.lower())
+
+        self.assertIn("## Installation", text)
+        self.assertIn("python3 -m pip install git+https://github.com/markuswondrak/AgentMux.git", text)
+        self.assertIn("pipx install git+https://github.com/markuswondrak/AgentMux.git", text)
+        self.assertIn("pipx install --force git+https://github.com/markuswondrak/AgentMux.git", text)
+        self.assertIn("python3 -m pip install -e .", text)
+        self.assertIn("agentmux --help", text)
+
+        self.assertIn("## Project Setup (`agentmux init`)", text)
+        self.assertIn("Default provider", text)
+        self.assertIn("Role setup", text)
+        self.assertIn("Base branch", text)
+        self.assertIn("Create draft PRs by default?", text)
+        self.assertIn("Branch prefix", text)
+        self.assertIn("CLAUDE.md setup", text)
+        self.assertIn("Select prompt stubs to create", text)
+        self.assertIn("agentmux init --defaults", text)
+        self.assertIn(".agentmux/config.yaml", text)
+        self.assertIn(".agentmux/prompts/agents/<role>.md", text)
+
+        self.assertIn("## First Pipeline Run", text)
+        self.assertIn('agentmux "Add a health check endpoint"', text)
+        self.assertIn("tmux attach -t <session-name>", text)
+        self.assertIn("planning", text.lower())
+        self.assertIn("implementing", text.lower())
+        self.assertIn("reviewing", text.lower())
+        self.assertIn("completing", text.lower())
+        self.assertIn("approve", text.lower())
+        self.assertIn("pull request", text.lower())
+
+        self.assertIn("## Tmux Essentials", text)
+        self.assertIn("Ctrl-b d", text)
+        self.assertIn("Ctrl-b <arrow>", text)
+
+        self.assertIn("## Troubleshooting", text)
+        self.assertIn("brew install tmux", text)
+        self.assertIn("apt install tmux", text)
+        self.assertIn("hangs", text.lower())
+
+        self.assertIn("## Next Steps", text)
+        self.assertIn("--product-manager", text)
+        self.assertIn("--issue", text)
+        self.assertIn("--resume", text)
+        self.assertIn("(configuration.md)", text)
+        self.assertIn("(session-resumption.md)", text)
+
+    def test_getting_started_guide_stays_under_200_lines(self) -> None:
+        lines = self._read("docs/getting-started.md").splitlines()
+        self.assertLessEqual(len(lines), 200)
+
+    def test_readme_has_quickstart_cross_link_and_docs_entry(self) -> None:
+        readme = self._read("README.md")
+        quickstart_block = """# Resume an interrupted run
+agentmux --resume
+
+```"""
+        guide_line = "For a detailed walkthrough, see the [Getting Started guide](docs/getting-started.md)."
+        gh_line = "If `gh` is authenticated, AgentMux can bootstrap from issue content and open a pull request when the pipeline completes."
+
+        self.assertIn(quickstart_block, readme)
+        self.assertIn(guide_line, readme)
+        self.assertIn(gh_line, readme)
+        self.assertLess(readme.index(quickstart_block), readme.index(guide_line))
+        self.assertLess(readme.index(guide_line), readme.index(gh_line))
+
+        docs_section_match = re.search(r"## Documentation\n\n(?P<section>(?:- .+\n)+)", readme)
+        self.assertIsNotNone(docs_section_match)
+        docs_section = docs_section_match.group("section")
+        first_entry = docs_section.splitlines()[0]
+        self.assertEqual(
+            "- [`docs/getting-started.md`](docs/getting-started.md) — installation, setup, and first pipeline run",
+            first_entry,
+        )
+
+    def test_relative_links_resolve_in_getting_started_guide(self) -> None:
+        text = self._read("docs/getting-started.md")
+        links = re.findall(r"\[[^\]]+\]\(([^)]+)\)", text)
+        relative_links = [link for link in links if not link.startswith(("http://", "https://", "#"))]
+
+        self.assertGreater(len(relative_links), 0)
+        docs_dir = REPO_ROOT / "docs"
+        for link in relative_links:
+            with self.subTest(link=link):
+                target = (docs_dir / link).resolve()
+                self.assertTrue(target.exists(), f"Missing relative link target: {link}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Initial Request

Create a getting-started guide covering installation, configuration, and running the first pipeline.

## Plan Summary

Scope

Create a new onboarding guide at `docs/getting-started.md` and link it from `README.md`. No code, config, or test changes.

## Review Verdict

verdict: pass



Closes #10
