### PR TITLE
optimize-prompts-and-commands

### DIFF
--- a/.agentmux/.last_completion.json
+++ b/.agentmux/.last_completion.json
@@ -1,0 +1,6 @@
+{
+  "feature_name": "add-onboarding-guide-for-new-users",
+  "commit_hash": "d183787",
+  "pr_url": "https://github.com/markuswondrak/AgentMux/pull/62",
+  "branch_name": "feature/add-onboarding-guide-for-new-users"
+}

--- a/agentmux/prompts/agents/architect.md
+++ b/agentmux/prompts/agents/architect.md
@@ -4,10 +4,17 @@ Session directory: [[placeholder:feature_dir]]
 Project directory: [[placeholder:project_dir]]
 Approved preference proposal artifact: [[placeholder:architect_preference_proposal_file]]
 
-Read these files first:
-- context.md
-- requirements.md
-- state.json
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 ## Research
 

--- a/agentmux/prompts/agents/code-researcher.md
+++ b/agentmux/prompts/agents/code-researcher.md
@@ -4,10 +4,17 @@ Session directory: [[placeholder:feature_dir]]
 Project directory: [[placeholder:project_dir]]
 Topic: [[placeholder:topic]]
 
-Read these files first:
-- context.md
-- requirements.md
-- 03_research/code-[[placeholder:topic]]/request.md
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="03_research/code-[[placeholder:topic]]/request.md">
+[[include:03_research/code-[[placeholder:topic]]/request.md]]
+</file>
 
 Your job:
 1. Analyze the request in `03_research/code-[[placeholder:topic]]/request.md`. Note the context, questions, and scope hints.

--- a/agentmux/prompts/agents/coder.md
+++ b/agentmux/prompts/agents/coder.md
@@ -2,13 +2,27 @@ You are the coder agent for this pipeline run.
 
 Session directory: [[placeholder:feature_dir]]
 
-Read these files first:
-- context.md
-- requirements.md
-- [[placeholder:plan_file]]
-- 02_planning/tasks.md
-- 04_design/design.md (if present)
-- state.json
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="[[placeholder:plan_file]]">
+[[include:[[placeholder:plan_file]]]]
+</file>
+
+<file path="02_planning/tasks.md">
+[[include:02_planning/tasks.md]]
+</file>
+
+[[include-optional:04_design/design.md]]
+
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 [[placeholder:research_handoff]]
 

--- a/agentmux/prompts/agents/designer.md
+++ b/agentmux/prompts/agents/designer.md
@@ -3,11 +3,21 @@ You are the UI designer agent for this pipeline run.
 Session directory: [[placeholder:feature_dir]]
 The project codebase is at `[[placeholder:project_dir]]`; reference it for existing patterns and styles.
 
-Read these files first:
-- context.md
-- requirements.md
-- 02_planning/plan.md
-- state.json
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="02_planning/plan.md">
+[[include:02_planning/plan.md]]
+</file>
+
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 Your job:
 1. First run `/frontend-design` to load the frontend design skill.

--- a/agentmux/prompts/agents/product-manager.md
+++ b/agentmux/prompts/agents/product-manager.md
@@ -4,10 +4,17 @@ Session directory: [[placeholder:feature_dir]]
 Project directory: [[placeholder:project_dir]]
 Approved preference proposal artifact: [[placeholder:pm_preference_proposal_file]]
 
-Read these files first:
-- context.md
-- requirements.md
-- state.json
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 ## Research
 

--- a/agentmux/prompts/agents/web-researcher.md
+++ b/agentmux/prompts/agents/web-researcher.md
@@ -4,10 +4,17 @@ Session directory: [[placeholder:feature_dir]]
 Project directory: [[placeholder:project_dir]]
 Topic: [[placeholder:topic]]
 
-Read these files first:
-- context.md
-- requirements.md
-- 03_research/web-[[placeholder:topic]]/request.md
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="03_research/web-[[placeholder:topic]]/request.md">
+[[include:03_research/web-[[placeholder:topic]]/request.md]]
+</file>
 
 Your job:
 1. Analyze the assignment in `03_research/web-[[placeholder:topic]]/request.md`. Note the context, questions, and scope.

--- a/agentmux/prompts/commands/change.md
+++ b/agentmux/prompts/commands/change.md
@@ -2,11 +2,21 @@ You are the architect agent for this pipeline run, handling requested changes.
 
 Session directory: [[placeholder:feature_dir]]
 
-Read these files first:
-- requirements.md
-- 02_planning/plan.md
-- 02_planning/tasks.md
-- 08_completion/changes.md
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="02_planning/plan.md">
+[[include:02_planning/plan.md]]
+</file>
+
+<file path="02_planning/tasks.md">
+[[include:02_planning/tasks.md]]
+</file>
+
+<file path="08_completion/changes.md">
+[[include:08_completion/changes.md]]
+</file>
 
 Your job:
 1. Revise requirements/plan as needed based on the change feedback.

