### PR TITLE
make-file-references-in-monitor-clickable

### DIFF
--- a/.agentmux/.last_completion.json
+++ b/.agentmux/.last_completion.json
@@ -1,6 +1,6 @@
 {
-  "feature_name": "add-onboarding-guide-for-new-users",
-  "commit_hash": "d183787",
-  "pr_url": "https://github.com/markuswondrak/AgentMux/pull/62",
-  "branch_name": "feature/add-onboarding-guide-for-new-users"
+  "feature_name": "claude-research-mcp-not-working",
+  "commit_hash": "418ff85",
+  "pr_url": "https://github.com/markuswondrak/AgentMux/pull/65",
+  "branch_name": "feature/claude-research-mcp-not-working"
 }

--- a/.agentmux/mcp_servers.json
+++ b/.agentmux/mcp_servers.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "agentmux-research": {
+      "type": "stdio",
+      "command": "/home/markus/.local/share/pipx/venvs/agentmux/bin/python",
+      "args": [
+        "-m",
+        "agentmux.integrations.mcp_research_server"
+      ],
+      "env": {
+        "PYTHONPATH": "/home/markus/workspace/multi-agent-system"
+      }
+    }
+  }
+}

--- a/agentmux/monitor/render.py
+++ b/agentmux/monitor/render.py
@@ -20,6 +20,7 @@ from .state_reader import (
     trim_model,
 )
 from agentmux.terminal_ui.colors import PRIMARY, SECONDARY
+from agentmux.terminal_ui.hyperlinks import OSC8_RE, file_hyperlink
 
 RESET = "\033[0m"
 BOLD = "\033[1m"
@@ -36,7 +37,7 @@ MONITOR_HEADER_LOGO = [
     (SECONDARY, "╰───────────╯"),
 ]
 
-_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+_ANSI_RE = re.compile(rf"\033\[[0-9;]*m|{OSC8_RE}")
 
 
 def get_terminal_size() -> tuple[int, int]:
@@ -119,7 +120,9 @@ def _wrap_feature_lines(text: str, width: int, *, max_lines: int = 4) -> list[st
     clean = " ".join(text.split())
     if not clean:
         return [""] * max_lines
-    wrapped = textwrap.wrap(clean, width=width, break_long_words=True, break_on_hyphens=False)
+    wrapped = textwrap.wrap(
+        clean, width=width, break_long_words=True, break_on_hyphens=False
+    )
     if len(wrapped) > max_lines:
         head = wrapped[: max_lines - 1]
         tail = " ".join(wrapped[max_lines - 1 :])
@@ -136,22 +139,36 @@ def _render_feature_header(width: int, state_path: Path) -> list[str]:
     text_width = width - logo_width - gap
 
     if text_width >= 10:
-        feature_lines = _wrap_feature_lines(feature_request, text_width, max_lines=len(MONITOR_HEADER_LOGO))
+        feature_lines = _wrap_feature_lines(
+            feature_request, text_width, max_lines=len(MONITOR_HEADER_LOGO)
+        )
         rows: list[str] = []
         for (color, logo_row), feature_line in zip(MONITOR_HEADER_LOGO, feature_lines):
             padded_logo = logo_row + (" " * max(0, logo_width - _vlen(logo_row)))
             logo_text = f"{BOLD}{color}{padded_logo}{RESET}"
-            rows.append(f"{logo_text}{' ' * gap}{feature_line}" if feature_line else logo_text)
+            rows.append(
+                f"{logo_text}{' ' * gap}{feature_line}" if feature_line else logo_text
+            )
         return rows
 
     if width >= logo_width:
-        rows = [f"{BOLD}{color}{logo_row}{RESET}" for color, logo_row in MONITOR_HEADER_LOGO]
+        rows = [
+            f"{BOLD}{color}{logo_row}{RESET}" for color, logo_row in MONITOR_HEADER_LOGO
+        ]
         if feature_request:
-            rows.extend(line for line in _wrap_feature_lines(feature_request, width, max_lines=2) if line)
+            rows.extend(
+                line
+                for line in _wrap_feature_lines(feature_request, width, max_lines=2)
+                if line
+            )
         return rows
 
     if feature_request:
-        return [line for line in _wrap_feature_lines(feature_request, max(1, width), max_lines=2) if line]
+        return [
+            line
+            for line in _wrap_feature_lines(feature_request, max(1, width), max_lines=2)
+            if line
+        ]
     return []
 
 
@@ -245,7 +262,9 @@ def _normalize_groups(raw: object) -> list[dict[str, object]]:
                         _first_present(item, ("mode", "execution_mode", "group_mode"))
                     ),
                     "plan_ids": _extract_str_list(
-                        _first_present(item, ("plan_ids", "plans", "plan_files", "plan_refs"))
+                        _first_present(
+                            item, ("plan_ids", "plans", "plan_files", "plan_refs")
+                        )
                     ),
                 }
             )
