### PR TITLE
sub-phase-highlighting-for-coder

### DIFF
--- a/.agentmux/config.yaml
+++ b/.agentmux/config.yaml
@@ -1,11 +1,14 @@
 version: 2
 
 defaults:
-  session_name: multi-agent-mvp
-  provider: copilot
+  session_name: agentmux
+  provider: opencode
   max_review_iterations: 3
 
-# roles:
-#  coder:
-#    provider: opencode
-#    model: opencode/qwen3.6-plus-free
+roles:
+  reviewer_expert:
+    provider: copilot
+  reviewer_logic:
+    provider: copilot
+  reviewer_quality:
+    provider: copilot

--- a/src/agentmux/monitor/render.py
+++ b/src/agentmux/monitor/render.py
@@ -499,14 +499,6 @@ def _format_plan_summary(plan_ids: list[str]) -> str:
     return f"{len(plan_ids)} plans"
 
 
-def _summarize_group_ids(group_ids: list[str]) -> str:
-    if not group_ids:
-        return ""
-    if len(group_ids) <= 3:
-        return ", ".join(group_ids)
-    return f"{', '.join(group_ids[:2])}, +{len(group_ids) - 2}"
-
-
 def _render_implementing_progress(width: int, progress: dict[str, object]) -> list[str]:
     total = int(progress.get("total", 0))
     completed = int(progress.get("completed", 0))
@@ -517,6 +509,8 @@ def _render_implementing_progress(width: int, progress: dict[str, object]) -> li
     queued_group_ids = _extract_str_list(progress.get("queued_group_ids"))
 
     rows: list[str] = []
+
+    # Summary header
     rows.append(
         _compose_line(
             width,
@@ -527,40 +521,53 @@ def _render_implementing_progress(width: int, progress: dict[str, object]) -> li
         )
     )
 
-    active_parts = [part for part in (active_group, active_mode) if part]
-    active_text = " ".join(active_parts)
-    plan_summary = _format_plan_summary(active_plan_ids)
-    if plan_summary:
-        active_text = f"{active_text} · {plan_summary}" if active_text else plan_summary
-    if active_text:
+    # Completed groups
+    for group_id in completed_group_ids:
         rows.append(
             _compose_line(
                 width,
                 prefix_plain=" │   ",
                 prefix_rendered=f" {SECONDARY}│{RESET}   ",
-                left_plain=f"› active: {active_text}",
-                left_rendered=f"{DIM}› active: {active_text}{RESET}",
+                left_plain=f"› ✓ {group_id}",
+                left_rendered=f"{DIM}› {GREEN}✓{RESET} {DIM}{group_id}{RESET}",
             )
         )
 
-    summary_parts: list[str] = []
-    done_summary = _summarize_group_ids(completed_group_ids)
-    queued_summary = _summarize_group_ids(queued_group_ids)
-    if done_summary:
-        summary_parts.append(f"done: {done_summary}")
-    if queued_summary:
-        summary_parts.append(f"queued: {queued_summary}")
-    if summary_parts:
-        summary_text = " · ".join(summary_parts)
+    # Active group
+    if active_group:
+        active_parts = [part for part in (active_group, active_mode) if part]
+        active_text = " ".join(active_parts)
+        plan_summary = _format_plan_summary(active_plan_ids)
+        if plan_summary:
+            active_text = (
+                f"{active_text} · {plan_summary}" if active_text else plan_summary
+            )
+        if active_text:
+            rows.append(
+                _compose_line(
+                    width,
+                    prefix_plain=" │   ",
+                    prefix_rendered=f" {SECONDARY}│{RESET}   ",
+                    left_plain=f"› ▶ {active_text}",
+                    left_rendered=(
+                        f"{DIM}› {BOLD}{SECONDARY}▶{RESET} "
+                        f"{BOLD}{SECONDARY}{active_text}{RESET}"
+                    ),
+                )
+            )
+
+    # Queued groups
+    for group_id in queued_group_ids:
         rows.append(
             _compose_line(
                 width,
                 prefix_plain=" │   ",
                 prefix_rendered=f" {SECONDARY}│{RESET}   ",
-                left_plain=f"› {summary_text}",
-                left_rendered=f"{DIM}› {summary_text}{RESET}",
+                left_plain=f"› · {group_id}",
+                left_rendered=f"{DIM}› · {group_id}{RESET}",
             )
         )
+
     return rows
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -221,8 +221,9 @@ class MonitorTests(unittest.TestCase):
             output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
 
             self.assertIn("› groups: 1/3 done", output)