--- a/agentmux/prompts/commands/confirmation.md
+++ b/agentmux/prompts/commands/confirmation.md
@@ -4,12 +4,25 @@ Session directory: [[placeholder:feature_dir]]
 Project directory: [[placeholder:project_dir]]
 Approved preference proposal artifact: [[placeholder:reviewer_preference_proposal_file]]
 
-Read these files first:
-- context.md
-- requirements.md
-- 02_planning/plan.md
-- 06_review/review.md
-- state.json
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="02_planning/plan.md">
+[[include:02_planning/plan.md]]
+</file>
+
+<file path="06_review/review.md">
+[[include:06_review/review.md]]
+</file>
+
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 Your job:
 1. Present what was implemented to the user.

--- a/agentmux/prompts/commands/fix.md
+++ b/agentmux/prompts/commands/fix.md
@@ -2,12 +2,25 @@ You are the coder agent for this pipeline run, fixing review findings.
 
 Session directory: [[placeholder:feature_dir]]
 
-Read these files first:
-- context.md
-- requirements.md
-- 02_planning/plan.md
-- 06_review/fix_request.md
-- state.json
+<file path="context.md">
+[[include:context.md]]
+</file>
+
+<file path="requirements.md">
+[[include:requirements.md]]
+</file>
+
+<file path="02_planning/plan.md">
+[[include:02_planning/plan.md]]
+</file>
+
+<file path="06_review/fix_request.md">
+[[include:06_review/fix_request.md]]
+</file>
+
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 Your job:
 1. Read the review findings in `06_review/fix_request.md` carefully.

--- a/agentmux/prompts/commands/review.md
+++ b/agentmux/prompts/commands/review.md
@@ -2,8 +2,9 @@ You are the reviewer agent in review mode for this pipeline run.
 
 Session directory: [[placeholder:feature_dir]]
 
-Read these files first:
-- state.json
+<file path="state.json">
+[[include:state.json]]
+</file>
 
 Then inspect the current repository state and compare the implementation against both requirements and plan.
 

--- a/agentmux/runtime/tmux_control.py
+++ b/agentmux/runtime/tmux_control.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shlex
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -479,10 +480,8 @@ def tmux_new_session(
     primary_role: str = "architect",
 ) -> tuple[dict[str, str | None], ContentZone]:
     """Create the tmux session with control pane + primary agent pane."""
-    project_root = Path(__file__).resolve().parent.parent
     monitor_cmd = (
-        f"cd {shlex.quote(str(project_root))} && "
-        f"python3 -m agentmux.monitor"
+        f"{shlex.quote(sys.executable)} -m agentmux.monitor"
         f" --feature-dir {shlex.quote(str(feature_dir))}"
         f" --session-name {shlex.quote(session_name)}"
     )

--- a/agentmux/workflow/prompts.py
+++ b/agentmux/workflow/prompts.py
@@ -9,6 +9,8 @@ from ..shared.models import RuntimeFiles
 PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
 _SHARED_FRAGMENT_PATTERN = re.compile(r"\[\[shared:([a-z0-9][a-z0-9_-]*)\]\]")
 _VALUE_PLACEHOLDER_PATTERN = re.compile(r"\[\[placeholder:([a-z0-9][a-z0-9_-]*)\]\]")
+_SESSION_INCLUDE_PATTERN = re.compile(r"\[\[include:([^\]]+)\]\]")
+_SESSION_INCLUDE_OPTIONAL_PATTERN = re.compile(r"\[\[include-optional:([^\]]+)\]\]")
 _MAX_SHARED_FRAGMENT_EXPANSION_DEPTH = 8
 _PROJECT_INSTRUCTIONS_PLACEHOLDER = "[[placeholder:project_instructions]]"
 
@@ -85,6 +87,27 @@ def _render_template(template: str, values: dict[str, object]) -> str:
     return _VALUE_PLACEHOLDER_PATTERN.sub(_replace, template)
 
 
+def _expand_session_includes(template: str, feature_dir: Path) -> str:
+    def _resolve_path(raw_path: str) -> Path:
+        include_path = raw_path.strip()
+        return feature_dir / include_path
+
+    def _replace_optional(match: re.Match[str]) -> str:
+        path = _resolve_path(match.group(1))
+        if not path.is_file():
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    def _replace_required(match: re.Match[str]) -> str:
+        path = _resolve_path(match.group(1))
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        return path.read_text(encoding="utf-8")
+
+    expanded = _SESSION_INCLUDE_OPTIONAL_PATTERN.sub(_replace_optional, template)
+    return _SESSION_INCLUDE_PATTERN.sub(_replace_required, expanded)
+
+
 def write_prompt_file(feature_dir: Path, name: str, content: str) -> Path:
     prompt_path = feature_dir / name
     prompt_path.parent.mkdir(parents=True, exist_ok=True)
@@ -118,7 +141,7 @@ def _build_coder_research_handoff(files: RuntimeFiles) -> str:
 
 
 def build_architect_prompt(files: RuntimeFiles) -> str:
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "agents",
         "architect",