@@ -269,7 +288,12 @@ def _normalize_active_index(raw: object, *, total: int) -> int | None:
 
 def _extract_execution_progress(state: dict[str, object]) -> dict[str, object] | None:
     root_candidates: list[dict[str, object]] = []
-    for key in ("execution_progress", "implementing_progress", "implementation_progress", "staged_execution"):
+    for key in (
+        "execution_progress",
+        "implementing_progress",
+        "implementation_progress",
+        "staged_execution",
+    ):
         value = state.get(key)
         if isinstance(value, dict):
             root_candidates.append(value)
@@ -321,8 +345,21 @@ def _extract_execution_progress(state: dict[str, object]) -> dict[str, object] |
         "group_id",
         "execution_group_id",
     )
-    groups_keys = ("groups", "execution_groups", "implementation_groups", "schedule", "execution_schedule")
-    signal_keys = total_keys + completed_keys + active_index_keys + active_mode_keys + active_plan_keys + groups_keys
+    groups_keys = (
+        "groups",
+        "execution_groups",
+        "implementation_groups",
+        "schedule",
+        "execution_schedule",
+    )
+    signal_keys = (
+        total_keys
+        + completed_keys
+        + active_index_keys
+        + active_mode_keys
+        + active_plan_keys
+        + groups_keys
+    )
 
     for raw in root_candidates:
         if not any(key in raw for key in signal_keys):
@@ -335,7 +372,9 @@ def _extract_execution_progress(state: dict[str, object]) -> dict[str, object] |
         if total is None or total <= 0:
             continue
 
-        active_index_key, active_index_raw = _first_present_with_key(raw, active_index_keys)
+        active_index_key, active_index_raw = _first_present_with_key(
+            raw, active_index_keys
+        )
         if active_index_key == "implementation_group_index":
             parsed_active_index = _extract_int(active_index_raw)
             if parsed_active_index is None:
@@ -365,14 +404,21 @@ def _extract_execution_progress(state: dict[str, object]) -> dict[str, object] |
             active_index = None
 
         synthetic_ids = [f"g{i}" for i in range(1, total + 1)]
-        group_ids = [str(g.get("id", f"g{i + 1}")).strip() or f"g{i + 1}" for i, g in enumerate(groups)]
+        group_ids = [
+            str(g.get("id", f"g{i + 1}")).strip() or f"g{i + 1}"
+            for i, g in enumerate(groups)
+        ]
         if len(group_ids) < total:
             group_ids.extend(synthetic_ids[len(group_ids) : total])
         elif len(group_ids) > total:
             group_ids = group_ids[:total]
 
         active_group = _extract_str(_first_present(raw, active_group_keys))
-        if not active_group and active_index is not None and active_index < len(group_ids):
+        if (
+            not active_group
+            and active_index is not None
+            and active_index < len(group_ids)
+        ):
             active_group = group_ids[active_index]
         elif not active_group and active_index is not None:
             active_group = f"g{active_index + 1}"
@@ -382,7 +428,11 @@ def _extract_execution_progress(state: dict[str, object]) -> dict[str, object] |
             active_mode = _normalize_group_mode(groups[active_index].get("mode"))
 
         active_plan_ids = _extract_str_list(_first_present(raw, active_plan_keys))
-        if not active_plan_ids and active_index is not None and active_index < len(groups):
+        if (
+            not active_plan_ids
+            and active_index is not None
+            and active_index < len(groups)
+        ):
             active_plan_ids = _extract_str_list(groups[active_index].get("plan_ids"))
 
         completed_group_ids: list[str] = []
@@ -494,7 +544,11 @@ def _render_pipeline_section(
     subplan_count: int,
 ) -> list[str]:
     lines = [_section_title("PIPELINE"), ""]
-    display_stages = [stage for stage in PIPELINE_STATES if stage not in OPTIONAL_PHASES or stage == status]
+    display_stages = [
+        stage
+        for stage in PIPELINE_STATES
+        if stage not in OPTIONAL_PHASES or stage == status
+    ]
     gutter_plain = " │ "
 
     try:
@@ -540,7 +594,9 @@ def _render_pipeline_section(
                         left_rendered=f"{DIM}› iter {review_iter}{RESET}",
                     )
                 )
-            progress = _extract_execution_progress(state) if stage == "implementing" else None
+            progress = (
+                _extract_execution_progress(state) if stage == "implementing" else None
+            )
             if progress is not None:
                 lines.extend(_render_implementing_progress(width, progress))
             elif subplan_count > 1:
@@ -656,7 +712,9 @@ def _render_agents_section(
         if role == "coder":
             parallel_keys = sorted(
                 [key for key in role_states if key.startswith("coder_")],
-                key=lambda key: int(key.split("_")[1]) if key.split("_")[1].isdigit() else 0,
+                key=lambda key: int(key.split("_")[1])
+                if key.split("_")[1].isdigit()
+                else 0,
             )
             if parallel_keys:
                 for coder_key in parallel_keys:
@@ -668,9 +726,15 @@ def _render_agents_section(
                         cfg,
                     )
             elif role_states.get("coder", "inactive") != "inactive":
-                _agent_row(role_labels.get("coder", "coder"), role_states.get("coder", "inactive"), cfg)
+                _agent_row(
+                    role_labels.get("coder", "coder"),
+                    role_states.get("coder", "inactive"),
+                    cfg,
+                )
         elif role_states.get(role, "inactive") != "inactive":
-            _agent_row(role_labels.get(role, role), role_states.get(role, "inactive"), cfg)
+            _agent_row(
+                role_labels.get(role, role), role_states.get(role, "inactive"), cfg
+            )
 
     if lines[-1] == "":
         lines.pop()
@@ -687,7 +751,9 @@ def _render_research_section(width: int, state: dict, feature_dir: Path) -> list
     all_tasks = [("c", topic, f"code-{topic}/done") for topic in code_tasks] + [
         ("w", topic, f"web-{topic}/done") for topic in web_tasks
     ]
-    done_count = sum(1 for _, _, marker in all_tasks if (research_dir / marker).exists())
+    done_count = sum(
+        1 for _, _, marker in all_tasks if (research_dir / marker).exists()
+    )
     rows = [_section_title(f"RESEARCH {done_count}/{len(all_tasks)}"), ""]
     pulse_on = int(time.time()) % 2 == 0
     for type_prefix, topic, marker in all_tasks:
@@ -696,9 +762,13 @@ def _render_research_section(width: int, state: dict, feature_dir: Path) -> list
         if done:
             rows.append(f" {GREEN}✓{RESET} {DIM}{type_prefix}·{RESET} {slug}")
         elif pulse_on:
-            rows.append(f" {YELLOW}{_spinner_frame()}{RESET} {DIM}{type_prefix}·{RESET} {BOLD}{slug}{RESET}")
+            rows.append(
+                f" {YELLOW}{_spinner_frame()}{RESET} {DIM}{type_prefix}·{RESET} {BOLD}{slug}{RESET}"
+            )
         else:
-            rows.append(f" {DIM}{_spinner_frame()}{RESET} {DIM}{type_prefix}· {slug}{RESET}")
+            rows.append(
+                f" {DIM}{_spinner_frame()}{RESET} {DIM}{type_prefix}· {slug}{RESET}"
+            )
     return rows
 
 
@@ -741,7 +811,9 @@ def render(
         )
     )
 
-    agent_rows = _render_agents_section(width, agents=agents, role_states=role_states, role_labels=role_labels)
+    agent_rows = _render_agents_section(
+        width, agents=agents, role_states=role_states, role_labels=role_labels
+    )
     if agent_rows:
         body.append("")
         body.extend(agent_rows)