-            self.assertIn("› active: g2 serial · plan_2", output)
-            self.assertIn("› done: g1 · queued: g3", output)
+            self.assertIn("› ✓ g1", output)
+            self.assertIn("› ▶ g2 serial · plan_2", output)
+            self.assertIn("› · g3", output)
 
     def test_render_implementing_shows_parallel_group_progress(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -247,8 +248,8 @@ class MonitorTests(unittest.TestCase):
             output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
 
             self.assertIn("› groups: 0/2 done", output)
-            self.assertIn("› active: g1 parallel · plan_1, plan_2", output)
-            self.assertIn("› queued: g2", output)
+            self.assertIn("› ▶ g1 parallel · plan_1, plan_2", output)
+            self.assertIn("› · g2", output)
 
     def test_render_implementing_mixed_schedule_summarizes_future_groups(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -273,8 +274,10 @@ class MonitorTests(unittest.TestCase):
             output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
 
             self.assertIn("› groups: 1/4 done", output)
-            self.assertIn("› active: g2 parallel · 3 plans", output)
-            self.assertIn("› done: g1 · queued: g3, g4", output)
+            self.assertIn("› ✓ g1", output)
+            self.assertIn("› ▶ g2 parallel · 3 plans", output)
+            self.assertIn("› · g3", output)
+            self.assertIn("› · g4", output)
 
     def test_render_implementing_reads_root_level_implementation_progress_fields(
         self,
@@ -301,8 +304,9 @@ class MonitorTests(unittest.TestCase):
             output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
 
             self.assertIn("› groups: 1/3 done", output)
-            self.assertIn("› active: g2 parallel · plan_2, plan_3", output)
-            self.assertIn("› done: g1 · queued: g3", output)
+            self.assertIn("› ✓ g1", output)
+            self.assertIn("› ▶ g2 parallel · plan_2, plan_3", output)
+            self.assertIn("› · g3", output)
             self.assertNotIn("› 4 subplans", output)
 
     def test_render_implementing_staged_details_remain_readable_when_narrow(
@@ -330,8 +334,62 @@ class MonitorTests(unittest.TestCase):
             output = self._strip_ansi(self._render(feature_dir, width=34, height=24))
 
             self.assertIn("› groups:", output)
-            self.assertIn("› active:", output)
-            self.assertIn("› done:", output)
+            self.assertIn("› ✓ g1", output)
+            self.assertIn("› ▶ g2", output)
+            self.assertIn("› · g3", output)
+
+    def test_render_implementing_single_group_only(self) -> None:
+        """Only active group, no completed or queued groups."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            state_path = feature_dir / "state.json"
+            runtime_state_path = feature_dir / "runtime_state.json"
+            state_path.write_text(
+                (
+                    '{"phase":"implementing","execution_progress":{'
+                    '"total_groups":1,'
+                    '"completed_groups":0,'
+                    '"active_group_index":0,'
+                    '"active_group_mode":"serial",'
+                    '"active_plan_ids":["plan_1"],'
+                    '"groups":[{"id":"g1"}]'
+                    "}}"
+                ),
+                encoding="utf-8",
+            )
+            runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
+
+            output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
+
+            self.assertIn("› groups: 0/1 done", output)
+            self.assertIn("› ▶ g1 serial · plan_1", output)
+            self.assertNotIn("› ✓", output)
+            self.assertNotIn("› ·", output)
+
+    def test_render_implementing_no_groups(self) -> None:
+        """No progress section when total=0 (extractor returns None)."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            state_path = feature_dir / "state.json"
+            runtime_state_path = feature_dir / "runtime_state.json"
+            state_path.write_text(
+                (
+                    '{"phase":"implementing","execution_progress":{'
+                    '"total_groups":0,'
+                    '"completed_groups":0,'
+                    '"groups":[]'
+                    "}}"
+                ),
+                encoding="utf-8",
+            )
+            runtime_state_path.write_text('{"primary": {}}', encoding="utf-8")
+
+            output = self._strip_ansi(self._render(feature_dir, width=80, height=24))
+
+            # When total=0, _extract_execution_progress returns None,
+            # so no progress lines render.
+            self.assertNotIn("› groups:", output)
+            self.assertNotIn("› active:", output)
 
     def test_render_does_not_show_documents_section_even_when_docs_exist(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Initial Request

### What problem does this solve?
When multiple sub-phases are active during the coding phase, the phase marker in the monitor does not visually distinguish between them. Users cannot quickly see which sub-phases are currently active and their status.

### Proposed solution
Highlight sub-phases in the phase marker according to their current status (e.g., working, idle, completed) so users can track parallel coding progress at a glance.

### Area
- Monitor / UI

## Plan Summary

Overview

Replace the current uniform-DIM summary lines in `_render_implementing_progress()` with per-group lines that use color-coded status indicators matching the existing pipeline stage conventions.

## Review Verdict

verdict: pass



Closes #78