@@ -128,10 +151,11 @@ def build_architect_prompt(files: RuntimeFiles) -> str:
         "project_dir": files.project_dir,
         "architect_preference_proposal_file": files.relative_path(files.architect_preference_proposal),
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_product_manager_prompt(files: RuntimeFiles) -> str:
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "agents",
         "product-manager",
@@ -141,17 +165,19 @@ def build_product_manager_prompt(files: RuntimeFiles) -> str:
         "project_dir": files.project_dir,
         "pm_preference_proposal_file": files.relative_path(files.pm_preference_proposal),
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_reviewer_prompt(files: RuntimeFiles, is_review: bool = False) -> str:
     if is_review:
-        return _render_template(
+        rendered = _render_template(
             _load_template(
             "commands",
             "review",
             project_dir=files.project_dir,
         ), {"feature_dir": files.feature_dir})
-    return _render_template(
+        return _expand_session_includes(rendered, files.feature_dir)
+    rendered = _render_template(
         _load_template(
         "agents",
         "reviewer",
@@ -161,6 +187,7 @@ def build_reviewer_prompt(files: RuntimeFiles, is_review: bool = False) -> str:
         "project_dir": files.project_dir,
         "reviewer_preference_proposal_file": files.relative_path(files.reviewer_preference_proposal),
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_designer_prompt(files: RuntimeFiles) -> str:
@@ -172,7 +199,7 @@ def build_designer_prompt(files: RuntimeFiles) -> str:
         "- Do not update state.json from the designer step.",
         "- `design.md` is the completion signal for this phase.",
     ])
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "agents",
         "designer",
@@ -183,6 +210,7 @@ def build_designer_prompt(files: RuntimeFiles) -> str:
         "completion_instruction": completion_instruction,
         "completion_constraints": completion_constraints,
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_coder_subplan_prompt(
@@ -201,7 +229,7 @@ def build_coder_subplan_prompt(
         "- Do not update state.json in parallel coder mode.",
         "- Do not write anything to the marker file; create it as an empty file.",
     ])
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "agents",
         "coder",
@@ -214,10 +242,11 @@ def build_coder_subplan_prompt(
         "completion_instruction": completion_instruction,
         "completion_constraints": completion_constraints,
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_fix_prompt(files: RuntimeFiles) -> str:
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "commands",
         "fix",
@@ -226,6 +255,7 @@ def build_fix_prompt(files: RuntimeFiles) -> str:
         "feature_dir": files.feature_dir,
         "project_dir": files.project_dir,
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_confirmation_prompt(files: RuntimeFiles) -> str:
@@ -243,7 +273,7 @@ def build_confirmation_prompt(files: RuntimeFiles) -> str:
         stderr = exc.stderr.strip() if exc.stderr else "(no stderr)"
         changed_files = f"{_CHANGED_FILES_FALLBACK}\nError: {stderr}"
 
-    prompt = _render_template(
+    rendered = _render_template(
         _load_template(
         "commands",
         "confirmation",
@@ -254,11 +284,12 @@ def build_confirmation_prompt(files: RuntimeFiles) -> str:
         "changed_files": changed_files,
         "reviewer_preference_proposal_file": files.relative_path(files.reviewer_preference_proposal),
     })
+    prompt = _expand_session_includes(rendered, files.feature_dir)
     return _append_confirmation_commit_message_contract(prompt)
 
 
 def build_code_researcher_prompt(topic: str, files: RuntimeFiles) -> str:
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "agents",
         "code-researcher",
@@ -268,10 +299,11 @@ def build_code_researcher_prompt(topic: str, files: RuntimeFiles) -> str:
         "project_dir": files.project_dir,
         "topic": topic,
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_web_researcher_prompt(topic: str, files: RuntimeFiles) -> str:
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "agents",
         "web-researcher",
@@ -281,6 +313,7 @@ def build_web_researcher_prompt(topic: str, files: RuntimeFiles) -> str:
         "project_dir": files.project_dir,
         "topic": topic,
     })
+    return _expand_session_includes(rendered, files.feature_dir)
 
 
 def build_initial_prompts(files: RuntimeFiles) -> dict[str, Path]:
@@ -295,9 +328,10 @@ def build_initial_prompts(files: RuntimeFiles) -> dict[str, Path]:
 
 
 def build_change_prompt(files: RuntimeFiles) -> str:
-    return _render_template(
+    rendered = _render_template(
         _load_template(
         "commands",
         "change",
         project_dir=files.project_dir,
     ), {"feature_dir": files.feature_dir})
+    return _expand_session_includes(rendered, files.feature_dir)

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -10,14 +10,21 @@
 ## Placeholder syntax
 
 Built-in prompt templates use `[[placeholder:name]]` value placeholders.
+Built-in templates can also inline session files with:
 
-Render model is two-stage:
+- `[[include:path]]` — required include; raises `FileNotFoundError` when missing.
+- `[[include-optional:path]]` — optional include; resolves to empty string when missing.
+
+Render model is three-stage:
 
 1. Template loading stage:
    - Expand shared fragments using `[[shared:fragment-name]]`.
    - Inject project extension text into `[[placeholder:project_instructions]]`.
 2. Render stage:
    - Resolve `[[placeholder:name]]` values from the active prompt builder context.
+3. Session include expansion stage:
+   - Resolve `[[include:path]]` / `[[include-optional:path]]` against `feature_dir`.
+   - Include expansion runs after placeholder rendering, so include paths can contain placeholders (for example `[[include:[[placeholder:plan_file]]]]`).
 
 Every prompt builder provides `feature_dir` as the session directory and references workflow files with phase subpaths (for example `02_planning/plan.md`, `06_review/review.md`, `state.json`).
 Builders that need project-level context (for example product manager and coder) also provide `project_dir`.
@@ -77,7 +84,7 @@ Prompts are not injected as full text. Instead, `send_prompt()` in `agentmux/run
 Read and follow the instructions in /full/path/to/prompt_file.md
 ```
 
-Agents read the referenced file themselves, reducing keystroke overhead and allowing agents to reuse file content without re-transmission. All prompt templates use file references (e.g., `requirements.md`, `02_planning/plan.md`) — agents fetch what they need.
+Agents still read the referenced prompt file themselves. Prompt files are now self-contained: session files referenced by template includes are inlined at build time, so agents do not need extra tool calls to fetch `requirements.md`, `plan.md`, `state.json`, and similar inputs separately.
 
 ## Lazy build
 

--- a/tests/test_code_researcher_requirements.py
+++ b/tests/test_code_researcher_requirements.py
@@ -76,6 +76,11 @@ class FakeZone:
 
 
 class CodeResearcherRequirementsTests(unittest.TestCase):
+    def _write_code_request(self, feature_dir: Path, topic: str) -> None:
+        request_path = feature_dir / RESEARCH_DIR / f"code-{topic}" / "request.md"
+        request_path.parent.mkdir(parents=True, exist_ok=True)
+        request_path.write_text("investigate topic\n", encoding="utf-8")
+
     def _make_ctx(self, feature_dir: Path) -> tuple[PipelineContext, Path]:
         project_dir = feature_dir.parent / "project"
         project_dir.mkdir(parents=True, exist_ok=True)
@@ -131,6 +136,7 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "research", "session-x")
+            self._write_code_request(feature_dir, "auth-module")
 
             prompt = build_code_researcher_prompt("auth-module", files)
 

--- a/tests/test_completion_commit_flow.py
+++ b/tests/test_completion_commit_flow.py
@@ -36,6 +36,10 @@ def _make_ctx(feature_dir: Path, *, skip_final_approval: bool = False) -> tuple[
     project_dir = feature_dir.parent / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
     files = create_feature_files(project_dir, feature_dir, "test", "session-x")
+    files.plan.parent.mkdir(parents=True, exist_ok=True)
+    files.plan.write_text("# Plan\n", encoding="utf-8")
+    files.review.parent.mkdir(parents=True, exist_ok=True)
+    files.review.write_text("verdict: pass\n", encoding="utf-8")
     agents = {
         "architect": AgentConfig(role="architect", cli="claude", model="opus", args=[]),
         "reviewer": AgentConfig(role="reviewer", cli="claude", model="sonnet", args=[]),

--- a/tests/test_designer_requirements.py
+++ b/tests/test_designer_requirements.py
@@ -59,6 +59,8 @@ def _make_ctx(feature_dir: Path, with_designer: bool = True) -> tuple[PipelineCo
     project_dir = feature_dir.parent / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
     files = create_feature_files(project_dir, feature_dir, "add designer", "session-x")
+    files.plan.parent.mkdir(parents=True, exist_ok=True)
+    files.plan.write_text("# Plan\n", encoding="utf-8")
 
     prompts = {"architect": feature_dir / PLANNING_DIR / "architect_prompt.md"}
     for path in prompts.values():
@@ -97,6 +99,12 @@ def _write_execution_plan(feature_dir: Path, *, name: str = "implementation") ->
 
 
 class DesignerRequirementsTests(unittest.TestCase):
+    def _write_coder_inputs(self, feature_dir: Path) -> None:
+        planning_dir = feature_dir / PLANNING_DIR
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / "plan_1.md").write_text("## Sub-plan 1: implementation\n", encoding="utf-8")
+        (planning_dir / "tasks.md").write_text("# Tasks\n\n- [ ] implement\n", encoding="utf-8")
+
     def test_load_config_parses_optional_designer(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
@@ -142,6 +150,9 @@ class DesignerRequirementsTests(unittest.TestCase):
             project_dir.mkdir()
 
             files = create_feature_files(project_dir, feature_dir, "do ui", "session")
+            files.plan.parent.mkdir(parents=True, exist_ok=True)
+            files.plan.write_text("# Plan\n", encoding="utf-8")
+            self._write_coder_inputs(feature_dir)
 
             coder_prompt = build_coder_subplan_prompt(files, feature_dir / PLANNING_DIR / "plan_1.md", 1)
             designer_prompt = build_designer_prompt(files)
@@ -167,6 +178,8 @@ class DesignerRequirementsTests(unittest.TestCase):
             project_dir.mkdir()
 
             files = create_feature_files(project_dir, feature_dir, "do ui", "session")
+            files.plan.parent.mkdir(parents=True, exist_ok=True)
+            files.plan.write_text("# Plan\n", encoding="utf-8")
             designer_prompt = build_designer_prompt(files)
 
             self.assertIn("tailwind.config.js", designer_prompt)

--- a/tests/test_mcp_pipeline_requirements.py
+++ b/tests/test_mcp_pipeline_requirements.py
@@ -317,8 +317,6 @@ class McpPipelineRequirementsTests(unittest.TestCase):
                 self.assertIn("stop and wait idle", prompt)
                 self.assertIn("summary.md", prompt)
                 self.assertNotIn("Fallback", prompt)
-                self.assertNotIn("03_research/code-<topic>/request.md", prompt)
-                self.assertNotIn("03_research/web-<topic>/request.md", prompt)
 
 
 if __name__ == "__main__":

--- a/tests/test_on_demand_prompt_handlers.py
+++ b/tests/test_on_demand_prompt_handlers.py
@@ -63,6 +63,14 @@ def _make_ctx(feature_dir: Path) -> tuple[PipelineContext, Path]:
     project_dir = feature_dir.parent / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
     files = create_feature_files(project_dir, feature_dir, "on demand prompt generation", "session-x")
+    files.plan.parent.mkdir(parents=True, exist_ok=True)
+    files.plan.write_text("# Plan\n", encoding="utf-8")
+    files.tasks.parent.mkdir(parents=True, exist_ok=True)
+    files.tasks.write_text("# Tasks\n\n- [ ] one task\n", encoding="utf-8")
+    files.fix_request.parent.mkdir(parents=True, exist_ok=True)
+    files.fix_request.write_text("# Fix request\n", encoding="utf-8")
+    files.review.parent.mkdir(parents=True, exist_ok=True)
+    files.review.write_text("verdict: pass\n", encoding="utf-8")
     architect_prompt = feature_dir / "02_planning" / "architect_prompt.md"
     architect_prompt.parent.mkdir(parents=True, exist_ok=True)
     architect_prompt.write_text("architect prompt", encoding="utf-8")
@@ -87,6 +95,7 @@ def _write_execution_plan(feature_dir: Path, plans: list[tuple[int, str]], *, mo
     (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
     for index, name in plans:
         (planning_dir / f"plan_{index}.md").write_text(f"## Sub-plan {index}: {name}\n", encoding="utf-8")
+    (planning_dir / "tasks.md").write_text("# Tasks\n\n- [ ] execute sub-plan\n", encoding="utf-8")
     (planning_dir / "execution_plan.json").write_text(
         json.dumps(
             {

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -54,6 +54,47 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
+    def _write_coder_inputs(self, feature_dir: Path, *, plan_name: str = "plan_1.md") -> None:
+        planning_dir = feature_dir / "02_planning"
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / plan_name).write_text(f"## {plan_name}\n", encoding="utf-8")
+        (planning_dir / "tasks.md").write_text("# Tasks\n\n- [ ] one\n", encoding="utf-8")
+
+    def _write_confirmation_inputs(self, feature_dir: Path) -> None:
+        planning_dir = feature_dir / "02_planning"
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        review_dir = feature_dir / "06_review"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        (review_dir / "review.md").write_text("verdict: pass\n", encoding="utf-8")
+
+    def _write_fix_inputs(self, feature_dir: Path) -> None:
+        planning_dir = feature_dir / "02_planning"
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        review_dir = feature_dir / "06_review"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        (review_dir / "fix_request.md").write_text("# Fix request\n", encoding="utf-8")
+
+    def _write_change_inputs(self, feature_dir: Path) -> None:
+        planning_dir = feature_dir / "02_planning"
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        (planning_dir / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+        completion_dir = feature_dir / "08_completion"
+        completion_dir.mkdir(parents=True, exist_ok=True)
+        (completion_dir / "changes.md").write_text("# Changes\n", encoding="utf-8")
+
+    def _write_designer_inputs(self, feature_dir: Path) -> None:
+        planning_dir = feature_dir / "02_planning"
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+
+    def _write_research_request(self, feature_dir: Path, kind: str, topic: str) -> None:
+        request_path = feature_dir / "03_research" / f"{kind}-{topic}" / "request.md"
+        request_path.parent.mkdir(parents=True, exist_ok=True)
+        request_path.write_text("request\n", encoding="utf-8")
+
     def test_shared_fragment_markers_expand_during_template_loading(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
@@ -285,6 +326,13 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "project-specific prompts", "session")
+            self._write_designer_inputs(feature_dir)
+            self._write_coder_inputs(feature_dir, plan_name="plan_1.md")
+            self._write_research_request(feature_dir, "code", "topic-a")
+            self._write_research_request(feature_dir, "web", "topic-b")
+            self._write_fix_inputs(feature_dir)
+            self._write_confirmation_inputs(feature_dir)
+            self._write_change_inputs(feature_dir)
 
             cases: list[tuple[str, str, str, object]] = [
                 ("agents", "architect", "EXT-ARCHITECT", lambda runtime: build_architect_prompt(runtime)),
@@ -341,6 +389,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "project-specific prompts", "session")
+            self._write_coder_inputs(feature_dir, plan_name="plan_1.md")
 
             injected = "Literal braces: {something} and orphan close brace } and open brace {\n"
             self._write_project_prompt(project_dir, "agents", "coder", injected)
@@ -357,6 +406,8 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "docs scope", "session")
+            self._write_change_inputs(feature_dir)
+            self._write_coder_inputs(feature_dir, plan_name="plan_1.md")
 
             architect_prompt = build_architect_prompt(files)
             change_prompt = build_change_prompt(files)
@@ -384,6 +435,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "research handoff", "session")
+            self._write_coder_inputs(feature_dir, plan_name="plan_1.md")
 
             self._create_research_topic(feature_dir, "web-openai-models", done=True, include_detail=False)
             self._create_research_topic(feature_dir, "code-auth-module", done=True, include_detail=True)
@@ -409,6 +461,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "research handoff", "session")
+            self._write_coder_inputs(feature_dir, plan_name="plan_1.md")
 
             self._create_research_topic(feature_dir, "web-routing", done=True, include_detail=True)
             self._create_research_topic(feature_dir, "code-db-indexes", done=True, include_detail=True)
@@ -428,6 +481,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "research handoff", "session")
+            self._write_coder_inputs(feature_dir, plan_name="plan_1.md")
 
             self._create_research_topic(feature_dir, "code-incomplete-topic", done=False, include_detail=True)
 
@@ -443,6 +497,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "preference capture", "session")
+            self._write_confirmation_inputs(feature_dir)
 
             product_prompt = build_product_manager_prompt(files)
             architect_prompt = build_architect_prompt(files)
@@ -517,6 +572,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "cross-prompt regression", "session")
+            self._write_confirmation_inputs(feature_dir)
             status_output = " M agentmux/workflow/prompts.py\n?? tests/test_project_prompt_extensions_requirements.py\n"
 
             product_prompt = build_product_manager_prompt(files)
@@ -557,6 +613,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "preference capture", "session")
+            self._write_confirmation_inputs(feature_dir)
 
             with patch(
                 "agentmux.workflow.prompts.subprocess.run",
@@ -587,6 +644,7 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "confirmation guidance", "session")
+            self._write_confirmation_inputs(feature_dir)
             status_output = " M agentmux/workflow/prompts.py\n?? tests/test_project_prompt_extensions_requirements.py\n"
 
             with patch(

--- a/tests/test_session_includes.py
+++ b/tests/test_session_includes.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentmux.sessions.state_store import create_feature_files
+from agentmux.workflow import prompts as prompts_module
+
+
+class SessionIncludeTests(unittest.TestCase):
+    def test_mandatory_include_resolves_file_content(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td) / "feature"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "context.md").write_text("ctx content\n", encoding="utf-8")
+
+            rendered = prompts_module._expand_session_includes("Header\n[[include:context.md]]\n", feature_dir)
+
+            self.assertIn("ctx content", rendered)
+            self.assertNotIn("[[include:context.md]]", rendered)
+
+    def test_mandatory_include_raises_for_missing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td) / "feature"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+
+            with self.assertRaises(FileNotFoundError):
+                prompts_module._expand_session_includes("[[include:missing.md]]", feature_dir)
+
+    def test_optional_include_resolves_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td) / "feature"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "04_design" / "design.md").parent.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "04_design" / "design.md").write_text("design details", encoding="utf-8")
+
+            rendered = prompts_module._expand_session_includes(
+                "A\n[[include-optional:04_design/design.md]]\nB",
+                feature_dir,
+            )
+
+            self.assertIn("design details", rendered)
+            self.assertNotIn("[[include-optional:04_design/design.md]]", rendered)
+
+    def test_optional_include_resolves_to_empty_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td) / "feature"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+
+            rendered = prompts_module._expand_session_includes(
+                "A\n[[include-optional:04_design/design.md]]\nB",
+                feature_dir,
+            )
+
+            self.assertEqual("A\n\nB", rendered)
+
+    def test_placeholder_inside_include_resolves_correctly(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td) / "feature"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "02_planning").mkdir(parents=True, exist_ok=True)
+            (feature_dir / "02_planning" / "plan_1.md").write_text("# Plan 1\n", encoding="utf-8")
+
+            template = "[[include:[[placeholder:plan_file]]]]"
+            rendered = prompts_module._render_template(template, {"plan_file": "02_planning/plan_1.md"})
+            expanded = prompts_module._expand_session_includes(rendered, feature_dir)
+
+            self.assertEqual("# Plan 1\n", expanded)
+
+    def test_multiple_includes_in_one_template_all_resolve(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td) / "feature"
+            feature_dir.mkdir(parents=True, exist_ok=True)
+            (feature_dir / "a.md").write_text("A", encoding="utf-8")
+            (feature_dir / "b.md").write_text("B", encoding="utf-8")
+
+            rendered = prompts_module._expand_session_includes(
+                "[[include:a.md]] + [[include:b.md]]",
+                feature_dir,
+            )
+
+            self.assertEqual("A + B", rendered)
+
+    def test_build_architect_prompt_inlines_include_content_end_to_end(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            prompts_dir = tmp_path / "prompts"
+            project_dir = tmp_path / "project"
+            feature_dir = tmp_path / "feature"
+            project_dir.mkdir()
+            files = create_feature_files(project_dir, feature_dir, "include e2e", "session-x")
+
+            architect_template = prompts_dir / "agents" / "architect.md"
+            architect_template.parent.mkdir(parents=True, exist_ok=True)
+            architect_template.write_text(
+                "Session [[placeholder:feature_dir]]\n[[include:context.md]]\n[[placeholder:project_instructions]]\nConstraints:\n",
+                encoding="utf-8",
+            )
+
+            with patch.object(prompts_module, "PROMPTS_DIR", prompts_dir):
+                prompt = prompts_module.build_architect_prompt(files)
+
+            self.assertIn("# Context", prompt)
+            self.assertNotIn("[[include:context.md]]", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_staged_execution_scheduler.py
+++ b/tests/test_staged_execution_scheduler.py
@@ -63,6 +63,14 @@ def _make_ctx(feature_dir: Path) -> tuple[PipelineContext, Path]:
     project_dir = feature_dir.parent / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
     files = create_feature_files(project_dir, feature_dir, "staged execution", "session-x")
+    files.plan.parent.mkdir(parents=True, exist_ok=True)
+    files.plan.write_text("# Plan\n", encoding="utf-8")
+    files.tasks.parent.mkdir(parents=True, exist_ok=True)
+    files.tasks.write_text("# Tasks\n\n- [ ] execute\n", encoding="utf-8")
+    files.fix_request.parent.mkdir(parents=True, exist_ok=True)
+    files.fix_request.write_text("# Fix request\n", encoding="utf-8")
+    files.review.parent.mkdir(parents=True, exist_ok=True)
+    files.review.write_text("verdict: pass\n", encoding="utf-8")
     ctx = PipelineContext(
         files=files,
         runtime=_FakeRuntime(),
@@ -100,6 +108,7 @@ def _write_execution_plan(ctx: PipelineContext, groups: list[dict]) -> None:
     (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
     payload = {"version": 1, "groups": groups}
     (planning_dir / "execution_plan.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    (planning_dir / "tasks.md").write_text("# Tasks\n\n- [ ] execute\n", encoding="utf-8")
     for group in groups:
         for plan_file in group["plans"]:
             plan_ref = plan_file["file"] if isinstance(plan_file, dict) else plan_file

--- a/tests/test_staged_planning_docs_requirements.py
+++ b/tests/test_staged_planning_docs_requirements.py
@@ -27,13 +27,15 @@ class StagedPlanningDocsRequirementsTests(unittest.TestCase):
         self.assertIn("technical debt", text.lower())
         self.assertNotIn("empty file-set intersection should be treated as parallelizable", text.lower())
 
-    def test_prompts_doc_covers_two_stage_template_rendering(self) -> None:
+    def test_prompts_doc_covers_three_stage_template_rendering(self) -> None:
         text = self._read_doc("docs/prompts.md")
         self.assertIn("[[shared:", text)
         self.assertIn("[[placeholder:", text)
-        self.assertIn("two-stage", text.lower())
+        self.assertIn("[[include:", text)
+        self.assertIn("three-stage", text.lower())
         self.assertIn("template loading", text.lower())
         self.assertIn("render", text.lower())
+        self.assertIn("session include expansion", text.lower())
 
     def test_prompts_doc_covers_coder_tdd_phase_and_atomic_contract(self) -> None:
         text = self._read_doc("docs/prompts.md")

--- a/tests/test_tasks_requirements.py
+++ b/tests/test_tasks_requirements.py
@@ -15,6 +15,12 @@ from agentmux.sessions.state_store import create_feature_files, load_runtime_fil
 
 
 class TasksRequirementsTests(unittest.TestCase):
+    def _write_coder_inputs(self, feature_dir: Path, plan_name: str = "plan_1.md") -> None:
+        planning_dir = feature_dir / "02_planning"
+        planning_dir.mkdir(parents=True, exist_ok=True)
+        (planning_dir / plan_name).write_text(f"## {plan_name}\n", encoding="utf-8")
+        (planning_dir / "tasks.md").write_text("# Tasks\n\n- [ ] one task\n", encoding="utf-8")
+
     def test_command_prompt_templates_no_longer_include_docs_agent_handoff_template(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]
         command_templates = sorted(path.name for path in (repo_root / "agentmux/prompts/commands").glob("*.md"))
@@ -62,6 +68,7 @@ class TasksRequirementsTests(unittest.TestCase):
             project_dir.mkdir()
 
             files = create_feature_files(project_dir, feature_dir, "add tasks list", "session")
+            self._write_coder_inputs(feature_dir, "plan_1.md")
 
             architect_prompt = build_architect_prompt(files)
             coder_prompt = build_coder_subplan_prompt(files, feature_dir / "02_planning" / "plan_1.md", 1)
@@ -112,6 +119,7 @@ class TasksRequirementsTests(unittest.TestCase):
             project_dir.mkdir()
 
             files = create_feature_files(project_dir, feature_dir, "subplan coder contract", "session")
+            self._write_coder_inputs(feature_dir, "plan_2.md")
 
             prompt = build_coder_subplan_prompt(files, feature_dir / "02_planning" / "plan_2.md", 2)
 
@@ -132,6 +140,7 @@ class TasksRequirementsTests(unittest.TestCase):
             project_dir.mkdir()
 
             files = create_feature_files(project_dir, feature_dir, "docs ownership", "session")
+            self._write_coder_inputs(feature_dir, "plan_1.md")
 
             coder_prompt = build_coder_subplan_prompt(files, feature_dir / "02_planning" / "plan_1.md", 1)
             reviewer_agent_prompt = build_reviewer_prompt(files)
@@ -152,7 +161,7 @@ class TasksRequirementsTests(unittest.TestCase):
                 reviewer_review_prompt,
             )
 
-    def test_change_prompt_references_files_instead_of_embedding_text(self) -> None:
+    def test_change_prompt_inlines_required_files(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             project_dir = tmp_path / "project"
@@ -168,11 +177,10 @@ class TasksRequirementsTests(unittest.TestCase):
 
             prompt = build_change_prompt(files)
 
-            self.assertIn("Read these files first:", prompt)
-            self.assertIn("- requirements.md", prompt)
-            self.assertIn("- 02_planning/plan.md", prompt)
-            self.assertIn("- 02_planning/tasks.md", prompt)
-            self.assertIn("- 08_completion/changes.md", prompt)
+            self.assertIn('<file path="requirements.md">', prompt)
+            self.assertIn('<file path="02_planning/plan.md">', prompt)
+            self.assertIn('<file path="02_planning/tasks.md">', prompt)
+            self.assertIn('<file path="08_completion/changes.md">', prompt)
             self.assertIn("02_planning/execution_plan.json", prompt)
             self.assertIn("02_planning/plan_meta.json", prompt)
             self.assertIn(
@@ -199,7 +207,7 @@ class TasksRequirementsTests(unittest.TestCase):
             self.assertIn("must belong only to that sub-plan's owned files/modules", prompt)
             self.assertIn("technical debt", prompt.lower())
             self.assertNotIn("should be treated as parallelizable unless a precise technical conflict is documented", prompt)
-            self.assertNotIn("1. Example task", prompt)
+            self.assertIn("1. Example task", prompt)
 
     def test_architect_prompt_no_longer_accepts_review_mode_and_reviewer_prompt_handles_review(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_web_researcher_requirements.py
+++ b/tests/test_web_researcher_requirements.py
@@ -51,6 +51,11 @@ class FakeRuntime:
 
 
 class WebResearcherRequirementsTests(unittest.TestCase):
+    def _write_web_request(self, feature_dir: Path, topic: str) -> None:
+        request_path = feature_dir / RESEARCH_DIR / f"web-{topic}" / "request.md"
+        request_path.parent.mkdir(parents=True, exist_ok=True)
+        request_path.write_text("research request\n", encoding="utf-8")
+
     def _make_ctx(self, feature_dir: Path) -> tuple[PipelineContext, Path]:
         project_dir = feature_dir.parent / "project"
         project_dir.mkdir(parents=True, exist_ok=True)
@@ -106,6 +111,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             feature_dir = tmp_path / "feature"
             project_dir.mkdir()
             files = create_feature_files(project_dir, feature_dir, "research", "session-x")
+            self._write_web_request(feature_dir, "openai-models")
 
             prompt = build_web_researcher_prompt("openai-models", files)
 
@@ -132,7 +138,6 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             self.assertIn("03_research/web-<topic>/summary.md", prompt)
             self.assertIn("03_research/web-<topic>/detail.md", prompt)
             self.assertIn("agentmux_research_dispatch_web", prompt)
-            self.assertNotIn("03_research/web-<topic>/request.md", prompt)
 
     def test_planning_detects_web_task_requested_and_completed(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Initial Request

aktuell arbeiten die prompts die an die agenten geschickt werden viel mit refrenzen was zusätziche Toolcalls erfordert. 

Wir sollten diese vor dem Send keys auflösen damit in der prompt datei gleich alle informationen enthalten isnd. 

gibt es eine möglichkeit dem agenten direkt beim start einen system prompt mitzugeben?

## Plan Summary

Problem

Agent prompts contain "Read these files first:" instructions listing 3-6 session files. Each reference costs the agent one tool call. For a coder prompt with 6 referenced files, the agent spends 6 tool calls just loading context before starting work.

## Review Verdict

verdict: pass



Closes #49