@@ -762,13 +834,23 @@ def render(
         reserved = len(body) + len(footer)
         available_for_log = height - reserved - 1
         if available_for_log >= 2:
-            entries = read_monitor_log_entries(log_path, created_files_log_path, max(1, available_for_log - 2))
+            entries = read_monitor_log_entries(
+                log_path, created_files_log_path, max(1, available_for_log - 2)
+            )
             if entries:
                 log_rows = [_section_title("LOG"), ""]
                 max_message = max(1, width - 8)
+                feature_dir = state_path.parent
                 for entry in entries:
                     message = _truncate_text(entry.message, max_message)
-                    rendered = f"{WHITE}{message}{RESET}" if entry.phase_event else message
+                    # Wrap file paths in OSC 8 hyperlinks for IDE Ctrl-click support
+                    if entry.relative_path and message.startswith("+ "):
+                        visible_path = message[2:]  # Strip "+ " prefix
+                        abs_path = feature_dir / entry.relative_path
+                        message = f"+ {file_hyperlink(abs_path, visible_path)}"
+                    rendered = (
+                        f"{WHITE}{message}{RESET}" if entry.phase_event else message
+                    )
                     log_rows.append(f" {DIM}{entry.time_str}{RESET} {rendered}")
 
     lines = list(body)

--- a/agentmux/monitor/state_reader.py
+++ b/agentmux/monitor/state_reader.py
@@ -75,6 +75,7 @@ class MonitorLogEntry:
     sort_order: int
     message: str
     phase_event: bool
+    relative_path: str = ""
 
 
 def load_runtime_registry(runtime_state_path: Path) -> dict[str, str | None]:
@@ -100,7 +101,15 @@ def get_role_states(session_name: str, runtime_state_path: Path) -> dict[str, st
 
     try:
         result_all = subprocess.run(
-            ["tmux", "list-panes", "-t", session_name, "-a", "-F", "#{pane_id} #{pane_dead}"],
+            [
+                "tmux",
+                "list-panes",
+                "-t",
+                session_name,
+                "-a",
+                "-F",
+                "#{pane_id} #{pane_dead}",
+            ],
             capture_output=True,
             text=True,
             check=False,
@@ -112,7 +121,14 @@ def get_role_states(session_name: str, runtime_state_path: Path) -> dict[str, st
         }
 
         result_pipeline = subprocess.run(
-            ["tmux", "list-panes", "-t", f"{session_name}:pipeline", "-F", "#{pane_id} #{pane_dead}"],
+            [
+                "tmux",
+                "list-panes",
+                "-t",
+                f"{session_name}:pipeline",
+                "-F",
+                "#{pane_id} #{pane_dead}",
+            ],
             capture_output=True,
             text=True,
             check=False,
@@ -154,7 +170,9 @@ def get_role_labels(state_path: Path, runtime_state_path: Path) -> dict[str, str
         if "_" in role_key:
             role, suffix = role_key.split("_", 1)
             task_id = int(suffix) if suffix.isdigit() else suffix
-        labels[role_key] = role_display_label(feature_dir, role, task_id=task_id, state=state)
+        labels[role_key] = role_display_label(
+            feature_dir, role, task_id=task_id, state=state
+        )
     return labels
 
 
@@ -181,7 +199,7 @@ def status_color(status: str) -> str:
 def trim_model(model: str, cli: str) -> str:
     prefix = f"{cli}-"
     if model.lower().startswith(prefix.lower()):
-        model = model[len(prefix):]
+        model = model[len(prefix) :]
     return model
 
 
@@ -199,7 +217,10 @@ def parse_timestamped_log_line(line: str) -> tuple[str, str] | None:
 
 
 def should_render_file_event(relative_path: str) -> bool:
-    return any(fnmatch.fnmatch(relative_path, pattern) for pattern in MONITOR_FILE_EVENT_PATTERNS)
+    return any(
+        fnmatch.fnmatch(relative_path, pattern)
+        for pattern in MONITOR_FILE_EVENT_PATTERNS
+    )
 
 
 def read_status_log_entries(log_path: Path) -> list[MonitorLogEntry]:
@@ -247,6 +268,7 @@ def read_created_file_log_entries(log_path: Path) -> list[MonitorLogEntry]:
                 sort_order=1,
                 message=f"+ {relative_path}",
                 phase_event=False,
+                relative_path=relative_path,
             )
         )
     return entries
@@ -264,7 +286,9 @@ def read_monitor_log_entries(
         entries.extend(read_created_file_log_entries(created_files_log_path))
     if not entries:
         return []
-    ordered = sorted(entries, key=lambda entry: (entry.timestamp, entry.sort_order, entry.message))
+    ordered = sorted(
+        entries, key=lambda entry: (entry.timestamp, entry.sort_order, entry.message)
+    )
     return ordered[-n:]
 
 

--- a/agentmux/terminal_ui/hyperlinks.py
+++ b/agentmux/terminal_ui/hyperlinks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+OSC8_RE: str = r"\033\]8;[^;]*;[^\033\a]*(?:\033\\|\a)"
+
+
+def file_hyperlink(path: Path, visible_text: str) -> str:
+    """Create an OSC 8 terminal hyperlink for a file path.
+
+    Args:
+        path: The file path to link to (will be converted to absolute and URI-encoded)
+        visible_text: The text to display (typically the relative path for readability)
+
+    Returns:
+        OSC 8 hyperlink string with ST terminator (\033\\)
+    """
+    url = path.resolve().as_uri()
+    return f"\033]8;;{url}\033\\{visible_text}\033]8;;\033\\"

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -1,6 +1,6 @@
 # Monitor Display
 
-> Related source files: `agentmux/monitor/__init__.py`, `agentmux/monitor/state_reader.py`, `agentmux/monitor/render.py`, `agentmux/terminal_ui/layout.py`
+> Related source files: `agentmux/monitor/__init__.py`, `agentmux/monitor/state_reader.py`, `agentmux/monitor/render.py`, `agentmux/terminal_ui/layout.py`, `agentmux/terminal_ui/hyperlinks.py`
 
 The control pane renders a live status box with the following sections:
 
@@ -25,6 +25,7 @@ The control pane renders a live status box with the following sections:
   - Phase-transition entries are rendered in white for contrast
   - Includes workflow artifacts such as `plan.md`, `tasks.md`, research `summary.md` / `detail.md` / `done`, `design.md`, review handoff files, implementation `done_*`, and completion artifacts
   - Excludes runtime noise such as `context.md`, prompt files, request files, temp files, and other orchestration internals
+  - File path entries are wrapped in OSC 8 terminal hyperlinks with `file://` URLs for IDE Ctrl-click support; the visible text shows the relative path while the hyperlink target is the absolute path on disk
 
 ## Key constants
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -52,7 +52,9 @@ class MonitorTests(unittest.TestCase):
             self.assertIn("beschreibung des features", output)
             self.assertIn("▶ implementing", output)
 
-    def test_state_reader_no_longer_lists_removed_docs_phase_or_event_markers(self) -> None:
+    def test_state_reader_no_longer_lists_removed_docs_phase_or_event_markers(
+        self,
+    ) -> None:
         self.assertNotIn("documenting", OPTIONAL_PHASES)
         self.assertNotIn("documenting", PIPELINE_STATES)
         self.assertNotIn("docs_written", EVENT_LABELS)
@@ -97,7 +99,9 @@ class MonitorTests(unittest.TestCase):
             self.assertNotIn("fixing", output)
             self.assertNotIn("documenting", output)
 
-    def test_render_shows_active_optional_phase_in_cyan_at_natural_position(self) -> None:
+    def test_render_shows_active_optional_phase_in_cyan_at_natural_position(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
             state_path = feature_dir / "state.json"
@@ -113,7 +117,9 @@ class MonitorTests(unittest.TestCase):
 
             self.assertIn("▶ designing", stripped)
             self.assertLess(stripped.index("✓ planning"), stripped.index("▶ designing"))
-            self.assertLess(stripped.index("▶ designing"), stripped.index("· implementing"))
+            self.assertLess(
+                stripped.index("▶ designing"), stripped.index("· implementing")
+            )
 
     def test_render_formats_last_event_label(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -209,7 +215,9 @@ class MonitorTests(unittest.TestCase):
             self.assertIn("› active: g2 parallel · 3 plans", output)
             self.assertIn("› done: g1 · queued: g3, g4", output)
 
-    def test_render_implementing_reads_root_level_implementation_progress_fields(self) -> None:
+    def test_render_implementing_reads_root_level_implementation_progress_fields(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
             state_path = feature_dir / "state.json"
@@ -236,7 +244,9 @@ class MonitorTests(unittest.TestCase):
             self.assertIn("› done: g1 · queued: g3", output)
             self.assertNotIn("› 4 subplans", output)
 
-    def test_render_implementing_staged_details_remain_readable_when_narrow(self) -> None:
+    def test_render_implementing_staged_details_remain_readable_when_narrow(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
             state_path = feature_dir / "state.json"
@@ -274,8 +284,12 @@ class MonitorTests(unittest.TestCase):
             runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
             (feature_dir / "02_planning").mkdir(parents=True, exist_ok=True)
             (feature_dir / "04_design").mkdir(parents=True, exist_ok=True)
-            (feature_dir / "02_planning" / "plan.md").write_text("# plan\n", encoding="utf-8")
-            (feature_dir / "04_design" / "design.md").write_text("# design\n", encoding="utf-8")
+            (feature_dir / "02_planning" / "plan.md").write_text(
+                "# plan\n", encoding="utf-8"
+            )
+            (feature_dir / "04_design" / "design.md").write_text(
+                "# design\n", encoding="utf-8"
+            )
 
             output = self._strip_ansi(self._render(feature_dir, width=15, height=24))
 
@@ -288,7 +302,9 @@ class MonitorTests(unittest.TestCase):
             feature_dir = Path(td)
             state_path = feature_dir / "state.json"
             runtime_state_path = feature_dir / "runtime_state.json"
-            research_dir = feature_dir / SESSION_DIR_NAMES["research"] / "code-auth-module"
+            research_dir = (
+                feature_dir / SESSION_DIR_NAMES["research"] / "code-auth-module"
+            )
 
             state_path.write_text(
                 '{"phase": "planning", "research_tasks": {"auth-module": "dispatched"}}',
@@ -308,10 +324,19 @@ class MonitorTests(unittest.TestCase):
             feature_dir = Path(td)
             log_path = feature_dir / "status_log.txt"
 
-            with patch("agentmux.monitor.time.strftime", side_effect=["2026-03-21 11:20:05", "2026-03-21 11:20:08"]):
-                prev = monitor.append_status_change(log_path, prev_status=None, status="planning")
-                prev = monitor.append_status_change(log_path, prev_status=prev, status="planning")
-                prev = monitor.append_status_change(log_path, prev_status=prev, status="implementing")
+            with patch(
+                "agentmux.monitor.time.strftime",
+                side_effect=["2026-03-21 11:20:05", "2026-03-21 11:20:08"],
+            ):
+                prev = monitor.append_status_change(
+                    log_path, prev_status=None, status="planning"
+                )
+                prev = monitor.append_status_change(
+                    log_path, prev_status=prev, status="planning"
+                )
+                prev = monitor.append_status_change(
+                    log_path, prev_status=prev, status="implementing"
+                )
 
             self.assertEqual("implementing", prev)
             lines = log_path.read_text(encoding="utf-8").splitlines()
@@ -329,7 +354,10 @@ class MonitorTests(unittest.TestCase):
             state_path = feature_dir / "state.json"
             runtime_state_path = feature_dir / "runtime_state.json"
             state_path.write_text('{"phase": "reviewing"}', encoding="utf-8")
-            runtime_state_path.write_text('{"primary": {"architect": "%1", "reviewer": "%2", "coder": "%3"}}', encoding="utf-8")
+            runtime_state_path.write_text(
+                '{"primary": {"architect": "%1", "reviewer": "%2", "coder": "%3"}}',
+                encoding="utf-8",
+            )
 
             agents = {
                 "architect": {"cli": "claude", "model": "opus"},
@@ -339,9 +367,15 @@ class MonitorTests(unittest.TestCase):
 
             with patch(
                 "agentmux.monitor.render_module.get_role_states",
-                return_value={"architect": "inactive", "reviewer": "working", "coder": "idle"},
+                return_value={
+                    "architect": "inactive",
+                    "reviewer": "working",
+                    "coder": "idle",
+                },
             ):
-                with patch("agentmux.monitor.render_module.time.time", return_value=0.0):
+                with patch(
+                    "agentmux.monitor.render_module.time.time", return_value=0.0
+                ):
                     output = self._strip_ansi(
                         monitor.render(
                             session_name="session-x",
@@ -367,13 +401,18 @@ class MonitorTests(unittest.TestCase):
             runtime_state_path = feature_dir / "runtime_state.json"
             planning_dir = feature_dir / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
-            (planning_dir / "plan_2.md").write_text("## Sub-plan 2: API wiring\n", encoding="utf-8")
+            (planning_dir / "plan_2.md").write_text(
+                "## Sub-plan 2: API wiring\n", encoding="utf-8"
+            )
             (planning_dir / "execution_plan.json").write_text(
                 '{"version": 1, "groups": [{"group_id": "g1", "mode": "parallel", "plans": [{"file": "plan_2.md", "name": "API wiring"}]}]}',
                 encoding="utf-8",
             )
             state_path.write_text('{"phase": "implementing"}', encoding="utf-8")
-            runtime_state_path.write_text('{"primary": {"coder": "%2"}, "parallel": {"coder": {"2": "%2"}}}', encoding="utf-8")
+            runtime_state_path.write_text(
+                '{"primary": {"coder": "%2"}, "parallel": {"coder": {"2": "%2"}}}',
+                encoding="utf-8",
+            )
 
             agents = {
                 "coder": {"cli": "codex", "model": "gpt-5.3-codex"},
@@ -383,7 +422,9 @@ class MonitorTests(unittest.TestCase):
                 "agentmux.monitor.render_module.get_role_states",
                 return_value={"coder_2": "working"},
             ):
-                with patch("agentmux.monitor.render_module.time.time", return_value=0.0):
+                with patch(
+                    "agentmux.monitor.render_module.time.time", return_value=0.0
+                ):
                     output = self._strip_ansi(
                         monitor.render(
                             session_name="session-x",
@@ -405,8 +446,12 @@ class MonitorTests(unittest.TestCase):
             feature_dir.mkdir(parents=True, exist_ok=True)
             state_path = feature_dir / "state.json"
             runtime_state_path = feature_dir / "runtime_state.json"
-            state_path.write_text('{"phase": "reviewing", "review_iteration": 1}', encoding="utf-8")
-            runtime_state_path.write_text('{"primary": {"reviewer": "%4", "designer": "%5"}}', encoding="utf-8")
+            state_path.write_text(
+                '{"phase": "reviewing", "review_iteration": 1}', encoding="utf-8"
+            )
+            runtime_state_path.write_text(
+                '{"primary": {"reviewer": "%4", "designer": "%5"}}', encoding="utf-8"
+            )
 
             agents = {
                 "reviewer": {"cli": "claude", "model": "sonnet"},
@@ -417,7 +462,9 @@ class MonitorTests(unittest.TestCase):
                 "agentmux.monitor.render_module.get_role_states",
                 return_value={"reviewer": "working", "designer": "idle"},
             ):
-                with patch("agentmux.monitor.render_module.time.time", return_value=0.0):
+                with patch(
+                    "agentmux.monitor.render_module.time.time", return_value=0.0
+                ):
                     output = self._strip_ansi(
                         monitor.render(
                             session_name="session-x",
@@ -538,8 +585,14 @@ class MonitorTests(unittest.TestCase):
             self.assertNotIn("context.md", output)
             self.assertNotIn("architect_prompt.md", output)
             self.assertNotIn("code-auth/request.md", output)
-            self.assertLess(output.index("11:20 > planning"), output.index("11:20 + 02_planning/plan.md"))
-            self.assertLess(output.index("11:20 + 02_planning/plan.md"), output.index("11:20 > implementing"))
+            self.assertLess(
+                output.index("11:20 > planning"),
+                output.index("11:20 + 02_planning/plan.md"),
+            )
+            self.assertLess(
+                output.index("11:20 + 02_planning/plan.md"),
+                output.index("11:20 > implementing"),
+            )
 
     def test_render_shows_allowed_created_file_entries_without_status_log(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -573,7 +626,9 @@ class MonitorTests(unittest.TestCase):
             self.assertIn(" LOG", output)
             self.assertIn("11:20 + 06_review/review.md", output)
 
-    def test_render_failed_state_shows_clean_failure_classification_and_cause(self) -> None:
+    def test_render_failed_state_shows_clean_failure_classification_and_cause(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
             state_path = feature_dir / "state.json"
@@ -590,7 +645,9 @@ class MonitorTests(unittest.TestCase):
             output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
 
             self.assertIn("› run failed unexpectedly", output)
-            self.assertIn("› cause: Background orchestrator exited unexpectedly.", output)
+            self.assertIn(
+                "› cause: Background orchestrator exited unexpectedly.", output
+            )
 
     def test_render_unknown_interruption_event_falls_back_to_raw_label(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -616,8 +673,12 @@ class MonitorTests(unittest.TestCase):
             )
 
             results = [
-                CompletedProcess(args=[], returncode=0, stdout="%1 1\n%2 0\n", stderr=""),
-                CompletedProcess(args=[], returncode=0, stdout="%1 1\n%2 0\n", stderr=""),
+                CompletedProcess(
+                    args=[], returncode=0, stdout="%1 1\n%2 0\n", stderr=""
+                ),
+                CompletedProcess(
+                    args=[], returncode=0, stdout="%1 1\n%2 0\n", stderr=""
+                ),
             ]
 
             with patch("agentmux.monitor.subprocess.run", side_effect=results):
@@ -625,6 +686,121 @@ class MonitorTests(unittest.TestCase):
 
             self.assertEqual("inactive", states["architect"])
             self.assertEqual("working", states["reviewer"])
+
+    def test_render_file_log_entries_contain_osc8_hyperlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            state_path = feature_dir / "state.json"
+            runtime_state_path = feature_dir / "runtime_state.json"
+            status_log_path = feature_dir / "status_log.txt"
+            created_files_log_path = feature_dir / "created_files.log"
+
+            state_path.write_text('{"phase": "planning"}', encoding="utf-8")
+            runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
+            created_files_log_path.write_text(
+                "2026-03-21 11:20:08  02_planning/plan.md\n",
+                encoding="utf-8",
+            )
+
+            with patch("agentmux.monitor.render_module.time.time", return_value=0.0):
+                output = monitor.render(
+                    session_name="session-x",
+                    state_path=state_path,
+                    runtime_state_path=runtime_state_path,
+                    agents={},
+                    width=60,
+                    height=24,
+                    start_time=0.0,
+                    log_path=status_log_path,
+                )
+
+            # Raw output should contain OSC 8 hyperlink sequences
+            self.assertIn("\033]8;;file://", output)
+            # Should contain the absolute path to the file
+            self.assertIn("02_planning/plan.md", output)
+
+    def test_render_phase_log_entries_do_not_contain_osc8_hyperlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            state_path = feature_dir / "state.json"
+            runtime_state_path = feature_dir / "runtime_state.json"
+            status_log_path = feature_dir / "status_log.txt"
+            created_files_log_path = feature_dir / "created_files.log"
+
+            state_path.write_text('{"phase": "planning"}', encoding="utf-8")
+            runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
+            status_log_path.write_text(
+                "2026-03-21 11:20:05  planning\n", encoding="utf-8"
+            )
+            created_files_log_path.write_text(
+                "2026-03-21 11:20:08  02_planning/plan.md\n",
+                encoding="utf-8",
+            )
+
+            with patch("agentmux.monitor.render_module.time.time", return_value=0.0):
+                output = monitor.render(
+                    session_name="session-x",
+                    state_path=state_path,
+                    runtime_state_path=runtime_state_path,
+                    agents={},
+                    width=60,
+                    height=24,
+                    start_time=0.0,
+                    log_path=status_log_path,
+                )
+
+            # Split output to find phase event lines vs file event lines
+            lines = output.split("\n")
+            phase_line = ""
+            file_line = ""
+            for line in lines:
+                if "> planning" in line:
+                    phase_line = line
+                # Look for file entry line by checking for the relative path in the line
+                # (accounting for OSC 8 escape sequences that may wrap it)
+                if "02_planning/plan.md" in line and "+ " in line:
+                    file_line = line
+
+            # Phase events should NOT contain OSC 8
+            self.assertNotIn("\033]8;;", phase_line)
+
+            # File events SHOULD contain OSC 8
+            self.assertIn("\033]8;;", file_line)
+
+    def test_strip_ansi_removes_osc8_sequences(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            state_path = feature_dir / "state.json"
+            runtime_state_path = feature_dir / "runtime_state.json"
+            status_log_path = feature_dir / "status_log.txt"
+            created_files_log_path = feature_dir / "created_files.log"
+
+            state_path.write_text('{"phase": "planning"}', encoding="utf-8")
+            runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
+            created_files_log_path.write_text(
+                "2026-03-21 11:20:08  02_planning/plan.md\n",
+                encoding="utf-8",
+            )
+
+            with patch("agentmux.monitor.render_module.time.time", return_value=0.0):
+                output = monitor.render(
+                    session_name="session-x",
+                    state_path=state_path,
+                    runtime_state_path=runtime_state_path,
+                    agents={},
+                    width=60,
+                    height=24,
+                    start_time=0.0,
+                    log_path=status_log_path,
+                )
+
+            stripped = self._strip_ansi(output)
+
+            # Stripped output should not contain OSC 8 sequences
+            self.assertNotIn("\033]8;;", stripped)
+            self.assertNotIn("\033\\", stripped)
+            # But should still contain the visible path text
+            self.assertIn("02_planning/plan.md", stripped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Initial Request

When running the terminal in an IDE I would like to ctrl-click follow file references to open them up in IDE directly

## Plan Summary

Overview

Wrap file paths displayed in the monitor LOG section with OSC 8 terminal hyperlinks using `file://` URLs pointing to absolute paths on disk. The visible text remains the relative path. Terminals that don't support OSC 8 silently ignore the escape sequences and show plain text.

The OSC 8 logic is encapsulated in a shared abstraction (`agentmux/terminal_ui/hyperlinks.py`) so any future UI surface can reuse it without reimplementing escape sequences.

## Review Verdict

verdict: pass



Closes #53
