### PR TITLE
review-should

### DIFF
--- a/.agentmux/config.yaml
+++ b/.agentmux/config.yaml
@@ -1,11 +1,10 @@
 version: 2
 
 defaults:
-  session_name: multi-agent-mvp
+  session_name: agentmux
   provider: copilot
   max_review_iterations: 3
 
-# roles:
-#  coder:
-#    provider: opencode
-#    model: opencode/qwen3.6-plus-free
+roles:
+  coder:
+    provider: claude

--- a/.agentmux/prompts/agents/architect.md
+++ b/.agentmux/prompts/agents/architect.md
@@ -1,2 +1,4 @@
 - Prefer extracting repeated prompt instructions into shared fragments/helpers instead of duplicating them across multiple prompt templates.
 - Avoid centralized if/else or switch chains for role/phase-specific behavior. Use declarative registries, dispatch tables, or per-role modules so each role/phase owns its own logic.
+
+- The `agentmux-research` MCP server is a pure signal channel: all tools (dispatch AND submission) validate inputs, append to `tool_events.jsonl`, and return confirmation — no file I/O. Side-effects (artifact writes, task dispatch) belong in the orchestrator handler layer, not in MCP tools.

--- a/.agentmux/review_should.md
+++ b/.agentmux/review_should.md
@@ -1,0 +1,48 @@
+
+# Refactoring - Should be
+
+Diese Aspekte sollten von der Implementierung umgesetzt worden sein
+
+- Toolcall als eigenes event (statt file events), auf das der Orchestrator hört
+- Orchestrator schreibt md Dateien (wie vorher) in das session verzeichnis
+- Die Dateien die vom entsprechenden Agent zwingend benötigt werden, werden (wie vorher) direkt in das Prompt eingebettet
+- MCP Tools haben eine saubere Abstraktion (MCP Tool), die von konkretem provider implementiert wird (copilot mcp aktivierung sieht anders aus als bei gemini zb)
+- Wir müssen eine hybride Lösung wählen: Agents schreiben die Dateien, Tool Call gibt signal dass der agent fertig ist und welche Dateien er geschrieben hat + Metadaten (z.b. ausführungsplan)
+- wenn wir schon einen agentmux namespace für die tools haben brauchen wir keinen 'agentmux_'
+- Alle "done-signale" müssen über ein entsprechendes Tool laufen
+
+Outlined Plan: 
+
+│ Refactoring Plan: Handoff Contracts — Should-Be Architecture                                                                        │
+│                                                                                                                                     │
+│ Approach: Implement the hybrid model where agents write files themselves AND call MCP tools to signal completion. Tool calls become │
+│ first-class tool.* events — not file events.                                                                                        │
+│                                                                                                                                     │
+│ 4 Steps (largely sequential, Step 4 independent):                                                                                   │
+│                                                                                                                                     │
+│ Step 1 — Tool Call Event Channel (infrastructure only)                                                                              │
+│                                                                                                                                     │
+│  - Add tool_events.jsonl append-only log to session dir                                                                             │
+│  - New ToolCallEventSource (watchdog-backed) emitting tool.<name> events                                                            │
+│  - Wire into EventBus + WorkflowEventRouter                                                                                         │
+│  - MCP tools append to this log instead of relying on file detection                                                                │
+│                                                                                                                                     │
+│ Step 2 — Migrate Handlers to Tool Events + Move File Writing                                                                        │
+│                                                                                                                                     │
+│  - ArchitectingHandler, PlanningHandler, ReviewingHandler: replace file EventSpecs with tool call events (tool.submit_architecture  │
+│ etc.)                                                                                                                               │
+│  - Move file-writing (architecture.md, plan.md, review.md) from MCP tools → orchestrator handlers                                   │
+│  - MCP tools become pure: validate → append to event log → return confirmation                                                      │
+│                                                                                                                                     │
+│ Step 3 — Coder/Researcher Done Tools + Rename                                                                                       │
+│                                                                                                                                     │
+│  - New submit_done(subplan_index) tool for coders                                                                                   │
+│  - New submit_research_done(topic, type) tool for researchers                                                                       │
+│  - Add coder/researcher roles to MCP access (DEFAULT_RESEARCH_ROLES)                                                                │
+│  - Remove redundant agentmux_ prefix from all tool names                                                                            │
+│  - Update all prompt templates                                                                                                      │
+│                                                                                                                                     │
+│ Step 4 — Copilot MCP Configurator (independent, can run parallel with 2-3)                                                          │
+│                                                                                                                                     │
+│  - Add CopilotConfigurator to integrations/mcp/configurators.py                                                                     │
+│  - Wire into CONFIGURATORS dict so init + ensure_mcp_config auto-covers Copilot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Role routing in these phases:
 - `product-manager`: product management phase only
 - `architect`: architecting phase only — creates technical architecture document (the "What" and "With what")
 - `planner`: planning/replanning only — creates execution plans from architecture (the "How" and "When")
-- `reviewer`: reviewing and final confirmation/completion prompts (dynamically routed to specialized reviewers based on `plan_meta.review_strategy`):
+- `reviewer`: reviewing and final confirmation/completion prompts (dynamically routed to specialized reviewers based on `execution_plan.yaml` `review_strategy`):
   - `reviewer_logic`: Logic & Alignment reviewer (functional correctness vs plan)
   - `reviewer_quality`: Quality & Style reviewer (clean code, naming, standards)  
   - `reviewer_expert`: Deep-Dive Expert reviewer (security, performance, edge cases)
@@ -156,6 +156,7 @@ src/agentmux/workflow/handlers.py       — phase helpers and state writes
 src/agentmux/workflow/transitions.py    — PipelineContext and transition helpers
 src/agentmux/workflow/interruptions.py  — interruption catalog and reporting
 src/agentmux/workflow/plan_parser.py    — execution-plan-backed subplan labels
+src/agentmux/workflow/handoff_contracts.py — contract definitions, validation, prompt rendering for structured agent handoffs
 
 src/agentmux/monitor/__init__.py        — monitor command entrypoint
 src/agentmux/monitor/state_reader.py    — monitor state/log aggregation
@@ -166,7 +167,7 @@ src/agentmux/terminal_ui/layout.py      — shared terminal layout constants
 
 src/agentmux/integrations/github.py     — GitHub issue bootstrap and PR creation
 src/agentmux/integrations/mcp.py        — provider-native MCP setup plus runtime env wiring
-src/agentmux/integrations/mcp_research_server.py — shared MCP research server
+src/agentmux/integrations/mcp_research_server.py — shared MCP research server (research dispatch + structured submission tools)
 src/agentmux/integrations/completion.py — completion-time commit / PR / cleanup side effects
 src/agentmux/integrations/compression.py — headroom proxy lifecycle and agent env injection
 
@@ -180,6 +181,12 @@ src/agentmux/prompts/agents/            — role-level prompts (define what each
   coder.md                     —   implementation phase
   code-researcher.md           —   codebase analysis on architect request
   web-researcher.md            —   internet search on architect request
+src/agentmux/prompts/shared/            — reusable prompt fragments inlined via [[shared:...]]
+  handoff-contract-architecture.md —  MCP tool usage + YAML fallback for architecture submission
+  handoff-contract-plan.md     —   MCP tool usage + YAML fallback for execution plan/subplan submission
+  handoff-contract-review.md   —   MCP tool usage + YAML fallback for review submission
+  coder-discipline.md          —   coder workflow discipline rules
+  preference-memory.md         —   preference memory instructions
 src/agentmux/prompts/commands/          — phase-specific command prompts (what to do at each step)
   review.md                    —   code review (legacy)
   review_logic.md              —   logic alignment review
@@ -212,6 +219,7 @@ Rules:
 - **Completion/commit flow**: Update `docs/completing-phase.md`
 - **Monitor constants or sections**: Update `docs/monitor.md`
 - **Prompt templates or rendering**: Update `docs/prompts.md`
+- **Handoff contracts or MCP submit tools**: Update `docs/handoff-contracts.md`
 - **Resume logic**: Update `docs/session-resumption.md`
 - **Architectural changes** (new phases, new agents, state machine transitions): Update this file (CLAUDE.md)
 - Do **not** document implementation details that are obvious from reading the code — docs describe contracts, flows, and schemas
@@ -227,4 +235,5 @@ Deeper context on specific subsystems:
 - `docs/completing-phase.md` — Approval flow, commit selection, cleanup
 - `docs/monitor.md` — Control pane display sections, constants, rendering
 - `docs/prompts.md` — Prompt templates, placeholders, rendering pipeline, and coder research handoff injection
+- `docs/handoff-contracts.md` — Structured handoff contracts, MCP submission tools, validation, dual-file output
 - `docs/session-resumption.md` — Resume flag, phase inference, runtime rehydration

--- a/docs/file-protocol.md
+++ b/docs/file-protocol.md
@@ -11,6 +11,7 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 - `context.md` — auto-generated rules/session info injected into prompts
 - `runtime_state.json` / `orchestrator.log` — runtime tracking and orchestrator logs
 - `created_files.log` — append-only created-file history written by the orchestrator as `YYYY-MM-DD HH:MM:SS  relative/path`; records files only (not directories), deduplicated by relative path, and seeded once at startup to include pre-existing session files
+- `tool_events.jsonl` — append-only MCP tool-call event log; each entry is a JSON object `{"tool": "<name>", "timestamp": "<ISO-8601>", "payload": {...}}`; written by MCP server tools and tailed by `ToolCallEventSource`
 
 ## Product Management (`01_product_management/`)
 
@@ -22,11 +23,11 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 
 - `architect_prompt.md` / `changes_prompt.txt` — architect prompts (for architecting phase)
 - `planner_prompt.md` — planner prompt for creating execution plans
-- `architecture.yaml` — canonical structured architecture document (the "What" and "With what"); written by MCP `agentmux_submit_architecture` or directly by the architect
+- `architecture.yaml` — canonical structured architecture document (the "What" and "With what"); written by MCP `submit_architecture` or directly by the architect
 - `architecture.md` — human-readable companion of `architecture.yaml`; consumed by the planner prompt, so it remains required alongside the canonical YAML
 - `plan.md` — human-readable planning overview created by planner; required alongside `execution_plan.yaml` for planning completion and later prompts
 - `plan_<N>.md` — executable per-unit implementation plans referenced by scheduler metadata and consumed by coder prompts
-- `plan_<N>.yaml` — canonical structured sub-plan data; written by MCP `agentmux_submit_subplan` or directly by the planner
+- `plan_<N>.yaml` — canonical structured sub-plan data; written by MCP `submit_subplan` or directly by the planner
 - `execution_plan.yaml` — merged machine-readable schedule and planner metadata
   - Each group has a unique `group_id` and an execution mode (`serial` or `parallel`)
   - `serial` groups execute plans one at a time in order (useful for sequential integration steps)
@@ -77,7 +78,7 @@ Execution scheduling is strict:
 ## Review (`06_review/`)
 
 - `review_prompt.md` — legacy review prompt (backward compatibility)
-- `review.yaml` — canonical structured review verdict and findings; written by MCP `agentmux_submit_review` or directly by the reviewer
+- `review.yaml` — canonical structured review verdict and findings; written by MCP `submit_review` or directly by the reviewer
 - `review.md` — human-readable review companion used by summary generation, monitor output, and PR assembly; generated automatically from `review.yaml` when missing
 - `review_logic_prompt.md` — Logic & Alignment reviewer prompt (functional correctness vs plan)
 - `review_quality_prompt.md` — Quality & Style reviewer prompt (clean code, naming, standards)
@@ -103,10 +104,25 @@ Execution scheduling is strict:
 - `EventBus` in `agentmux/runtime/event_bus.py` — generic dispatcher plus start/stop lifecycle for dedicated event sources
 - `FileEventSource` / `FeatureEventHandler` in `agentmux/runtime/file_events.py` — normalize watchdog activity under the feature directory and publish `file.*` events
 - `CreatedFilesLogListener` / `seed_existing_files()` in `agentmux/runtime/file_events.py` — enforce created-file logging semantics (`created_files.log`, first-seen only, bootstrap coverage)
+- `ToolCallEventSource` in `agentmux/runtime/tool_events.py` — tail `tool_events.jsonl` and publish `tool.<name>` events into the EventBus; seeded at startup, then watched via watchdog
 - `InterruptionEventSource` in `agentmux/runtime/interruption_sources.py` — publish interruption events when registered tmux panes disappear
 - `WorkflowEventRouter.enter_current_phase()` in `agentmux/workflow/event_router.py` — explicitly bootstraps the active phase before steady-state event processing starts
 - `build_*_prompt()` in `agentmux/workflow/prompts.py` — loads and renders the markdown template for each phase; called lazily by handlers
 - Handler functions in `agentmux/workflow/handlers.py` — each builds and writes its prompt file just before sending to agent
+
+## MCP Tool Event Protocol
+
+When agents call MCP tools (`submit_architecture`, `submit_execution_plan`, `submit_subplan`, `submit_review`, `submit_done`, `submit_research_done`, `submit_pm_done`), the tool validates the inputs, appends an entry to `tool_events.jsonl`, and returns a confirmation string. The tools are **pure**: they do not write any workflow artifacts directly.
+
+Each entry has this shape:
+
+```json
+{"tool": "<tool_name>", "timestamp": "<ISO-8601>", "payload": {...}}
+```
+
+`ToolCallEventSource` tails `tool_events.jsonl` and emits `SessionEvent(kind="tool.<name>")` events into the `EventBus`. The `WorkflowEventRouter` routes these via `ToolSpec` to the appropriate phase handler, which writes the canonical artifacts (`.yaml` + `.md`) as side-effects and drives state transitions.
+
+Agents no longer need to create workflow artifact files manually. The orchestrator handles all artifact creation in response to tool-call events.
 
 ## Workflow Events
 

--- a/docs/file-protocol.md
+++ b/docs/file-protocol.md
@@ -22,10 +22,12 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 
 - `architect_prompt.md` / `changes_prompt.txt` — architect prompts (for architecting phase)
 - `planner_prompt.md` — planner prompt for creating execution plans
-- `architecture.md` — technical architecture document created by architect (the "What" and "With what")
+- `architecture.yaml` — canonical structured architecture document (the "What" and "With what"); written by MCP `agentmux_submit_architecture` or directly by the architect
+- `architecture.md` — human-readable companion of `architecture.yaml`
 - `plan.md` — human-readable planning overview created by planner
 - `plan_<N>.md` — executable per-unit implementation plans referenced by scheduler metadata
-- `execution_plan.json` — machine-readable schedule of ordered execution groups
+- `plan_<N>.yaml` — canonical structured sub-plan data; written by MCP `agentmux_submit_subplan` or directly by the planner
+- `execution_plan.yaml` — merged machine-readable schedule and planner metadata
   - Each group has a unique `group_id` and an execution mode (`serial` or `parallel`)
   - `serial` groups execute plans one at a time in order (useful for sequential integration steps)
   - `parallel` groups execute all plans simultaneously
@@ -35,7 +37,8 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
   - Group ordering defines implementation wave order
 - `tasks_<N>.md` — per-plan implementation checklists; each coder receives only their assigned plan's tasks
 - `tasks.md` — optional human-readable overview summarizing all tasks (not used by scheduler)
-- `plan_meta.json` — planner workflow-intent metadata:
+
+The `execution_plan.yaml` file also contains planner workflow-intent metadata alongside the groups:
   - `needs_design` (`true`/`false`) — whether to run a dedicated design handoff
   - `needs_docs` (`true`/`false`) — informational signal that documentation updates are in scope
   - `doc_files` (`string[]`) — planned documentation targets when docs work is in scope
@@ -46,7 +49,7 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 
 Execution scheduling is strict:
 
-- `execution_plan.json` is required before implementation starts.
+- `execution_plan.yaml` is required before implementation starts.
 - `groups[].plans[]` entries must use `{ "file": "plan_<N>.md", "name": "Human title" }` objects.
 - Implementation dispatch uses numbered prompt files (`coder_prompt_<N>.txt`) only.
 
@@ -74,12 +77,13 @@ Execution scheduling is strict:
 ## Review (`06_review/`)
 
 - `review_prompt.md` / `review.md` — legacy review prompt (backward compatibility)
+- `review.yaml` — canonical structured review verdict and findings; written by MCP `agentmux_submit_review` or directly by the reviewer
 - `review_logic_prompt.md` — Logic & Alignment reviewer prompt (functional correctness vs plan)
 - `review_quality_prompt.md` — Quality & Style reviewer prompt (clean code, naming, standards)
 - `review_expert_prompt.md` — Deep-Dive Expert reviewer prompt (security, performance, edge cases)
 - `fix_prompt.txt` / `fix_request.md`
 
-**Reviewer Selection:** Which prompt is used depends on `plan_meta.review_strategy`:
+**Reviewer Selection:** Which prompt is used depends on `execution_plan.yaml` `review_strategy`:
 - Missing `review_strategy` → uses `review_logic_prompt.md` (backward compatible default)
 - `severity: low` → uses `review_quality_prompt.md`
 - `severity: medium/high` without security/performance focus → uses `review_logic_prompt.md`

--- a/docs/file-protocol.md
+++ b/docs/file-protocol.md
@@ -23,16 +23,16 @@ Agents communicate via files in `.agentmux/.sessions/<feature-name>/`. Files are
 - `architect_prompt.md` / `changes_prompt.txt` — architect prompts (for architecting phase)
 - `planner_prompt.md` — planner prompt for creating execution plans
 - `architecture.yaml` — canonical structured architecture document (the "What" and "With what"); written by MCP `agentmux_submit_architecture` or directly by the architect
-- `architecture.md` — human-readable companion of `architecture.yaml`
-- `plan.md` — human-readable planning overview created by planner
-- `plan_<N>.md` — executable per-unit implementation plans referenced by scheduler metadata
+- `architecture.md` — human-readable companion of `architecture.yaml`; consumed by the planner prompt, so it remains required alongside the canonical YAML
+- `plan.md` — human-readable planning overview created by planner; required alongside `execution_plan.yaml` for planning completion and later prompts
+- `plan_<N>.md` — executable per-unit implementation plans referenced by scheduler metadata and consumed by coder prompts
 - `plan_<N>.yaml` — canonical structured sub-plan data; written by MCP `agentmux_submit_subplan` or directly by the planner
 - `execution_plan.yaml` — merged machine-readable schedule and planner metadata
   - Each group has a unique `group_id` and an execution mode (`serial` or `parallel`)
   - `serial` groups execute plans one at a time in order (useful for sequential integration steps)
   - `parallel` groups execute all plans simultaneously
   - Both modes can reference one or more named `plan_<N>.md` entries
-  - Canonical plan-entry shape is `{ "file": "plan_<N>.md", "name": "Human title" }`
+  - Canonical plan-entry shape is a YAML mapping with `file` and `name` keys (for example `- file: plan_1.md` followed by `name: Core setup`)
   - Plan references must be unique across groups
   - Group ordering defines implementation wave order
 - `tasks_<N>.md` — per-plan implementation checklists; each coder receives only their assigned plan's tasks
@@ -50,7 +50,7 @@ The `execution_plan.yaml` file also contains planner workflow-intent metadata al
 Execution scheduling is strict:
 
 - `execution_plan.yaml` is required before implementation starts.
-- `groups[].plans[]` entries must use `{ "file": "plan_<N>.md", "name": "Human title" }` objects.
+- `groups[].plans[]` entries must use YAML mappings with `file` and `name` keys.
 - Implementation dispatch uses numbered prompt files (`coder_prompt_<N>.txt`) only.
 
 ## Research (`03_research/`)
@@ -76,8 +76,9 @@ Execution scheduling is strict:
 
 ## Review (`06_review/`)
 
-- `review_prompt.md` / `review.md` — legacy review prompt (backward compatibility)
+- `review_prompt.md` — legacy review prompt (backward compatibility)
 - `review.yaml` — canonical structured review verdict and findings; written by MCP `agentmux_submit_review` or directly by the reviewer
+- `review.md` — human-readable review companion used by summary generation, monitor output, and PR assembly; generated automatically from `review.yaml` when missing
 - `review_logic_prompt.md` — Logic & Alignment reviewer prompt (functional correctness vs plan)
 - `review_quality_prompt.md` — Quality & Style reviewer prompt (clean code, naming, standards)
 - `review_expert_prompt.md` — Deep-Dive Expert reviewer prompt (security, performance, edge cases)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,7 +163,7 @@ Fix:
 
 - Tune provider/model settings in [Configuration](configuration.md)
 - Add a requirements-refinement phase with `--product-manager`
-- Bootstrap runs from GitHub issues with `--issue <number-or-url>`
+- Bootstrap runs from GitHub issues with `--issue <number-or-url>` (includes issue body and all comments)
 - Continue interrupted work with `--resume` (see [Session Resumption](session-resumption.md))
 - Use reference docs as needed:
   - [Tmux Layout](tmux-layout.md)

--- a/docs/handoff-contracts.md
+++ b/docs/handoff-contracts.md
@@ -8,7 +8,7 @@ Handoff contracts define the structured interface between workflow phases. Each 
 
 Agents submit phase outputs through either:
 
-1. **MCP submission tools** (preferred) — the `agentmux-research` MCP server exposes four `agentmux_submit_*` tools that accept structured parameters, validate them against the contract, and write both `.yaml` and `.md` files.
+1. **MCP submission tools** (preferred) — the `agentmux-research` MCP server exposes `submit_*` tools that accept structured parameters, validate them against the contract, append an event to `tool_events.jsonl`, and return a confirmation string. The tools are **pure**: they do not write workflow artifacts directly. The orchestrator observes the event and drives artifact creation as a side-effect. Agents no longer need to create any files manually.
 2. **Direct YAML write** (fallback) — agents that cannot call MCP tools write the canonical `.yaml` file directly. Shared prompt fragments (`[[shared:handoff-contract-*]]`) embedded in agent prompts provide the YAML schema and examples.
 
 Completion semantics are phase-specific:
@@ -21,7 +21,7 @@ Completion semantics are phase-specific:
 
 ### Architecture
 
-- **MCP tool:** `agentmux_submit_architecture`
+- **MCP tool:** `submit_architecture`
 - **Canonical file:** `02_planning/architecture.yaml`
 - **Companion file:** `02_planning/architecture.md`
 - **Required fields:** `solution_overview`, `components` (list of `{name, responsibility, interfaces}`), `interfaces_and_contracts`, `data_models`, `cross_cutting_concerns`, `technology_choices`, `risks_and_mitigations`
@@ -29,7 +29,7 @@ Completion semantics are phase-specific:
 
 ### Execution plan
 
-- **MCP tool:** `agentmux_submit_execution_plan`
+- **MCP tool:** `submit_execution_plan`
 - **Canonical file:** `02_planning/execution_plan.yaml`
 - **Companion file:** `02_planning/plan.md`
 - **Required fields:** `groups` (list of `{group_id, mode, plans: [{file, name}]}`), `review_strategy` (`{severity, focus}`), `needs_design`, `needs_docs`, `doc_files`, `plan_overview`
@@ -38,7 +38,7 @@ The YAML file merges the former `execution_plan.json` scheduling data and `plan_
 
 ### Subplan
 
-- **MCP tool:** `agentmux_submit_subplan`
+- **MCP tool:** `submit_subplan`
 - **Canonical file:** `02_planning/plan_N.yaml`
 - **Companion files:** `02_planning/plan_N.md`, `02_planning/tasks_N.md`
 - **Required fields:** `index`, `title`, `scope`, `owned_files`, `dependencies`, `implementation_approach`, `acceptance_criteria`, `tasks`
@@ -48,7 +48,7 @@ Subplans are submitted individually before the execution plan. The `index` value
 
 ### Review
 
-- **MCP tool:** `agentmux_submit_review`
+- **MCP tool:** `submit_review`
 - **Canonical file:** `06_review/review.yaml`
 - **Companion file:** `06_review/review.md`
 - **Required fields:** `verdict` (`"pass"` or `"fail"`), `summary`

--- a/docs/handoff-contracts.md
+++ b/docs/handoff-contracts.md
@@ -1,0 +1,85 @@
+# Handoff Contracts
+
+> Related source files: `agentmux/workflow/handoff_contracts.py`, `agentmux/integrations/mcp_research_server.py`, `agentmux/prompts/shared/handoff-contract-architecture.md`, `agentmux/prompts/shared/handoff-contract-plan.md`, `agentmux/prompts/shared/handoff-contract-review.md`
+
+Handoff contracts define the structured interface between workflow phases. Each contract specifies the fields an agent must produce, validates submissions, and writes dual output files (YAML canonical + MD human-readable).
+
+## Overview
+
+Agents submit phase outputs through either:
+
+1. **MCP submission tools** (preferred) — the `agentmux-research` MCP server exposes four `agentmux_submit_*` tools that accept structured parameters, validate them against the contract, and write both `.yaml` and `.md` files.
+2. **Direct YAML write** (fallback) — agents that cannot call MCP tools write the `.yaml` file directly. Shared prompt fragments (`[[shared:handoff-contract-*]]`) embedded in agent prompts provide the YAML schema and examples.
+
+The orchestrator watches for the canonical `.yaml` files to detect phase completion.
+
+## Contracts
+
+### Architecture
+
+- **MCP tool:** `agentmux_submit_architecture`
+- **Canonical file:** `02_planning/architecture.yaml`
+- **Companion file:** `02_planning/architecture.md`
+- **Required fields:** `solution_overview`, `components` (list of `{name, responsibility, interfaces}`), `interfaces_and_contracts`, `data_models`, `cross_cutting_concerns`, `technology_choices`, `risks_and_mitigations`
+- **Optional fields:** `design_handoff`
+
+### Execution plan
+
+- **MCP tool:** `agentmux_submit_execution_plan`
+- **Canonical file:** `02_planning/execution_plan.yaml`
+- **Companion file:** `02_planning/plan.md`
+- **Required fields:** `groups` (list of `{group_id, mode, plans: [{file, name}]}`), `review_strategy` (`{severity, focus}`), `needs_design`, `needs_docs`, `doc_files`, `plan_overview`
+
+The YAML file merges the former `execution_plan.json` scheduling data and `plan_meta.json` workflow-intent metadata into a single file with a `version: 1` header.
+
+### Subplan
+
+- **MCP tool:** `agentmux_submit_subplan`
+- **Canonical file:** `02_planning/plan_N.yaml`
+- **Companion files:** `02_planning/plan_N.md`, `02_planning/tasks_N.md`
+- **Required fields:** `index`, `title`, `scope`, `owned_files`, `dependencies`, `implementation_approach`, `acceptance_criteria`, `tasks`
+- **Optional fields:** `isolation_rationale`
+
+Subplans are submitted individually before the execution plan. The `index` value determines the `N` in file names.
+
+### Review
+
+- **MCP tool:** `agentmux_submit_review`
+- **Canonical file:** `06_review/review.yaml`
+- **Companion file:** `06_review/review.md`
+- **Required fields:** `verdict` (`"pass"` or `"fail"`), `summary`
+- **Conditional fields:** `findings` (required on `fail` — list of `{location, issue, severity, recommendation}`), `commit_message` (optional on `pass`)
+
+## Validation
+
+`validate_submission(contract_name, data)` in `handoff_contracts.py` performs:
+
+1. **Required-field presence** — all required fields must be present
+2. **Type checking** — loose type validation against field specs (`str`, `bool`, `int`, `list[str]`, `list[dict]`, `dict`)
+3. **Allowed-value enforcement** — fields with constrained values (e.g., verdict: `pass`/`fail`) are validated
+4. **Contract-specific rules:**
+   - Architecture: each component must have `name` and `responsibility`
+   - Execution plan: groups must be non-empty, unique `group_id`, valid `mode`, plans must have `file` and `name`
+   - Subplan: `index` >= 1, non-empty `tasks` and `owned_files`
+   - Review: `fail` verdict requires non-empty `findings` with `issue` and `recommendation`
+
+MCP tools raise a validation error with all issues listed; agents receive the error message and can correct their submission.
+
+## Dual-file output
+
+Each submission writes two files:
+
+- **`.yaml`** — the machine-readable canonical artifact. The orchestrator watches for this file to trigger phase transitions.
+- **`.md`** — a human-readable companion generated from the same data. Useful for attaching to tmux, reviewing in PRs, and reading in subsequent agent prompts via `[[include:...]]`.
+
+## Shared prompt fragments
+
+Three shared fragments provide agents with MCP tool usage instructions and YAML fallback examples:
+
+| Fragment | Included by | Purpose |
+|---|---|---|
+| `handoff-contract-architecture.md` | `architect.md` | Architecture submission instructions |
+| `handoff-contract-plan.md` | `planner.md`, `change.md` | Execution plan + subplan submission instructions |
+| `handoff-contract-review.md` | `review_logic.md`, `review_quality.md`, `review_expert.md` | Review submission instructions |
+
+These are inlined at template-load time via the `[[shared:fragment-name]]` syntax.

--- a/docs/handoff-contracts.md
+++ b/docs/handoff-contracts.md
@@ -1,6 +1,6 @@
 # Handoff Contracts
 
-> Related source files: `agentmux/workflow/handoff_contracts.py`, `agentmux/integrations/mcp_research_server.py`, `agentmux/prompts/shared/handoff-contract-architecture.md`, `agentmux/prompts/shared/handoff-contract-plan.md`, `agentmux/prompts/shared/handoff-contract-review.md`
+> Related source files: `agentmux/workflow/handoff_contracts.py`, `agentmux/workflow/handoff_artifacts.py`, `agentmux/integrations/mcp_research_server.py`, `agentmux/prompts/shared/handoff-contract-architecture.md`, `agentmux/prompts/shared/handoff-contract-plan.md`, `agentmux/prompts/shared/handoff-contract-review.md`
 
 Handoff contracts define the structured interface between workflow phases. Each contract specifies the fields an agent must produce, validates submissions, and writes dual output files (YAML canonical + MD human-readable).
 
@@ -9,9 +9,13 @@ Handoff contracts define the structured interface between workflow phases. Each 
 Agents submit phase outputs through either:
 
 1. **MCP submission tools** (preferred) — the `agentmux-research` MCP server exposes four `agentmux_submit_*` tools that accept structured parameters, validate them against the contract, and write both `.yaml` and `.md` files.
-2. **Direct YAML write** (fallback) — agents that cannot call MCP tools write the `.yaml` file directly. Shared prompt fragments (`[[shared:handoff-contract-*]]`) embedded in agent prompts provide the YAML schema and examples.
+2. **Direct YAML write** (fallback) — agents that cannot call MCP tools write the canonical `.yaml` file directly. Shared prompt fragments (`[[shared:handoff-contract-*]]`) embedded in agent prompts provide the YAML schema and examples.
 
-The orchestrator watches for the canonical `.yaml` files to detect phase completion.
+Completion semantics are phase-specific:
+
+- **Architecture** — `architecture.yaml` is the canonical structured artifact, but the planner prompt still consumes `architecture.md`, so the companion Markdown file remains required in practice.
+- **Execution plan + subplans** — `execution_plan.yaml` / `plan_N.yaml` are canonical structured artifacts, but `plan.md`, `plan_N.md`, and `tasks_N.md` remain required human-readable companions for downstream prompts and coder handoffs.
+- **Review** — `review.yaml` is the canonical structured review artifact. If `review.md` is missing, AgentMux materializes it from `review.yaml` before summary/completion steps so downstream prompts can continue to read the Markdown companion.
 
 ## Contracts
 
@@ -69,8 +73,10 @@ MCP tools raise a validation error with all issues listed; agents receive the er
 
 Each submission writes two files:
 
-- **`.yaml`** — the machine-readable canonical artifact. The orchestrator watches for this file to trigger phase transitions.
+- **`.yaml`** — the machine-readable canonical artifact.
 - **`.md`** — a human-readable companion generated from the same data. Useful for attaching to tmux, reviewing in PRs, and reading in subsequent agent prompts via `[[include:...]]`.
+
+For architecture, execution plans, and subplans, the `.md` companions are still required by downstream prompts. For reviews, the runtime can synthesize `review.md` from `review.yaml` when the Markdown companion is missing.
 
 ## Shared prompt fragments
 

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -18,7 +18,7 @@ The control pane renders a live status box with the following sections:
   - Inactive agents are filtered out of the AGENTS section
   - For parallel coder mode, only non-inactive `coder_<n>` workers are shown
   - Agent rows use a shared `[role] secondary-info` format
-  - Coder rows use the explicit `name` from `02_planning/execution_plan.json`
+  - Coder rows use the explicit `name` from `02_planning/execution_plan.yaml`
   - Reviewer rows show the current review iteration, and designer rows show the feature being designed
 - **Research tasks** — progress on code and web research (if any)
 - **Event log** — recent timeline entries with timestamps: phase transitions plus filtered handover-relevant file creations from `created_files.log`
@@ -42,7 +42,7 @@ The control pane renders a live status box with the following sections:
 ## Staged implementation display notes
 
 - The monitor should represent implementing as grouped work, not only a single undifferentiated `implementing` phase.
-- Group labels are derived from orchestrator-managed state and should stay consistent with `02_planning/execution_plan.json`.
+- Group labels are derived from orchestrator-managed state and should stay consistent with `02_planning/execution_plan.yaml`.
 
 ## Component split
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,11 +1,12 @@
 # Prompt Templates and Rendering
 
-> Related source files: `agentmux/workflow/prompts.py`, `agentmux/runtime/tmux_control.py`, `agentmux/prompts/agents/`, `agentmux/prompts/commands/`
+> Related source files: `agentmux/workflow/prompts.py`, `agentmux/runtime/tmux_control.py`, `agentmux/prompts/agents/`, `agentmux/prompts/commands/`, `agentmux/prompts/shared/`
 
 ## Template directories
 
 - `agentmux/prompts/agents/` — role-level prompts (define what each agent is): `architect.md`, `planner.md`, `product-manager.md`, `reviewer.md`, `coder.md`, `code-researcher.md`, `web-researcher.md`, `designer.md`
 - `agentmux/prompts/commands/` — phase-specific command prompts (what to do at each step): `review.md`, `review_logic.md`, `review_quality.md`, `review_expert.md`, `fix.md`, `summary.md`, `change.md`
+- `agentmux/prompts/shared/` — reusable prompt fragments inlined via `[[shared:fragment-name]]`: `handoff-contract-architecture.md`, `handoff-contract-plan.md`, `handoff-contract-review.md`, `coder-discipline.md`, `preference-memory.md`
 
 ## Placeholder syntax
 
@@ -92,6 +93,16 @@ Prompt files are built lazily by handlers just before injection, not pre-generat
 
 Startup and resume now use explicit phase bootstrap: the orchestrator re-enters the active phase before steady-state event sources start, and that phase entry is what causes the handler to build and send the current prompt. Prompt injection therefore does not depend on the first seeded `file.created` event.
 
+## Handoff contract fragments
+
+Three shared prompt fragments provide agents with MCP submission tool instructions and YAML fallback examples for non-MCP providers. They are inlined at template-load time via `[[shared:fragment-name]]`:
+
+- `handoff-contract-architecture.md` — used by `architect.md`; documents `agentmux_submit_architecture` parameters and fallback `architecture.yaml` schema
+- `handoff-contract-plan.md` — used by `planner.md` and `change.md`; documents `agentmux_submit_subplan` and `agentmux_submit_execution_plan` parameters and fallback YAML schemas
+- `handoff-contract-review.md` — used by `review_logic.md`, `review_quality.md`, `review_expert.md`; documents `agentmux_submit_review` parameters and fallback `review.yaml` schema
+
+See `docs/handoff-contracts.md` for full contract details.
+
 ## Coder research handoff
 
 Coder prompt rendering injects a `Research handoff` block into `agentmux/prompts/agents/coder.md` via `[[placeholder:research_handoff]]`.
@@ -126,10 +137,9 @@ Planner (and replanning via `build_change_prompt()`) output contract:
 
 - `02_planning/plan.md` is the human-readable overview
 - `02_planning/plan_<N>.md` files are executable implementation units
-- `02_planning/execution_plan.json` is the scheduling source of truth (ordered execution groups, each marked as `serial` or `parallel`, with explicit named plan references)
+- `02_planning/execution_plan.yaml` is the scheduling source of truth (ordered execution groups, each marked as `serial` or `parallel`, with explicit named plan references) and also contains planner workflow-intent metadata (`needs_design`, `needs_docs`, `doc_files`, `review_strategy`)
 - `02_planning/tasks_<N>.md` are per-plan implementation checklists mapped to the same work; each coder receives only their assigned plan's tasks
 - `02_planning/tasks.md` is an optional human-readable overview summarizing all tasks (not used by scheduler)
-- `02_planning/plan_meta.json` is planner workflow-intent metadata (`needs_design`, `needs_docs`, `doc_files`, `review_strategy`)
 - Documentation updates must be represented in planning artifacts (`plan.md`, `plan_<N>.md`, and corresponding `tasks_<N>.md`) rather than a dedicated post-review docs phase.
 
 Planner output requirements for execution plans include:
@@ -149,10 +159,9 @@ Current prompt builders:
 - planning/replanning prompt contracts require:
   - `02_planning/plan.md` as the human-readable overview
   - `02_planning/plan_<N>.md` executable sub-plan files
-  - `02_planning/execution_plan.json` as machine-readable schedule metadata (`version`, ordered `groups`, `group_id`, `mode`, `plans`)
-  - new plans must write `groups[].plans[]` entries as `{ "file": "plan_<N>.md", "name": "<sub-plan title>" }`
-  - `02_planning/plan_meta.json` with `needs_design`, `needs_docs`, and `doc_files` (empty list when `needs_docs` is `false`)
-  - `execution_plan.json` is required before implementation scheduling starts
+  - `02_planning/execution_plan.yaml` as machine-readable schedule and metadata (`version`, ordered `groups`, `group_id`, `mode`, `plans`, plus `needs_design`, `needs_docs`, `doc_files`, `review_strategy`)
+  - new plans must write `groups[].plans[]` entries as `{ file: plan_<N>.md, name: "<sub-plan title>" }`
+  - `execution_plan.yaml` is required before implementation scheduling starts
 - `build_product_manager_prompt()` renders the PM analysis prompt
 - `build_coder_subplan_prompt()` renders implementing prompts for numbered `coder_prompt_<N>.txt` dispatch, including completion marker instructions and optional research handoff references
 - `build_coder_whole_plan_prompt()` renders a single combined prompt for single-coder mode, embedding all plan and tasks content inline. When the coder provider is `copilot` with `single_coder: true`, the dispatch sends a `/fleet` prefix command as keystrokes before the prompt file reference, so Copilot CLI decomposes the plan into parallel sub-agent tasks. The prompt instructs copilot to create `done_N` completion markers as each plan finishes.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -97,9 +97,9 @@ Startup and resume now use explicit phase bootstrap: the orchestrator re-enters 
 
 Three shared prompt fragments provide agents with MCP submission tool instructions and YAML fallback examples for non-MCP providers. They are inlined at template-load time via `[[shared:fragment-name]]`:
 
-- `handoff-contract-architecture.md` — used by `architect.md`; documents `agentmux_submit_architecture` parameters and fallback `architecture.yaml` schema
-- `handoff-contract-plan.md` — used by `planner.md` and `change.md`; documents `agentmux_submit_subplan` and `agentmux_submit_execution_plan` parameters and fallback YAML schemas
-- `handoff-contract-review.md` — used by `review_logic.md`, `review_quality.md`, `review_expert.md`; documents `agentmux_submit_review` parameters and fallback `review.yaml` schema
+- `handoff-contract-architecture.md` — used by `architect.md`; documents `submit_architecture` parameters and fallback `architecture.yaml` schema
+- `handoff-contract-plan.md` — used by `planner.md` and `change.md`; documents `submit_subplan` and `submit_execution_plan` parameters and fallback YAML schemas
+- `handoff-contract-review.md` — used by `review_logic.md`, `review_quality.md`, `review_expert.md`; documents `submit_review` parameters and fallback `review.yaml` schema
 
 See `docs/handoff-contracts.md` for full contract details.
 

--- a/docs/research-dispatch.md
+++ b/docs/research-dispatch.md
@@ -6,7 +6,9 @@ Research dispatch is now MCP-first. The architect and product-manager should cal
 
 ## MCP tools
 
-The `agentmux-research` MCP server exposes:
+The `agentmux-research` MCP server exposes research dispatch tools and structured submission tools.
+
+### Research dispatch
 
 - `agentmux_research_dispatch_code(topic, context, questions, feature_dir, scope_hints)`
 - `agentmux_research_dispatch_web(topic, context, questions, feature_dir, scope_hints)`
@@ -28,6 +30,17 @@ Typical flow:
 Research completion stays file-driven: the orchestrator detects `done`, updates task state, and sends a follow-up message pointing the owner agent to `summary.md`. `detail.md` remains available as a secondary artifact. AgentMux passes the active session directory explicitly as `feature_dir`, so the server does not rely on provider-specific environment propagation.
 
 Completed research topics are also used for coder handoff: coder prompts include references to `03_research/<type>-<topic>/summary.md` (and `detail.md` when present) for topics that have a `done` marker.
+
+### Structured submission tools
+
+The same MCP server also provides four submission tools for structured agent handoffs:
+
+- `agentmux_submit_architecture` — validates and writes `architecture.yaml` + `architecture.md`
+- `agentmux_submit_execution_plan` — validates and writes `execution_plan.yaml` + `plan.md`
+- `agentmux_submit_subplan` — validates and writes `plan_N.yaml` + `plan_N.md` + `tasks_N.md`
+- `agentmux_submit_review` — validates and writes `review.yaml` + `review.md`
+
+These tools validate input against handoff contracts defined in `agentmux/workflow/handoff_contracts.py`. See `docs/handoff-contracts.md` for full contract details.
 
 ## Provider setup strategy
 

--- a/docs/session-resumption.md
+++ b/docs/session-resumption.md
@@ -16,9 +16,9 @@ agentmux resume <feature-dir-or-name>  # Resume specific session by name or path
 1. `list_resumable_sessions(project_dir)` scans `.agentmux/.sessions/` for all feature directories with `state.json` and returns them sorted by recency
 2. `select_session(sessions)` presents an interactive menu (or auto-selects if only one exists)
 3. For `resume <feature-dir-or-name>`, non-absolute names are resolved against `.agentmux/.sessions/<name>` first, then `<project>/<name>` as a fallback
-4. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `02_planning/plan_meta.json`, `05_implementation/done_*`, `06_review/review.md`, etc.) to determine the correct phase to resume into; this makes resume artifact-driven even after abrupt termination
+4. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `02_planning/execution_plan.yaml`, `05_implementation/done_*`, `06_review/review.md`, etc.) to determine the correct phase to resume into; this makes resume artifact-driven even after abrupt termination
 5. If `"product_manager": true` in state and `01_product_management/done` is missing, resume returns `product_management`; once `done` exists, resume falls through to normal `02_planning` / `05_implementation` inference
-6. `plan_meta.json` is used as architect-authored intent metadata during inference:
+6. `execution_plan.yaml` is used as planner-authored intent metadata during inference:
    - `needs_design: true` resumes into `designing` when `04_design/design.md` is still missing
    - `needs_docs`/`doc_files` remain planning metadata and do not create a dedicated resume phase
    - a passed review resumes directly into `completing`

--- a/docs/session-resumption.md
+++ b/docs/session-resumption.md
@@ -16,7 +16,7 @@ agentmux resume <feature-dir-or-name>  # Resume specific session by name or path
 1. `list_resumable_sessions(project_dir)` scans `.agentmux/.sessions/` for all feature directories with `state.json` and returns them sorted by recency
 2. `select_session(sessions)` presents an interactive menu (or auto-selects if only one exists)
 3. For `resume <feature-dir-or-name>`, non-absolute names are resolved against `.agentmux/.sessions/<name>` first, then `<project>/<name>` as a fallback
-4. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `02_planning/execution_plan.yaml`, `05_implementation/done_*`, `06_review/review.md`, etc.) to determine the correct phase to resume into; this makes resume artifact-driven even after abrupt termination
+4. `infer_resume_phase(feature_dir, state)` examines workflow artifacts (`01_product_management/done`, `02_planning/plan.md`, `02_planning/execution_plan.yaml`, `05_implementation/done_*`, `06_review/review.md` / `06_review/review.yaml`, etc.) to determine the correct phase to resume into; this makes resume artifact-driven even after abrupt termination
 5. If `"product_manager": true` in state and `01_product_management/done` is missing, resume returns `product_management`; once `done` exists, resume falls through to normal `02_planning` / `05_implementation` inference
 6. `execution_plan.yaml` is used as planner-authored intent metadata during inference:
    - `needs_design: true` resumes into `designing` when `04_design/design.md` is still missing

--- a/opencode.json
+++ b/opencode.json
@@ -10,5 +10,10 @@
       ],
       "enabled": true
     }
+  },
+  "agent": {
+    "agentmux-coder": {
+      "model": "opencode/qwen3.6-plus-free"
+    }
   }
 }

--- a/src/agentmux/integrations/github.py
+++ b/src/agentmux/integrations/github.py
@@ -6,6 +6,7 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from ..shared.models import GitHubConfig
@@ -29,10 +30,33 @@ def check_gh_authenticated() -> bool:
     return True
 
 
-def fetch_issue(issue_ref: str) -> dict[str, str]:
+def _format_issue_comments(comments: list[dict]) -> str:
+    """Format GitHub issue comments into a readable markdown section.
+
+    Returns an empty string when there are no comments.
+    """
+    if not comments:
+        return ""
+
+    parts = ["## Issue Comments\n"]
+    for comment in comments:
+        author = comment.get("author", {}).get("login", "Unknown")
+        created_at = comment.get("createdAt", "")
+        body = comment.get("body", "").strip()
+
+        header = f"### {author}"
+        if created_at:
+            header += f" ({created_at})"
+
+        parts.append(f"{header}\n\n{body}\n")
+
+    return "\n".join(parts)
+
+
+def fetch_issue(issue_ref: str) -> dict[str, Any]:
     try:
         result = subprocess.run(
-            ["gh", "issue", "view", issue_ref, "--json", "title,body"],
+            ["gh", "issue", "view", issue_ref, "--json", "title,body,comments"],
             capture_output=True,
             text=True,
             check=True,
@@ -59,7 +83,7 @@ def fetch_issue(issue_ref: str) -> dict[str, str]:
     body = str(payload.get("body", ""))
     if not title:
         raise RuntimeError(f"GitHub issue '{issue_ref}' returned an empty title.")
-    return {"title": title, "body": body}
+    return {"title": title, "body": body, "comments": payload.get("comments", [])}
 
 
 def extract_issue_number(issue_ref: str) -> str:
@@ -89,6 +113,7 @@ class IssueBootstrap:
     slug_source: str
     issue_number: str
     gh_available: bool = True
+    comments_text: str = ""
 
 
 class GitHubBootstrapper:
@@ -144,10 +169,17 @@ class GitHubBootstrapper:
                 f"{stderr}"
             )
 
+        comments_text = _format_issue_comments(payload.get("comments", []))
+
+        body_text = payload["body"].strip() or payload["title"]
+        if comments_text:
+            body_text = f"{body_text}\n\n{comments_text}"
+
         return IssueBootstrap(
-            prompt_text=payload["body"].strip() or payload["title"],
+            prompt_text=body_text,
             slug_source=payload["title"],
             issue_number=issue_number,
+            comments_text=comments_text,
         )
 
 

--- a/src/agentmux/integrations/mcp/__init__.py
+++ b/src/agentmux/integrations/mcp/__init__.py
@@ -17,6 +17,7 @@ from .configurators import (
     CONFIGURATORS,
     ClaudeConfigurator,
     CodexConfigurator,
+    CopilotConfigurator,
     GeminiConfigurator,
     JsonMcpConfigurator,
     OpenCodeConfigurator,
@@ -57,6 +58,7 @@ __all__ = [
     # Configurators
     "ClaudeConfigurator",
     "CodexConfigurator",
+    "CopilotConfigurator",
     "CONFIGURATORS",
     "GeminiConfigurator",
     "JsonMcpConfigurator",

--- a/src/agentmux/integrations/mcp/configurators.py
+++ b/src/agentmux/integrations/mcp/configurators.py
@@ -30,6 +30,21 @@ def _persistent_local_server(server: McpServerSpec) -> dict[str, object]:
     }
 
 
+def _copilot_local_server(server: McpServerSpec) -> dict[str, object]:
+    """Build a Copilot CLI-compatible local MCP server entry.
+
+    Copilot CLI uses 'command' as a string and 'args' as a separate array,
+    unlike OpenCode which uses 'command' as a list.
+    See: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+    """
+    return {
+        "type": "local",
+        "command": _python_command(),
+        "args": ["-m", server.module],
+        "enabled": True,
+    }
+
+
 def _toml_quote(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
     return f'"{escaped}"'
@@ -259,9 +274,57 @@ class CodexConfigurator(PersistentMcpConfigurator):
         return f"Configured codex MCP research tools at {path}."
 
 
+class CopilotConfigurator(JsonMcpConfigurator):
+    """Installs agentmux-research MCP server into GitHub Copilot CLI config.
+
+    Config path: ~/.copilot/mcp-config.json
+    Source: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+    """
+
+    provider = "copilot"
+
+    def config_path(self, project_dir: Path) -> Path:
+        _ = project_dir
+        return Path.home() / ".copilot" / "mcp-config.json"
+
+    def has_server(self, server: McpServerSpec, project_dir: Path) -> bool:
+        data = self._load_json(project_dir)
+        servers = data.get("mcpServers", {})
+        return isinstance(servers, dict) and server.name in servers
+
+    def install(self, server: McpServerSpec, project_dir: Path) -> None:
+        data = self._load_json(project_dir)
+        servers = data.get("mcpServers")
+        if not isinstance(servers, dict):
+            servers = {}
+        servers[server.name] = _copilot_local_server(server)
+        data["mcpServers"] = servers
+        self._write_json(data, project_dir)
+
+    def uninstall(self, server: McpServerSpec, project_dir: Path) -> None:
+        path = self.config_path(project_dir)
+        if not path.exists():
+            return
+        data = self._load_json(project_dir)
+        servers = data.get("mcpServers")
+        if isinstance(servers, dict):
+            servers.pop(server.name, None)
+        self._write_json(data, project_dir)
+
+    def prompt_message(
+        self, server: McpServerSpec, project_dir: Path, roles_label: str
+    ) -> str:
+        path = self.config_path(project_dir)
+        return (
+            f"Configure project MCP research tools for copilot ({roles_label}) "
+            f"at {path}?"
+        )
+
+
 CONFIGURATORS: dict[str, PersistentMcpConfigurator] = {
     "claude": ClaudeConfigurator(),
     "codex": CodexConfigurator(),
+    "copilot": CopilotConfigurator(),
     "gemini": GeminiConfigurator(),
     "opencode": OpenCodeConfigurator(),
 }
@@ -334,7 +397,10 @@ def _server_entry_matches(
         return False
 
     # Compare to what would be generated
-    expected_entry = _persistent_stdio_server(server)
+    if isinstance(configurator, CopilotConfigurator):
+        expected_entry = _copilot_local_server(server)
+    else:
+        expected_entry = _persistent_stdio_server(server)
 
     # Compare relevant fields (type, command, args)
     if existing_entry.get("type") != expected_entry.get("type"):

--- a/src/agentmux/integrations/mcp/models.py
+++ b/src/agentmux/integrations/mcp/models.py
@@ -12,7 +12,17 @@ class McpServerSpec:
     env: dict[str, str]
 
 
-DEFAULT_RESEARCH_ROLES = ("architect", "product-manager")
+DEFAULT_RESEARCH_ROLES = (
+    "architect",
+    "product-manager",
+    "planner",
+    "coder",
+    "code-researcher",
+    "web-researcher",
+    "reviewer_logic",
+    "reviewer_quality",
+    "reviewer_expert",
+)
 DEFAULT_RESEARCH_SERVERS = (
     McpServerSpec(
         name="agentmux-research",

--- a/src/agentmux/integrations/mcp_research_server.py
+++ b/src/agentmux/integrations/mcp_research_server.py
@@ -5,19 +5,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from ..shared.models import SESSION_DIR_NAMES
-from ..workflow.handoff_artifacts import (
-    submit_architecture as write_architecture_submission,
-)
-from ..workflow.handoff_artifacts import (
-    submit_execution_plan as write_execution_plan_submission,
-)
-from ..workflow.handoff_artifacts import (
-    submit_review as write_review_submission,
-)
-from ..workflow.handoff_artifacts import (
-    submit_subplan as write_subplan_submission,
-)
+from ..runtime.tool_events import append_tool_event
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -50,6 +38,10 @@ def _feature_dir(feature_dir: str | None = None) -> Path:
     return path
 
 
+def _log_path(feature_dir: str | None = None) -> Path:
+    return _feature_dir(feature_dir) / "tool_events.jsonl"
+
+
 def _validate_topic(topic: str) -> str:
     normalized = topic.strip()
     if not normalized or not TOPIC_PATTERN.fullmatch(normalized):
@@ -78,93 +70,79 @@ def _normalize_scope_hints(scope_hints: str | list[str] | None) -> list[str] | N
     return cleaned or None
 
 
-def _research_dir(
-    topic: str, research_type: str, feature_dir: str | None = None
-) -> Path:
-    return (
-        _feature_dir(feature_dir)
-        / SESSION_DIR_NAMES["research"]
-        / f"{research_type}-{topic}"
-    )
+def _validate_or_raise(contract_name: str, data: dict[str, Any]) -> None:
+    """Validate data against the contract for the given name.
+
+    Raises ValueError with details if validation fails.
+    """
+    from ..workflow.handoff_contracts import ValidationError, validate_submission
+
+    try:
+        errors = validate_submission(contract_name, data)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+    if errors:
+        raise ValueError("; ".join(errors))
 
 
-def _request_content(
-    context: str, questions: list[str], scope_hints: list[str] | None
-) -> str:
-    lines = [
-        "## Context",
-        context.strip(),
-        "",
-        "## Questions",
-    ]
-    for index, question in enumerate(questions, start=1):
-        lines.append(f"{index}. {question}")
-
-    lines.extend(["", "## Scope hints"])
-    if scope_hints:
-        lines.extend(f"- {hint}" for hint in scope_hints)
-    else:
-        lines.append("- (none provided)")
-
-    return "\n".join(lines).rstrip() + "\n"
+# ---------------------------------------------------------------------------
+# Research dispatch tools
+# ---------------------------------------------------------------------------
 
 
-def _dispatch(
-    research_type: str,
+@_tool()
+def research_dispatch_code(
     topic: str,
     context: str,
     questions: list[str],
-    scope_hints: str | list[str] | None,
     feature_dir: str | None = None,
+    scope_hints: str | list[str] | None = None,
 ) -> str:
+    """Dispatch a code-research task."""
     normalized_topic = _validate_topic(topic)
     normalized_questions = _validate_questions(questions)
     normalized_scope_hints = _normalize_scope_hints(scope_hints)
-    directory = _research_dir(normalized_topic, research_type, feature_dir)
-    directory.mkdir(parents=True, exist_ok=True)
-
-    request_path = directory / "request.md"
-    request_path.write_text(
-        _request_content(context, normalized_questions, normalized_scope_hints),
-        encoding="utf-8",
-    )
-
-    label = "Code research" if research_type == "code" else "Web research"
-    return f"{label} on '{normalized_topic}' dispatched."
-
-
-def _result_content(topic: str, directory: Path, detail: bool) -> str:
-    filename = "detail.md" if detail else "summary.md"
-    target = directory / filename
-    if not target.exists():
-        return f"Research on '{topic}' completed but {filename} is missing."
-    return target.read_text(encoding="utf-8")
+    payload = {
+        "topic": normalized_topic,
+        "context": context.strip(),
+        "questions": normalized_questions,
+        "scope_hints": normalized_scope_hints,
+        "research_type": "code",
+    }
+    append_tool_event(_log_path(feature_dir), "research_dispatch_code", payload)
+    return f"Code research on '{normalized_topic}' dispatched."
 
 
 @_tool()
-def agentmux_research_dispatch_code(
+def research_dispatch_web(
     topic: str,
     context: str,
     questions: list[str],
     feature_dir: str | None = None,
     scope_hints: str | list[str] | None = None,
 ) -> str:
-    return _dispatch("code", topic, context, questions, scope_hints, feature_dir)
+    """Dispatch a web-research task."""
+    normalized_topic = _validate_topic(topic)
+    normalized_questions = _validate_questions(questions)
+    normalized_scope_hints = _normalize_scope_hints(scope_hints)
+    payload = {
+        "topic": normalized_topic,
+        "context": context.strip(),
+        "questions": normalized_questions,
+        "scope_hints": normalized_scope_hints,
+        "research_type": "web",
+    }
+    append_tool_event(_log_path(feature_dir), "research_dispatch_web", payload)
+    return f"Web research on '{normalized_topic}' dispatched."
+
+
+# ---------------------------------------------------------------------------
+# Submission tools
+# ---------------------------------------------------------------------------
 
 
 @_tool()
-def agentmux_research_dispatch_web(
-    topic: str,
-    context: str,
-    questions: list[str],
-    feature_dir: str | None = None,
-    scope_hints: str | list[str] | None = None,
-) -> str:
-    return _dispatch("web", topic, context, questions, scope_hints, feature_dir)
-
-
-@_tool()
-def agentmux_submit_architecture(
+def submit_architecture(
     solution_overview: str,
     components: list[dict[str, Any]],
     interfaces_and_contracts: str,
@@ -177,7 +155,7 @@ def agentmux_submit_architecture(
 ) -> str:
     """Submit architecture document.
 
-    Validates input, writes architecture.yaml + architecture.md.
+    Validates input and appends to tool_events.jsonl.
     """
     data: dict[str, Any] = {
         "solution_overview": solution_overview,
@@ -191,11 +169,13 @@ def agentmux_submit_architecture(
     if design_handoff is not None:
         data["design_handoff"] = design_handoff
 
-    return write_architecture_submission(_feature_dir(feature_dir), data)
+    _validate_or_raise("architecture", data)
+    append_tool_event(_log_path(feature_dir), "submit_architecture", data)
+    return "Architecture submitted."
 
 
 @_tool()
-def agentmux_submit_execution_plan(
+def submit_execution_plan(
     groups: list[dict[str, Any]],
     review_strategy: dict[str, Any],
     needs_design: bool,
@@ -204,7 +184,7 @@ def agentmux_submit_execution_plan(
     plan_overview: str,
     feature_dir: str | None = None,
 ) -> str:
-    """Submit the execution plan. Validates and writes execution_plan.yaml + plan.md."""
+    """Submit the execution plan. Validates and appends to tool_events.jsonl."""
     data: dict[str, Any] = {
         "groups": groups,
         "review_strategy": review_strategy,
@@ -214,11 +194,13 @@ def agentmux_submit_execution_plan(
         "plan_overview": plan_overview,
     }
 
-    return write_execution_plan_submission(_feature_dir(feature_dir), data)
+    _validate_or_raise("execution_plan", data)
+    append_tool_event(_log_path(feature_dir), "submit_execution_plan", data)
+    return "Execution plan submitted."
 
 
 @_tool()
-def agentmux_submit_subplan(
+def submit_subplan(
     index: int,
     title: str,
     scope: str,
@@ -230,10 +212,7 @@ def agentmux_submit_subplan(
     feature_dir: str | None = None,
     isolation_rationale: str | None = None,
 ) -> str:
-    """Submit a sub-plan.
-
-    Validates and writes plan_N.yaml, plan_N.md, tasks_N.md.
-    """
+    """Submit a sub-plan. Validates and appends to tool_events.jsonl."""
     data: dict[str, Any] = {
         "index": index,
         "title": title,
@@ -247,18 +226,20 @@ def agentmux_submit_subplan(
     if isolation_rationale is not None:
         data["isolation_rationale"] = isolation_rationale
 
-    return write_subplan_submission(_feature_dir(feature_dir), data)
+    _validate_or_raise("subplan", data)
+    append_tool_event(_log_path(feature_dir), "submit_subplan", data)
+    return f"Sub-plan {index} submitted."
 
 
 @_tool()
-def agentmux_submit_review(
+def submit_review(
     verdict: str,
     summary: str,
     feature_dir: str | None = None,
     findings: list[dict[str, Any]] | None = None,
     commit_message: str | None = None,
 ) -> str:
-    """Submit a code review. Validates and writes review.yaml + review.md."""
+    """Submit a code review. Validates and appends to tool_events.jsonl."""
     data: dict[str, Any] = {
         "verdict": verdict,
         "summary": summary,
@@ -268,7 +249,55 @@ def agentmux_submit_review(
     if commit_message is not None:
         data["commit_message"] = commit_message
 
-    return write_review_submission(_feature_dir(feature_dir), data)
+    _validate_or_raise("review", data)
+    append_tool_event(_log_path(feature_dir), "submit_review", data)
+    return f"Review submitted (verdict: {verdict})."
+
+
+# ---------------------------------------------------------------------------
+# Completion-signal tools
+# ---------------------------------------------------------------------------
+
+
+@_tool()
+def submit_done(
+    subplan_index: int,
+    feature_dir: str | None = None,
+) -> str:
+    """Mark a sub-plan as done."""
+    if not isinstance(subplan_index, int) or subplan_index < 1:
+        raise ValueError("subplan_index must be an integer >= 1.")
+    append_tool_event(
+        _log_path(feature_dir), "submit_done", {"subplan_index": subplan_index}
+    )
+    return f"Sub-plan {subplan_index} marked done."
+
+
+@_tool()
+def submit_research_done(
+    topic: str,
+    type: str,
+    feature_dir: str | None = None,
+) -> str:
+    """Mark a research task as done."""
+    normalized = _validate_topic(topic)
+    if type not in ("code", "web"):
+        raise ValueError("type must be 'code' or 'web'.")
+    append_tool_event(
+        _log_path(feature_dir),
+        "submit_research_done",
+        {"topic": normalized, "type": type},
+    )
+    return f"Research on '{normalized}' ({type}) marked done."
+
+
+@_tool()
+def submit_pm_done(
+    feature_dir: str | None = None,
+) -> str:
+    """Mark the product management phase as done."""
+    append_tool_event(_log_path(feature_dir), "submit_pm_done", {})
+    return "Product management phase done."
 
 
 if __name__ == "__main__":

--- a/src/agentmux/integrations/mcp_research_server.py
+++ b/src/agentmux/integrations/mcp_research_server.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 from ..shared.models import SESSION_DIR_NAMES
+from ..workflow.handoff_contracts import validate_submission
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -148,6 +152,292 @@ def agentmux_research_dispatch_web(
     scope_hints: str | list[str] | None = None,
 ) -> str:
     return _dispatch("web", topic, context, questions, scope_hints, feature_dir)
+
+
+# ---------------------------------------------------------------------------
+# Handoff submission helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    """Write data as YAML, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = yaml.dump(data, default_flow_style=False, sort_keys=False)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_md(path: Path, content: str) -> None:
+    """Write markdown content, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _validate_or_raise(contract_name: str, data: dict[str, Any]) -> None:
+    """Validate data against contract; raise on failure."""
+    errors = validate_submission(contract_name, data)
+    if errors:
+        raise ValueError(
+            f"Validation failed for '{contract_name}': " + "; ".join(errors)
+        )
+
+
+def _generate_architecture_md(data: dict[str, Any]) -> str:
+    """Generate human-readable markdown from architecture data."""
+    lines = ["# Architecture", ""]
+    lines.extend(["## Solution Overview", "", data["solution_overview"].strip(), ""])
+
+    lines.append("## Components")
+    lines.append("")
+    for comp in data["components"]:
+        lines.append(f"### {comp['name']}")
+        lines.append("")
+        lines.append(f"**Responsibility:** {comp['responsibility']}")
+        interfaces = comp.get("interfaces")
+        if interfaces:
+            lines.append("")
+            lines.append("**Interfaces:**")
+            for iface in interfaces:
+                lines.append(f"- {iface}")
+        lines.append("")
+
+    for section, key in [
+        ("Interfaces and Contracts", "interfaces_and_contracts"),
+        ("Data Models", "data_models"),
+        ("Cross-Cutting Concerns", "cross_cutting_concerns"),
+        ("Technology Choices", "technology_choices"),
+        ("Risks and Mitigations", "risks_and_mitigations"),
+    ]:
+        lines.extend([f"## {section}", "", data[key].strip(), ""])
+
+    if data.get("design_handoff"):
+        lines.extend(["## Design Handoff", "", data["design_handoff"].strip(), ""])
+
+    return "\n".join(lines)
+
+
+def _generate_plan_md(data: dict[str, Any]) -> str:
+    """Generate plan.md from plan_overview content."""
+    return data["plan_overview"].strip() + "\n"
+
+
+def _generate_subplan_md(data: dict[str, Any]) -> str:
+    """Generate plan_N.md from subplan data."""
+    lines = [f"# {data['title']}", ""]
+    lines.extend(["## Scope", "", data["scope"].strip(), ""])
+    lines.extend(["## Owned Files", ""])
+    for f in data["owned_files"]:
+        lines.append(f"- `{f}`")
+    lines.append("")
+    lines.extend(["## Dependencies", "", data["dependencies"].strip(), ""])
+    lines.extend(
+        ["## Implementation Approach", "", data["implementation_approach"].strip(), ""]
+    )
+    lines.extend(
+        ["## Acceptance Criteria", "", data["acceptance_criteria"].strip(), ""]
+    )
+    if data.get("isolation_rationale"):
+        lines.extend(
+            ["## Isolation Rationale", "", data["isolation_rationale"].strip(), ""]
+        )
+    return "\n".join(lines)
+
+
+def _generate_tasks_md(data: dict[str, Any]) -> str:
+    """Generate tasks_N.md checklist from subplan tasks."""
+    lines = [f"# Tasks: {data['title']}", ""]
+    for task in data["tasks"]:
+        lines.append(f"- [ ] {task}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_review_md(data: dict[str, Any]) -> str:
+    """Generate review.md with verdict on first line for handler compat."""
+    verdict = data["verdict"]
+    lines = [f"verdict: {verdict}", ""]
+    lines.extend(["## Summary", "", data["summary"].strip(), ""])
+
+    if verdict == "fail" and data.get("findings"):
+        lines.append("## Findings")
+        lines.append("")
+        for i, finding in enumerate(data["findings"], 1):
+            lines.append(f"### Finding {i}")
+            lines.append("")
+            if finding.get("location"):
+                lines.append(f"**Location:** `{finding['location']}`")
+            lines.append(f"**Issue:** {finding['issue']}")
+            if finding.get("severity"):
+                lines.append(f"**Severity:** {finding['severity']}")
+            lines.append(f"**Recommendation:** {finding['recommendation']}")
+            lines.append("")
+
+    if verdict == "pass" and data.get("commit_message"):
+        lines.extend(
+            ["## Suggested Commit Message", "", data["commit_message"].strip(), ""]
+        )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# MCP submission tools
+# ---------------------------------------------------------------------------
+
+
+@_tool()
+def agentmux_submit_architecture(
+    solution_overview: str,
+    components: list[dict[str, Any]],
+    interfaces_and_contracts: str,
+    data_models: str,
+    cross_cutting_concerns: str,
+    technology_choices: str,
+    risks_and_mitigations: str,
+    feature_dir: str | None = None,
+    design_handoff: str | None = None,
+) -> str:
+    """Submit architecture document.
+
+    Validates input, writes architecture.yaml + architecture.md.
+    """
+    data: dict[str, Any] = {
+        "solution_overview": solution_overview,
+        "components": components,
+        "interfaces_and_contracts": interfaces_and_contracts,
+        "data_models": data_models,
+        "cross_cutting_concerns": cross_cutting_concerns,
+        "technology_choices": technology_choices,
+        "risks_and_mitigations": risks_and_mitigations,
+    }
+    if design_handoff is not None:
+        data["design_handoff"] = design_handoff
+
+    _validate_or_raise("architecture", data)
+
+    fdir = _feature_dir(feature_dir)
+    planning_dir = fdir / SESSION_DIR_NAMES["planning"]
+    planning_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_yaml(planning_dir / "architecture.yaml", data)
+    _write_md(planning_dir / "architecture.md", _generate_architecture_md(data))
+
+    return "Architecture submitted. Files: architecture.yaml, architecture.md"
+
+
+@_tool()
+def agentmux_submit_execution_plan(
+    groups: list[dict[str, Any]],
+    review_strategy: dict[str, Any],
+    needs_design: bool,
+    needs_docs: bool,
+    doc_files: list[str],
+    plan_overview: str,
+    feature_dir: str | None = None,
+) -> str:
+    """Submit the execution plan. Validates and writes execution_plan.yaml + plan.md."""
+    data: dict[str, Any] = {
+        "groups": groups,
+        "review_strategy": review_strategy,
+        "needs_design": needs_design,
+        "needs_docs": needs_docs,
+        "doc_files": doc_files,
+        "plan_overview": plan_overview,
+    }
+
+    _validate_or_raise("execution_plan", data)
+
+    fdir = _feature_dir(feature_dir)
+    planning_dir = fdir / SESSION_DIR_NAMES["planning"]
+    planning_dir.mkdir(parents=True, exist_ok=True)
+
+    yaml_data = {
+        "version": 1,
+        "review_strategy": review_strategy,
+        "needs_design": needs_design,
+        "needs_docs": needs_docs,
+        "doc_files": doc_files,
+        "groups": groups,
+    }
+    _write_yaml(planning_dir / "execution_plan.yaml", yaml_data)
+    _write_md(planning_dir / "plan.md", _generate_plan_md(data))
+
+    return "Execution plan submitted. Files: execution_plan.yaml, plan.md"
+
+
+@_tool()
+def agentmux_submit_subplan(
+    index: int,
+    title: str,
+    scope: str,
+    owned_files: list[str],
+    dependencies: str,
+    implementation_approach: str,
+    acceptance_criteria: str,
+    tasks: list[str],
+    feature_dir: str | None = None,
+    isolation_rationale: str | None = None,
+) -> str:
+    """Submit a sub-plan.
+
+    Validates and writes plan_N.yaml, plan_N.md, tasks_N.md.
+    """
+    data: dict[str, Any] = {
+        "index": index,
+        "title": title,
+        "scope": scope,
+        "owned_files": owned_files,
+        "dependencies": dependencies,
+        "implementation_approach": implementation_approach,
+        "acceptance_criteria": acceptance_criteria,
+        "tasks": tasks,
+    }
+    if isolation_rationale is not None:
+        data["isolation_rationale"] = isolation_rationale
+
+    _validate_or_raise("subplan", data)
+
+    fdir = _feature_dir(feature_dir)
+    planning_dir = fdir / SESSION_DIR_NAMES["planning"]
+    planning_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_yaml(planning_dir / f"plan_{index}.yaml", data)
+    _write_md(planning_dir / f"plan_{index}.md", _generate_subplan_md(data))
+    _write_md(planning_dir / f"tasks_{index}.md", _generate_tasks_md(data))
+
+    return (
+        f"Sub-plan {index} submitted. "
+        f"Files: plan_{index}.yaml, plan_{index}.md, tasks_{index}.md"
+    )
+
+
+@_tool()
+def agentmux_submit_review(
+    verdict: str,
+    summary: str,
+    feature_dir: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
+    commit_message: str | None = None,
+) -> str:
+    """Submit a code review. Validates and writes review.yaml + review.md."""
+    data: dict[str, Any] = {
+        "verdict": verdict,
+        "summary": summary,
+    }
+    if findings is not None:
+        data["findings"] = findings
+    if commit_message is not None:
+        data["commit_message"] = commit_message
+
+    _validate_or_raise("review", data)
+
+    fdir = _feature_dir(feature_dir)
+    review_dir = fdir / SESSION_DIR_NAMES["review"]
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_yaml(review_dir / "review.yaml", data)
+    _write_md(review_dir / "review.md", _generate_review_md(data))
+
+    return f"Review submitted (verdict: {verdict}). Files: review.yaml, review.md"
 
 
 if __name__ == "__main__":

--- a/src/agentmux/integrations/mcp_research_server.py
+++ b/src/agentmux/integrations/mcp_research_server.py
@@ -5,10 +5,19 @@ import re
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from ..shared.models import SESSION_DIR_NAMES
-from ..workflow.handoff_contracts import validate_submission
+from ..workflow.handoff_artifacts import (
+    submit_architecture as write_architecture_submission,
+)
+from ..workflow.handoff_artifacts import (
+    submit_execution_plan as write_execution_plan_submission,
+)
+from ..workflow.handoff_artifacts import (
+    submit_review as write_review_submission,
+)
+from ..workflow.handoff_artifacts import (
+    submit_subplan as write_subplan_submission,
+)
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -154,136 +163,6 @@ def agentmux_research_dispatch_web(
     return _dispatch("web", topic, context, questions, scope_hints, feature_dir)
 
 
-# ---------------------------------------------------------------------------
-# Handoff submission helpers
-# ---------------------------------------------------------------------------
-
-
-def _write_yaml(path: Path, data: dict[str, Any]) -> None:
-    """Write data as YAML, creating parent directories."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    content = yaml.dump(data, default_flow_style=False, sort_keys=False)
-    path.write_text(content, encoding="utf-8")
-
-
-def _write_md(path: Path, content: str) -> None:
-    """Write markdown content, creating parent directories."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-
-
-def _validate_or_raise(contract_name: str, data: dict[str, Any]) -> None:
-    """Validate data against contract; raise on failure."""
-    errors = validate_submission(contract_name, data)
-    if errors:
-        raise ValueError(
-            f"Validation failed for '{contract_name}': " + "; ".join(errors)
-        )
-
-
-def _generate_architecture_md(data: dict[str, Any]) -> str:
-    """Generate human-readable markdown from architecture data."""
-    lines = ["# Architecture", ""]
-    lines.extend(["## Solution Overview", "", data["solution_overview"].strip(), ""])
-
-    lines.append("## Components")
-    lines.append("")
-    for comp in data["components"]:
-        lines.append(f"### {comp['name']}")
-        lines.append("")
-        lines.append(f"**Responsibility:** {comp['responsibility']}")
-        interfaces = comp.get("interfaces")
-        if interfaces:
-            lines.append("")
-            lines.append("**Interfaces:**")
-            for iface in interfaces:
-                lines.append(f"- {iface}")
-        lines.append("")
-
-    for section, key in [
-        ("Interfaces and Contracts", "interfaces_and_contracts"),
-        ("Data Models", "data_models"),
-        ("Cross-Cutting Concerns", "cross_cutting_concerns"),
-        ("Technology Choices", "technology_choices"),
-        ("Risks and Mitigations", "risks_and_mitigations"),
-    ]:
-        lines.extend([f"## {section}", "", data[key].strip(), ""])
-
-    if data.get("design_handoff"):
-        lines.extend(["## Design Handoff", "", data["design_handoff"].strip(), ""])
-
-    return "\n".join(lines)
-
-
-def _generate_plan_md(data: dict[str, Any]) -> str:
-    """Generate plan.md from plan_overview content."""
-    return data["plan_overview"].strip() + "\n"
-
-
-def _generate_subplan_md(data: dict[str, Any]) -> str:
-    """Generate plan_N.md from subplan data."""
-    lines = [f"# {data['title']}", ""]
-    lines.extend(["## Scope", "", data["scope"].strip(), ""])
-    lines.extend(["## Owned Files", ""])
-    for f in data["owned_files"]:
-        lines.append(f"- `{f}`")
-    lines.append("")
-    lines.extend(["## Dependencies", "", data["dependencies"].strip(), ""])
-    lines.extend(
-        ["## Implementation Approach", "", data["implementation_approach"].strip(), ""]
-    )
-    lines.extend(
-        ["## Acceptance Criteria", "", data["acceptance_criteria"].strip(), ""]
-    )
-    if data.get("isolation_rationale"):
-        lines.extend(
-            ["## Isolation Rationale", "", data["isolation_rationale"].strip(), ""]
-        )
-    return "\n".join(lines)
-
-
-def _generate_tasks_md(data: dict[str, Any]) -> str:
-    """Generate tasks_N.md checklist from subplan tasks."""
-    lines = [f"# Tasks: {data['title']}", ""]
-    for task in data["tasks"]:
-        lines.append(f"- [ ] {task}")
-    lines.append("")
-    return "\n".join(lines)
-
-
-def _generate_review_md(data: dict[str, Any]) -> str:
-    """Generate review.md with verdict on first line for handler compat."""
-    verdict = data["verdict"]
-    lines = [f"verdict: {verdict}", ""]
-    lines.extend(["## Summary", "", data["summary"].strip(), ""])
-
-    if verdict == "fail" and data.get("findings"):
-        lines.append("## Findings")
-        lines.append("")
-        for i, finding in enumerate(data["findings"], 1):
-            lines.append(f"### Finding {i}")
-            lines.append("")
-            if finding.get("location"):
-                lines.append(f"**Location:** `{finding['location']}`")
-            lines.append(f"**Issue:** {finding['issue']}")
-            if finding.get("severity"):
-                lines.append(f"**Severity:** {finding['severity']}")
-            lines.append(f"**Recommendation:** {finding['recommendation']}")
-            lines.append("")
-
-    if verdict == "pass" and data.get("commit_message"):
-        lines.extend(
-            ["## Suggested Commit Message", "", data["commit_message"].strip(), ""]
-        )
-
-    return "\n".join(lines)
-
-
-# ---------------------------------------------------------------------------
-# MCP submission tools
-# ---------------------------------------------------------------------------
-
-
 @_tool()
 def agentmux_submit_architecture(
     solution_overview: str,
@@ -312,16 +191,7 @@ def agentmux_submit_architecture(
     if design_handoff is not None:
         data["design_handoff"] = design_handoff
 
-    _validate_or_raise("architecture", data)
-
-    fdir = _feature_dir(feature_dir)
-    planning_dir = fdir / SESSION_DIR_NAMES["planning"]
-    planning_dir.mkdir(parents=True, exist_ok=True)
-
-    _write_yaml(planning_dir / "architecture.yaml", data)
-    _write_md(planning_dir / "architecture.md", _generate_architecture_md(data))
-
-    return "Architecture submitted. Files: architecture.yaml, architecture.md"
+    return write_architecture_submission(_feature_dir(feature_dir), data)
 
 
 @_tool()
@@ -344,24 +214,7 @@ def agentmux_submit_execution_plan(
         "plan_overview": plan_overview,
     }
 
-    _validate_or_raise("execution_plan", data)
-
-    fdir = _feature_dir(feature_dir)
-    planning_dir = fdir / SESSION_DIR_NAMES["planning"]
-    planning_dir.mkdir(parents=True, exist_ok=True)
-
-    yaml_data = {
-        "version": 1,
-        "review_strategy": review_strategy,
-        "needs_design": needs_design,
-        "needs_docs": needs_docs,
-        "doc_files": doc_files,
-        "groups": groups,
-    }
-    _write_yaml(planning_dir / "execution_plan.yaml", yaml_data)
-    _write_md(planning_dir / "plan.md", _generate_plan_md(data))
-
-    return "Execution plan submitted. Files: execution_plan.yaml, plan.md"
+    return write_execution_plan_submission(_feature_dir(feature_dir), data)
 
 
 @_tool()
@@ -394,20 +247,7 @@ def agentmux_submit_subplan(
     if isolation_rationale is not None:
         data["isolation_rationale"] = isolation_rationale
 
-    _validate_or_raise("subplan", data)
-
-    fdir = _feature_dir(feature_dir)
-    planning_dir = fdir / SESSION_DIR_NAMES["planning"]
-    planning_dir.mkdir(parents=True, exist_ok=True)
-
-    _write_yaml(planning_dir / f"plan_{index}.yaml", data)
-    _write_md(planning_dir / f"plan_{index}.md", _generate_subplan_md(data))
-    _write_md(planning_dir / f"tasks_{index}.md", _generate_tasks_md(data))
-
-    return (
-        f"Sub-plan {index} submitted. "
-        f"Files: plan_{index}.yaml, plan_{index}.md, tasks_{index}.md"
-    )
+    return write_subplan_submission(_feature_dir(feature_dir), data)
 
 
 @_tool()
@@ -428,16 +268,7 @@ def agentmux_submit_review(
     if commit_message is not None:
         data["commit_message"] = commit_message
 
-    _validate_or_raise("review", data)
-
-    fdir = _feature_dir(feature_dir)
-    review_dir = fdir / SESSION_DIR_NAMES["review"]
-    review_dir.mkdir(parents=True, exist_ok=True)
-
-    _write_yaml(review_dir / "review.yaml", data)
-    _write_md(review_dir / "review.md", _generate_review_md(data))
-
-    return f"Review submitted (verdict: {verdict}). Files: review.yaml, review.md"
+    return write_review_submission(_feature_dir(feature_dir), data)
 
 
 if __name__ == "__main__":

--- a/src/agentmux/pipeline/init_command.py
+++ b/src/agentmux/pipeline/init_command.py
@@ -13,7 +13,8 @@ import yaml
 
 from ..configuration import load_builtin_catalog, load_layered_config
 from ..integrations.mcp import (
-    McpServerSpec,
+    DEFAULT_RESEARCH_ROLES,
+    DEFAULT_RESEARCH_SERVERS,
     ensure_mcp_config,
 )
 from ..integrations.opencode_agents import OpenCodeAgentConfigurator
@@ -730,14 +731,8 @@ def run_init(defaults_mode: bool = False) -> int:
         loaded = load_layered_config(project_dir)
         ensure_mcp_config(
             loaded.agents,
-            [
-                McpServerSpec(
-                    name="agentmux-research",
-                    module="agentmux.integrations.mcp_research_server",
-                    env={},
-                )
-            ],
-            ("architect", "product-manager"),
+            list(DEFAULT_RESEARCH_SERVERS),
+            DEFAULT_RESEARCH_ROLES,
             project_dir,
             interactive=True,
             output=sys.stdout,
@@ -771,14 +766,8 @@ def run_init_provider(
         print("No additional setup needed for copilot")
         return 0
 
-    server = McpServerSpec(
-        name="agentmux-research",
-        module="agentmux.integrations.mcp_research_server",
-        env={},
-    )
-
     # Build minimal agents dict so _required_configurators selects the right MCP backend
-    _mcp_roles = ("architect", "product-manager")
+    _mcp_roles = DEFAULT_RESEARCH_ROLES
     _dummy = {
         r: AgentConfig(role=r, cli=provider, model="", provider=provider)
         for r in _mcp_roles
@@ -788,7 +777,7 @@ def run_init_provider(
     if provider == "opencode":
         ensure_mcp_config(
             _dummy,
-            [server],
+            list(DEFAULT_RESEARCH_SERVERS),
             _mcp_roles,
             project_dir,
             interactive=False,
@@ -798,7 +787,7 @@ def run_init_provider(
         # Non-opencode: MCP at home level
         ensure_mcp_config(
             _dummy,
-            [server],
+            list(DEFAULT_RESEARCH_SERVERS),
             _mcp_roles,
             Path.home(),
             interactive=False,

--- a/src/agentmux/prompts/agents/architect.md
+++ b/src/agentmux/prompts/agents/architect.md
@@ -14,6 +14,11 @@ Approved preference proposal artifact: [[placeholder:architect_preference_propos
 
 [[include-optional:01_product_management/analysis.md]]
 
+## Identity & Vision
+
+You design the technical foundation — the "What" and "With what".
+Good architecture means clear component boundaries, single responsibilities per component, loose coupling through defined interfaces, and decisions that remain maintainable as the codebase grows. Every design choice must be explainable and its trade-offs documented.
+
 ## Research
 
 Before drafting the architecture, assess what you need to know about the codebase or external landscape.
@@ -50,14 +55,21 @@ Use a JSON-style array for `scope_hints`, not a single string. Example:
    - **Cross-cutting concerns** — error handling strategy, logging, security, testing approach, observability
    - **Technology choices** — libraries, frameworks, patterns and rationale
    - **Risks & constraints** — known limitations, technical debt, open questions
-   - **Design handoff** — include a `needs_design: true` note here if the PM analysis flagged that UI/visual design work is needed, so the planner can set this flag in `plan_meta.json`
+   - **Design handoff** — include a `needs_design: true` note here if the PM analysis flagged that UI/visual design work is needed, so the planner can set this flag in `execution_plan.yaml`
 4. Do not define the execution schedule. Do not create implementation phases, sub-plans, task lists, or parallel lanes — that is the planner's job.
 5. Do not implement code, run implementation validation, or produce UI design artifacts.
 6. When presenting the architectural draft, use the `[[placeholder:user_ask_tool]]` tool to ask for feedback and approval. Incorporate any feedback and revise as needed. Repeat until the user explicitly approves.
 7. Only after the user explicitly approves (e.g. says 'approved', 'looks good', 'go ahead'), write the final architecture to `02_planning/architecture.md`. Only include chosen Options, you MUST omit options that were discarded.
 8. FINAL STEP ONLY — after writing `02_planning/architecture.md`, stop. Do not update `state.json` or any workflow status.
 
-## Preference memory at phase-end approval
+## Output & Artifacts
+
+- `02_planning/architecture.md` — technical architecture. Required sections: Solution Overview, Components & Responsibilities, Interfaces & Contracts, Data Models, Cross-cutting Concerns, Technology Choices, Risks & Constraints. Only include chosen options — omit discarded alternatives.
+- `[[placeholder:architect_preference_proposal_file]]` — JSON, optional; only write if preference candidates are approved.
+
+[[shared:handoff-contract-architecture]]
+
+## Preference Memory
 
 [[shared:preference-memory]]
 
@@ -69,10 +81,10 @@ Architect preference proposal output:
 
 [[placeholder:project_instructions]]
 
-Constraints:
+## Constraints
 - Focus exclusively on the technical design (components, interfaces, data models, cross-cutting concerns). Leave scheduling and task breakdown to the planner.
 - Do not write `02_planning/architecture.md` before the user approves the architectural draft.
-- Do not write any plan files (`plan.md`, `plan_<N>.md`, `execution_plan.json`, `tasks_<N>.md`, `plan_meta.json`).
+- Do not write any plan files (`plan.md`, `plan_<N>.md`, `execution_plan.yaml`, `tasks_<N>.md`).
 - Do not update `state.json` from the architect step.
 - When a topic requires reading more than 3 project files or exploring code patterns you are unfamiliar with, delegate to code-researcher instead of exploring directly.
 - Never use built-in web search or code-exploration tools for research.

--- a/src/agentmux/prompts/agents/architect.md
+++ b/src/agentmux/prompts/agents/architect.md
@@ -26,17 +26,19 @@ Before drafting the architecture, assess what you need to know about the codebas
 **Look it up yourself** when reading 1–3 specific files whose paths you already know (e.g. checking a function signature, a config schema). Do this directly with your file-reading tool.
 
 **Delegate to code-researcher** for anything requiring broad exploration — tracing a feature across modules, understanding patterns you haven't seen, surveying all usages of something:
-1. Call `agentmux_research_dispatch_code` with your topic, context, `questions=[...]`, `feature_dir="[[placeholder:feature_dir]]"`, and `scope_hints=[...]`.
+1. Call `research_dispatch_code` with your topic, context, `questions=[...]`, `feature_dir="[[placeholder:feature_dir]]"`, and `scope_hints=[...]`.
 2. After dispatching, stop and wait idle. Do not poll and do not call another MCP wait tool.
 3. AgentMux will send you a follow-up message when research is complete.
 4. When that message arrives, read `03_research/code-<topic>/summary.md` first and `03_research/code-<topic>/detail.md` only if needed.
 
 **Delegate to web-researcher** for external information — library APIs, version compatibility, ecosystem best practices:
-1. Call `agentmux_research_dispatch_web` with your topic, context, `questions=[...]`, `feature_dir="[[placeholder:feature_dir]]"`, and `scope_hints=[...]`.
+1. Call `research_dispatch_web` with your topic, context, `questions=[...]`, `feature_dir="[[placeholder:feature_dir]]"`, and `scope_hints=[...]`.
 2. After dispatching, stop and wait idle for AgentMux to notify you that the result files are ready.
 3. Then read `03_research/web-<topic>/summary.md` first and `03_research/web-<topic>/detail.md` if needed.
 
 You can dispatch multiple topics before going idle. Research tasks run in parallel.
+
+When all your research tasks are complete, call `submit_research_done` to signal to the orchestrator that you are ready to proceed.
 
 Use a JSON-style array for `scope_hints`, not a single string. Example:
 `scope_hints=["agent prompts", "planning tests", "ignore runtime internals"]`

--- a/src/agentmux/prompts/agents/coder.md
+++ b/src/agentmux/prompts/agents/coder.md
@@ -27,6 +27,7 @@ Your job:
 When your assigned task checklist includes documentation tasks, complete them as part of implementation in this coder step.
 Do not defer documentation to a separate docs agent or post-review docs phase.
 [[shared:coder-discipline]]
+12. When your sub-plan implementation is complete, call `submit_done(subplan_index=N)` to signal completion to the orchestrator.
 13. If implementation reveals that requirements or the plan need adjustment (e.g. a requirement turns out to be infeasible as written, or a task needs to be split or reordered), update `requirements.md` and `[[placeholder:plan_file]]` / `[[placeholder:tasks_file]]` accordingly so they stay in sync with reality.
 14. [[placeholder:completion_instruction]]
 

--- a/src/agentmux/prompts/agents/planner.md
+++ b/src/agentmux/prompts/agents/planner.md
@@ -12,9 +12,11 @@ Approved preference proposal artifact: [[placeholder:planner_preference_proposal
 [[include:02_planning/architecture.md]]
 </file>
 
-## Your Role
+## Identity & Vision
 
-You are the **Execution Planner** (Ausführungsplaner). You receive a completed architecture document as input. Your ONLY task is to transform this technical design into a structured, chronological execution plan.
+You translate architecture into a chronological, testable execution plan — the "How" and "When".
+Your work is done when a coder can pick up a sub-plan and implement it end-to-end without ambiguity.
+Good plans minimize blockers, maximize parallel work, and leave no task scope open to interpretation.
 
 **CRITICAL CONSTRAINT:** Verändere niemals die Architektur. Nimm das Design als absolute Wahrheit. Do not modify the architecture. Take the design as absolute truth.
 
@@ -42,16 +44,35 @@ You are the **Execution Planner** (Ausführungsplaner). You receive a completed 
 * **Technical Debt:** Explicitly note any deferred refactors.
 
 ### **5. Final Artifact Generation (Post-Approval)**
-Write the following to `02_planning/`:
-1.  **`plan.md`**: Human-readable overview.
-2.  **`plan_<N>.md` & `tasks_<N>.md`**: Detailed specs and testable units for each sub-plan.
-3.  **`execution_plan.json`**: Machine-readable schedule.
-    * *Schema:* `{"version": 1, "groups": [{"group_id": "str", "mode": "serial|parallel", "plans": [{"file": "plan_N.md", "name": "Title"}]}]}`
-4.  **`plan_meta.json`**: Risk and doc metadata.
-    * *Schema:* `{"needs_design": bool, "needs_docs": bool, "doc_files": [], "review_strategy": {"severity": "low|medium|high", "focus": []}}`
 
+See Output & Artifacts below for file specs. Write all files to `02_planning/` after explicit user approval.
 
-## Preference memory at phase-end approval
+## Output & Artifacts
+
+- **`02_planning/plan.md`** — human-readable overview of all phases and sub-plans.
+- **`02_planning/plan_<N>.md`** — detailed spec per sub-plan: Scope, Owned Files/Modules, Dependencies, Isolation rationale.
+- **`02_planning/tasks_<N>.md`** — testable task checklist per sub-plan.
+- **`02_planning/execution_plan.yaml`** — merged machine-readable schedule and metadata.
+  ```yaml
+  version: 1
+  review_strategy:
+    severity: low|medium|high
+    focus: []
+  needs_design: true|false
+  needs_docs: true|false
+  doc_files: []
+  groups:
+    - group_id: "str"
+      mode: serial|parallel
+      plans:
+        - file: plan_N.md
+          name: "Title"
+  ```
+- **`[[placeholder:planner_preference_proposal_file]]`** — JSON, optional; only write if preference candidates are approved.
+
+[[shared:handoff-contract-plan]]
+
+## Preference Memory
 
 [[shared:preference-memory]]
 
@@ -63,8 +84,8 @@ Planner preference proposal output:
 
 [[placeholder:project_instructions]]
 
-Constraints:
+## Constraints
 - Take the architecture document as absolute truth — do not modify it.
 - Create actionable, implementation-oriented plans only (the "How" and "When").
-- Do not write to `02_planning/plan.md`/`02_planning/plan_<N>.md`/`02_planning/execution_plan.json`/`02_planning/tasks.md`/`02_planning/plan_meta.json` before the user approves.
+- Do not write to `02_planning/plan.md`/`02_planning/plan_<N>.md`/`02_planning/execution_plan.yaml`/`02_planning/tasks.md` before the user approves.
 - Do not update `state.json` from the planner planning step.

--- a/src/agentmux/prompts/agents/product-manager.md
+++ b/src/agentmux/prompts/agents/product-manager.md
@@ -16,13 +16,15 @@ Approved preference proposal artifact: [[placeholder:pm_preference_proposal_file
 
 Before finalizing recommendations, assess what you need to know about the codebase or external landscape.
 
-- Use `agentmux_research_dispatch_code` for codebase exploration requests, always pass `feature_dir="[[placeholder:feature_dir]]"`, and format `scope_hints` as `["...", "..."]`.
-- Use `agentmux_research_dispatch_web` for external research requests, always pass `feature_dir="[[placeholder:feature_dir]]"`, and format `scope_hints` as `["...", "..."]`.
+- Use `research_dispatch_code` for codebase exploration requests, always pass `feature_dir="[[placeholder:feature_dir]]"`, and format `scope_hints` as `["...", "..."]`.
+- Use `research_dispatch_web` for external research requests, always pass `feature_dir="[[placeholder:feature_dir]]"`, and format `scope_hints` as `["...", "..."]`.
 - After dispatching, stop and wait idle. Do not poll and do not call a blocking MCP wait tool.
 - AgentMux will send you a follow-up message when the result files are ready.
 - Read `summary.md` first, then `detail.md` when needed.
 
 You can dispatch multiple topics before going idle. Research tasks run in parallel.
+
+When your product management deliverable is ready, call `submit_pm_done` to signal completion to the orchestrator.
 
 Example:
 `scope_hints=["user-facing docs", "config tests", "ignore unrelated runtime internals"]`

--- a/src/agentmux/prompts/agents/reviewer_expert.md
+++ b/src/agentmux/prompts/agents/reviewer_expert.md
@@ -12,6 +12,11 @@ Approved preference proposal artifact (confirmation step): [[placeholder:reviewe
 [[include:02_planning/architecture.md]]
 </file>
 
+## Identity & Vision
+
+You look for what others miss.
+Your quality standard is thoroughness: security vulnerabilities, performance bottlenecks, race conditions, and edge cases that only emerge under scrutiny. Take your time — a missed vulnerability is worse than a slow review.
+
 ## Your Specialization
 
 You focus **exclusively** on security vulnerabilities, performance issues, edge cases, race conditions, and other deep technical concerns.
@@ -26,7 +31,13 @@ You focus **exclusively** on security vulnerabilities, performance issues, edge 
 
 **Constraint:** Deep analysis mode — investigate thoroughly: race conditions, SQL injection, efficient queries, error handling paths, exception management, resource leaks, concurrency issues.
 
-## Preference-capture rules for the final confirmation step:
+## Output & Artifacts
+
+- `06_review/review.md` — verdict (pass/fail) with security/performance findings and guidance for the coder if fail.
+- `08_completion/confirmation_prompt.md` — confirmation prompt for the user (confirmation step only).
+- `[[placeholder:reviewer_preference_proposal_file]]` — JSON, optional; only write if candidates are approved.
+
+## Preference Memory
 
 [[shared:preference-memory]]
 
@@ -36,7 +47,7 @@ Reviewer preference proposal output:
 
 [[placeholder:project_instructions]]
 
-Constraints:
+## Constraints
 - Keep review and confirmation guidance aligned with security/performance requirements from plan.
 - Do not mix implementation verdicting with preference-capture decisions.
 - Do not implement fixes or modify any project files.

--- a/src/agentmux/prompts/agents/reviewer_logic.md
+++ b/src/agentmux/prompts/agents/reviewer_logic.md
@@ -12,6 +12,11 @@ Approved preference proposal artifact (confirmation step): [[placeholder:reviewe
 [[include:02_planning/architecture.md]]
 </file>
 
+## Identity & Vision
+
+You verify that the implementation does what the plan says it should do.
+Your quality standard is functional truth: logic is correct, requirements are met, and the code behaves as specified. Style and naming are not your concern.
+
 ## Your Specialization
 
 You focus **exclusively** on whether the technical implementation aligns with the architect's plan and fulfills the requirements.
@@ -26,7 +31,13 @@ You focus **exclusively** on whether the technical implementation aligns with th
 
 **Constraint:** Ignore style questions (variable names, formatting) unless they make the code illogical or unclear. Concentrate on the "truth" of the logic.
 
-## Preference-capture rules for the final confirmation step:
+## Output & Artifacts
+
+- `06_review/review.md` — verdict (pass/fail) with findings, logic gaps, and guidance for the coder if fail.
+- `08_completion/confirmation_prompt.md` — confirmation prompt for the user (confirmation step only).
+- `[[placeholder:reviewer_preference_proposal_file]]` — JSON, optional; only write if candidates are approved.
+
+## Preference Memory
 
 [[shared:preference-memory]]
 
@@ -36,7 +47,7 @@ Reviewer preference proposal output:
 
 [[placeholder:project_instructions]]
 
-Constraints:
+## Constraints
 - Keep review and confirmation guidance aligned with `requirements.md` and `02_planning/plan.md`.
 - Do not mix implementation verdicting with preference-capture decisions.
 - Do not implement fixes or modify any project files.

--- a/src/agentmux/prompts/agents/reviewer_quality.md
+++ b/src/agentmux/prompts/agents/reviewer_quality.md
@@ -12,6 +12,11 @@ Approved preference proposal artifact (confirmation step): [[placeholder:reviewe
 [[include:02_planning/architecture.md]]
 </file>
 
+## Identity & Vision
+
+You verify that the code is clean, readable, and maintainable.
+Your quality standard is long-term health: code that new contributors can understand and extend without surprises. Business logic correctness and security are not your scope.
+
 ## Your Specialization
 
 You focus **exclusively** on Clean Code principles, naming conventions, and project standards adherence.
@@ -26,7 +31,13 @@ You focus **exclusively** on Clean Code principles, naming conventions, and proj
 
 **Constraint:** Focus on maintainability and readability. Do not analyze business logic correctness or security vulnerabilities — that's handled by other reviewers.
 
-## Preference-capture rules for the final confirmation step:
+## Output & Artifacts
+
+- `06_review/review.md` — verdict (pass/fail) with findings on code quality, naming, and style.
+- `08_completion/confirmation_prompt.md` — confirmation prompt for the user (confirmation step only).
+- `[[placeholder:reviewer_preference_proposal_file]]` — JSON, optional; only write if candidates are approved.
+
+## Preference Memory
 
 [[shared:preference-memory]]
 
@@ -36,7 +47,7 @@ Reviewer preference proposal output:
 
 [[placeholder:project_instructions]]
 
-Constraints:
+## Constraints
 - Keep review and confirmation guidance aligned with project standards from context files.
 - Do not mix implementation verdicting with preference-capture decisions.
 - Do not implement fixes or modify any project files.

--- a/src/agentmux/prompts/commands/change.md
+++ b/src/agentmux/prompts/commands/change.md
@@ -36,21 +36,36 @@ Your job:
 8. Treat shared mutable artifacts conservatively. Per-plan task files (`02_planning/tasks_<N>.md`) enforce task ownership by file structure—each tasks file is scoped to its corresponding sub-plan. Files such as prompt templates, monitor/state metadata files, and cross-cutting tests/docs should have a single owner in Phase 2 unless they are intentionally deferred to a serial integration sub-plan.
 9. Keep Phase 2 task ownership unambiguous. Each per-plan tasks file (`02_planning/tasks_<N>.md`) contains only tasks relevant to that specific sub-plan. Tasks in a given tasks file must belong only to that sub-plan's owned files/modules. If a task would reasonably belong to multiple lanes, it does not belong in parallel Phase 2 as written.
 10. Explicitly assess enabling refactors and technical debt tradeoffs.
-11. After writing `02_planning/plan.md`, also write numbered executable plan files (`02_planning/plan_<N>.md`) and also write `02_planning/execution_plan.json` with shape:
-`{{ "version": 1, "groups": [{{ "group_id": "string", "mode": "serial|parallel", "plans": [{{ "file": "plan_1.md", "name": "Foundation contracts" }}] }}] }}`
-12. `02_planning/execution_plan.json` is required. Every `plans[]` entry must be an object with both `file` and `name`.
+11. After writing `02_planning/plan.md`, also write numbered executable plan files (`02_planning/plan_<N>.md`) and also write `02_planning/execution_plan.yaml` with this shape:
+```yaml
+version: 1
+review_strategy:
+  severity: low|medium|high
+  focus: []
+needs_design: true|false
+needs_docs: true|false
+doc_files: []
+groups:
+  - group_id: "string"
+    mode: serial|parallel
+    plans:
+      - file: plan_1.md
+        name: "Foundation contracts"
+```
+12. `02_planning/execution_plan.yaml` is required. Every `plans[]` entry must be an object with both `file` and `name`.
 13. After writing planning/execution artifacts, also write per-plan task files `02_planning/tasks_<N>.md` for each numbered plan. Each tasks file must contain only tasks relevant to that specific sub-plan. Each task must be a concrete, testable unit of work (for example: "Create function X in file Y", "Add test for Z").
 14. Documentation updates must be captured as explicit plan and task items in `02_planning/plan.md`, every `02_planning/plan_<N>.md`, and every `02_planning/tasks_<N>.md`.
 Do not defer documentation to a separate post-review handoff; keep documentation work in the same implementation scope as code changes.
-15. You may optionally write `02_planning/tasks.md` as a human-readable overview summarizing all tasks across plans, but this is not required for execution—the scheduler uses only the per-plan task files. After writing planning/task/execution artifacts, write `02_planning/plan_meta.json` with this exact shape: `{{ "needs_design": true|false, "needs_docs": true|false, "doc_files": ["path/to/doc.md", ...] }}`.
-Set `needs_docs` based on whether docs updates are required by the revised plan scope.
+15. You may optionally write `02_planning/tasks.md` as a human-readable overview summarizing all tasks across plans, but this is not required for execution—the scheduler uses only the per-plan task files. The `02_planning/execution_plan.yaml` file must include the metadata fields alongside the groups. Set `needs_design` and `needs_docs` based on the revised plan scope.
 `doc_files` must list expected docs updates when `needs_docs` is `true`, and must be an empty list when `needs_docs` is `false`.
 Do not treat `needs_docs` as a workflow switch; it is planning metadata only and must not imply a dedicated agent or phase.
 16. FINAL STEP ONLY — after writing the planning artifacts, stop. Do not update `state.json` or any workflow status from this step.
 
 [[placeholder:project_instructions]]
 
+[[shared:handoff-contract-plan]]
+
 Constraints:
 - Do not implement code.
 - Do not update `state.json` from the replanning step.
-- Do not write to `02_planning/plan.md`/`02_planning/plan_<N>.md`/`02_planning/execution_plan.json`/`02_planning/tasks.md`/`02_planning/plan_meta.json` before explicit user approval.
+- Do not write to `02_planning/plan.md`/`02_planning/plan_<N>.md`/`02_planning/execution_plan.yaml`/`02_planning/tasks.md` before explicit user approval.

--- a/src/agentmux/prompts/commands/review_expert.md
+++ b/src/agentmux/prompts/commands/review_expert.md
@@ -6,7 +6,7 @@ Session directory: [[placeholder:feature_dir]]
 [[include:state.json]]
 </file>
 
-Then inspect `02_planning/plan_meta.json` for the `review_strategy.focus` array and perform deep analysis on those specific areas.
+Then inspect `02_planning/execution_plan.yaml` for the `review_strategy.focus` array and perform deep analysis on those specific areas.
 
 ## Your Checklist
 
@@ -20,7 +20,7 @@ Then inspect `02_planning/plan_meta.json` for the `review_strategy.focus` array 
 **Constraint:** Deep analysis mode — investigate thoroughly. This is expert-level scrutiny; assume sophisticated threat models matter here.
 
 Your job:
-1. Review the implementation for security vulnerabilities and performance issues based on focus areas from `plan_meta.review_strategy.focus`.
+1. Review the implementation for security vulnerabilities and performance issues based on focus areas from `execution_plan.yaml`'s `review_strategy.focus`.
 2. Always write `06_review/review.md`.
 3. The first line of `06_review/review.md` must be exactly one of:
    - `verdict: pass`
@@ -31,6 +31,8 @@ Your job:
 7. FINAL STEP ONLY — once `06_review/review.md` is fully written and nothing else remains, stop. Do not update `state.json` or any workflow status from review.
 
 [[placeholder:project_instructions]]
+
+[[shared:handoff-contract-review]]
 
 Constraints:
 - Communicate only through the files in the shared feature directory.

--- a/src/agentmux/prompts/commands/review_logic.md
+++ b/src/agentmux/prompts/commands/review_logic.md
@@ -30,6 +30,8 @@ Your job:
 
 [[placeholder:project_instructions]]
 
+[[shared:handoff-contract-review]]
+
 Constraints:
 - Communicate only through the files in the shared feature directory.
 - Do not rewrite the plan during review.

--- a/src/agentmux/prompts/commands/review_quality.md
+++ b/src/agentmux/prompts/commands/review_quality.md
@@ -31,6 +31,8 @@ Your job:
 
 [[placeholder:project_instructions]]
 
+[[shared:handoff-contract-review]]
+
 Constraints:
 - Communicate only through the files in the shared feature directory.
 - Do not rewrite the plan during review.

--- a/src/agentmux/prompts/shared/handoff-contract-architecture.md
+++ b/src/agentmux/prompts/shared/handoff-contract-architecture.md
@@ -1,0 +1,41 @@
+## Submitting Your Architecture
+
+Use the `agentmux_submit_architecture` MCP tool to submit your architecture document. This ensures structured, validated output.
+
+**Tool parameters:**
+- `solution_overview` (required) — High-level approach and rationale
+- `components` (required) — List of components, each with `name`, `responsibility`, and `interfaces`
+- `interfaces_and_contracts` (required) — API boundaries, data formats, protocols
+- `data_models` (required) — Key entities, relationships, storage
+- `cross_cutting_concerns` (required) — Error handling, logging, security, testing strategy
+- `technology_choices` (required) — Tools, libraries, frameworks with rationale
+- `risks_and_mitigations` (required) — Known risks and mitigation strategies
+- `design_handoff` (optional) — Notes for the designer if UI work is needed
+
+The tool validates your input and writes `architecture.yaml` + `architecture.md` to the planning directory.
+
+**If the MCP tool is unavailable**, write `02_planning/architecture.yaml` directly:
+
+```yaml
+solution_overview: |
+  High-level approach description.
+components:
+  - name: ComponentName
+    responsibility: What it does
+    interfaces:
+      - method_or_endpoint()
+interfaces_and_contracts: |
+  API boundaries and data formats.
+data_models: |
+  Key entities and relationships.
+cross_cutting_concerns: |
+  Error handling, logging, security.
+technology_choices: |
+  Tools and libraries with rationale.
+risks_and_mitigations: |
+  Known risks and mitigations.
+design_handoff: |  # optional
+  Notes for designer.
+```
+
+Then write `02_planning/architecture.md` as a human-readable version of the same content.

--- a/src/agentmux/prompts/shared/handoff-contract-architecture.md
+++ b/src/agentmux/prompts/shared/handoff-contract-architecture.md
@@ -1,6 +1,8 @@
 ## Submitting Your Architecture
 
-Use the `agentmux_submit_architecture` MCP tool to submit your architecture document. This ensures structured, validated output.
+Use the `submit_architecture` MCP tool to submit your architecture document. This ensures structured, validated output.
+
+> When you call this tool, the orchestrator observes the event and advances the workflow. No manual file creation is required.
 
 **Tool parameters:**
 - `solution_overview` (required) — High-level approach and rationale

--- a/src/agentmux/prompts/shared/handoff-contract-plan.md
+++ b/src/agentmux/prompts/shared/handoff-contract-plan.md
@@ -1,0 +1,65 @@
+## Submitting Your Execution Plan
+
+Use the MCP tools to submit your execution plan. This ensures structured, validated output.
+
+### Step 1: Submit sub-plans
+
+For each sub-plan, call `agentmux_submit_subplan` with:
+- `index` (required) — Sub-plan number (1, 2, 3, ...)
+- `title` (required) — Short descriptive title
+- `scope` (required) — What this sub-plan covers
+- `owned_files` (required) — Files created or modified (for parallel isolation)
+- `dependencies` (required) — What this sub-plan depends on
+- `implementation_approach` (required) — Step-by-step approach
+- `acceptance_criteria` (required) — Testable criteria for completion
+- `tasks` (required) — Task checklist items
+- `isolation_rationale` (optional) — Why this sub-plan is safe for parallel execution
+
+### Step 2: Submit the execution plan
+
+Call `agentmux_submit_execution_plan` with:
+- `groups` (required) — Execution groups: `[{group_id, mode: "serial"|"parallel", plans: [{file, name}]}]`
+- `review_strategy` (required) — `{severity: "low"|"medium"|"high", focus: [...]}`
+- `needs_design` (required) — Whether a design phase is required
+- `needs_docs` (required) — Whether documentation updates are needed
+- `doc_files` (required) — Documentation files to create or update
+- `plan_overview` (required) — Human-readable plan summary
+
+The tools validate input and write the corresponding `.yaml` and `.md` files.
+
+**If MCP tools are unavailable**, write `02_planning/execution_plan.yaml` directly:
+
+```yaml
+version: 1
+review_strategy:
+  severity: medium
+  focus: [security, performance]
+needs_design: false
+needs_docs: true
+doc_files: [docs/api.md]
+groups:
+  - group_id: core-setup
+    mode: serial
+    plans:
+      - file: plan_1.md
+        name: Setup core module
+```
+
+And write each `02_planning/plan_N.yaml`:
+
+```yaml
+index: 1
+title: Plan title
+scope: What it covers
+owned_files: [src/file.py]
+dependencies: None
+implementation_approach: |
+  Step-by-step approach.
+acceptance_criteria: |
+  Testable criteria.
+tasks:
+  - First task
+  - Second task
+```
+
+Then write the corresponding `.md` and `tasks_N.md` files as human-readable versions.

--- a/src/agentmux/prompts/shared/handoff-contract-plan.md
+++ b/src/agentmux/prompts/shared/handoff-contract-plan.md
@@ -4,7 +4,9 @@ Use the MCP tools to submit your execution plan. This ensures structured, valida
 
 ### Step 1: Submit sub-plans
 
-For each sub-plan, call `agentmux_submit_subplan` with:
+For each sub-plan, call `submit_subplan` with:
+
+> When you call this tool, the orchestrator observes the event and advances the workflow. No manual file creation is required.
 - `index` (required) — Sub-plan number (1, 2, 3, ...)
 - `title` (required) — Short descriptive title
 - `scope` (required) — What this sub-plan covers
@@ -17,7 +19,9 @@ For each sub-plan, call `agentmux_submit_subplan` with:
 
 ### Step 2: Submit the execution plan
 
-Call `agentmux_submit_execution_plan` with:
+Call `submit_execution_plan` with:
+
+> When you call this tool, the orchestrator observes the event and advances the workflow. No manual file creation is required.
 - `groups` (required) — Execution groups: `[{group_id, mode: "serial"|"parallel", plans: [{file, name}]}]`
 - `review_strategy` (required) — `{severity: "low"|"medium"|"high", focus: [...]}`
 - `needs_design` (required) — Whether a design phase is required

--- a/src/agentmux/prompts/shared/handoff-contract-review.md
+++ b/src/agentmux/prompts/shared/handoff-contract-review.md
@@ -1,6 +1,8 @@
 ## Submitting Your Review
 
-Use the `agentmux_submit_review` MCP tool to submit your review. This ensures structured, validated output.
+Use the `submit_review` MCP tool to submit your review. This ensures structured, validated output.
+
+> When you call this tool, the orchestrator observes the event and advances the workflow. No manual file creation is required.
 
 **Tool parameters:**
 - `verdict` (required) — `"pass"` or `"fail"`

--- a/src/agentmux/prompts/shared/handoff-contract-review.md
+++ b/src/agentmux/prompts/shared/handoff-contract-review.md
@@ -1,0 +1,35 @@
+## Submitting Your Review
+
+Use the `agentmux_submit_review` MCP tool to submit your review. This ensures structured, validated output.
+
+**Tool parameters:**
+- `verdict` (required) — `"pass"` or `"fail"`
+- `summary` (required) — What was reviewed and the outcome
+- `findings` (on fail) — List of issues: `[{location, issue, severity, recommendation}]`
+- `commit_message` (on pass, optional) — Suggested commit message
+
+The tool validates your input and writes `review.yaml` + `review.md` to the review directory.
+
+**If the MCP tool is unavailable**, write `06_review/review.yaml` directly:
+
+On pass:
+```yaml
+verdict: pass
+summary: |
+  All checks passed. Implementation matches the plan.
+commit_message: "feat: implement feature X"
+```
+
+On fail:
+```yaml
+verdict: fail
+summary: |
+  Found issues that need fixing.
+findings:
+  - location: src/file.py:42
+    issue: Missing input validation
+    severity: high
+    recommendation: Add email format check before database lookup.
+```
+
+Then write `06_review/review.md` with `verdict: pass` or `verdict: fail` as the **first line**, followed by the review content.

--- a/src/agentmux/runtime/file_events.py
+++ b/src/agentmux/runtime/file_events.py
@@ -30,6 +30,7 @@ RUNTIME_FILE_NAMES = {
     "runtime_state.json",
     "created_files.log",
     "status_log.txt",
+    "tool_events.jsonl",
 }
 
 

--- a/src/agentmux/runtime/tool_events.py
+++ b/src/agentmux/runtime/tool_events.py
@@ -1,0 +1,141 @@
+"""Tool-call event logging and event source for the session event bus.
+
+This module provides:
+- ``append_tool_event()`` — append a structured JSON line to
+  ``tool_events.jsonl`` so that downstream consumers (MCP submit tools,
+  the orchestrator) can observe tool invocations.
+- ``ToolCallEventSource`` — an ``EventSource`` that seeds existing entries
+  from ``tool_events.jsonl`` and tails the file via watchdog, publishing
+  ``SessionEvent(kind="tool.<name>", source="tool_call", ...)`` to the bus.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .event_bus import EventBus, EventSource, SessionEvent
+
+logger = logging.getLogger(__name__)
+
+TOOL_EVENTS_LOG_NAME = "tool_events.jsonl"
+
+
+def append_tool_event(
+    log_path: Path,
+    tool_name: str,
+    payload: dict[str, Any],
+) -> None:
+    """Append one JSON line to *log_path* describing a tool call.
+
+    Creates parent directories if they do not exist.  Subsequent calls
+    append without truncating.
+    """
+    entry = {
+        "tool": tool_name,
+        "timestamp": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "payload": payload,
+    }
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+class ToolCallEventSource(EventSource):
+    """Watch ``tool_events.jsonl`` and emit ``SessionEvent`` objects.
+
+    On ``start()`` the source seeds any pre-existing lines, then tails
+    the file for new appends via a watchdog observer.
+    """
+
+    def __init__(self, feature_dir: Path) -> None:
+        self._feature_dir = feature_dir.resolve()
+        self._offset = 0
+        self._observer: Any = None
+
+    def start(self, bus: EventBus) -> None:
+        from .file_events import ensure_watchdog_available
+
+        ensure_watchdog_available()
+
+        self._seed_existing(bus)
+
+        from watchdog.events import FileSystemEvent, FileSystemEventHandler
+        from watchdog.observers import Observer
+
+        class _ToolLogHandler(FileSystemEventHandler):
+            def __init__(self, source: ToolCallEventSource, bus: EventBus) -> None:
+                super().__init__()
+                self._source = source
+                self._bus = bus
+
+            def on_any_event(self, event: FileSystemEvent) -> None:
+                if getattr(event, "is_directory", False):
+                    return
+                src = getattr(event, "src_path", "")
+                if Path(src).name != TOOL_EVENTS_LOG_NAME:
+                    return
+                self._source._on_modified(self._bus)
+
+        observer = Observer()
+        observer.schedule(
+            _ToolLogHandler(self, bus),
+            str(self._feature_dir),
+            recursive=False,
+        )
+        observer.start()
+        self._observer = observer
+
+    def stop(self) -> None:
+        if self._observer is None:
+            return
+        self._observer.stop()
+        self._observer.join()
+        self._observer = None
+
+    def _seed_existing(self, bus: EventBus) -> None:
+        log_path = self._feature_dir / TOOL_EVENTS_LOG_NAME
+        if not log_path.exists():
+            return
+
+        text = log_path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        for line in lines:
+            self._emit_line(line, bus)
+        self._offset = log_path.stat().st_size
+
+    def _on_modified(self, bus: EventBus) -> None:
+        log_path = self._feature_dir / TOOL_EVENTS_LOG_NAME
+        if not log_path.exists():
+            return
+
+        current_size = log_path.stat().st_size
+        if current_size <= self._offset:
+            return
+
+        with log_path.open("r", encoding="utf-8") as f:
+            f.seek(self._offset)
+            for line in f:
+                stripped = line.rstrip("\n")
+                if stripped:
+                    self._emit_line(stripped, bus)
+            self._offset = f.tell()
+
+    def _emit_line(self, line: str, bus: EventBus) -> None:
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("Skipping malformed tool event line: %s", line[:120])
+            return
+
+        tool_name = entry.get("tool", "unknown")
+        bus.publish(
+            SessionEvent(
+                kind=f"tool.{tool_name}",
+                source="tool_call",
+                payload=entry,
+            )
+        )

--- a/src/agentmux/sessions/state_store.py
+++ b/src/agentmux/sessions/state_store.py
@@ -119,7 +119,7 @@ def _make_runtime_files(project_dir: Path, feature_dir: Path) -> RuntimeFiles:
         plan=planning_dir / "plan.md",
         architecture=planning_dir / "architecture.md",
         tasks=planning_dir / "tasks.md",
-        execution_plan=planning_dir / "execution_plan.json",
+        execution_plan=planning_dir / "execution_plan.yaml",
         design=design_dir / "design.md",
         review=review_dir / "review.md",
         fix_request=review_dir / "fix_request.md",

--- a/src/agentmux/workflow/event_catalog.py
+++ b/src/agentmux/workflow/event_catalog.py
@@ -66,7 +66,7 @@ WORKFLOW_EVENT_CATALOG: dict[str, WorkflowEventDefinition] = {
     EVENT_PLAN_WRITTEN: WorkflowEventDefinition(
         name=EVENT_PLAN_WRITTEN,
         display_label="plan ready",
-        description="Planner wrote plan.md, execution_plan.json, and plan_meta.json.",
+        description="Planner wrote plan.md and execution_plan.yaml.",
     ),
     EVENT_DESIGN_WRITTEN: WorkflowEventDefinition(
         name=EVENT_DESIGN_WRITTEN,

--- a/src/agentmux/workflow/event_router.py
+++ b/src/agentmux/workflow/event_router.py
@@ -58,6 +58,24 @@ class WorkflowEvent:
     payload: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class ToolSpec:
+    """Declarative specification for routing tool-call events.
+
+    When a ``SessionEvent`` with ``kind="tool.<bare_name>"`` arrives, the
+    router checks each ``ToolSpec`` returned by the handler's
+    ``get_tool_specs()``.  If ``bare_name`` is in ``tool_names``, the event
+    is dispatched to ``handle_event`` with ``kind=spec.name``.
+
+    Attributes:
+        name: Logical event name dispatched to ``handle_event``.
+        tool_names: Bare MCP tool names to match (without the "tool." prefix).
+    """
+
+    name: str
+    tool_names: tuple[str, ...]
+
+
 @runtime_checkable
 class PhaseHandler(Protocol):
     """Protocol for phase-specific event handling.
@@ -100,6 +118,15 @@ class PhaseHandler(Protocol):
         Returns:
             Sequence of EventSpec objects.  Return empty sequence (or don't
             override) to receive raw WorkflowEvents in handle_event instead.
+        """
+        ...
+
+    def get_tool_specs(self) -> Sequence[ToolSpec]:
+        """Return ToolSpecs for MCP tool-call events.
+
+        Returns:
+            Sequence of ToolSpec objects.  Return empty sequence (or don't
+            override) to have tool.* events return ({}, None).
         """
         ...
 
@@ -266,7 +293,25 @@ class WorkflowEventRouter:
         - If no spec fires, return ``{}, None``.
 
         Handlers without specs receive the raw WorkflowEvent unchanged.
+
+        Tool-call events (``tool.*``) are routed via ``ToolSpec``:
+        - If the handler declares ``get_tool_specs()``, match the bare tool
+          name against each spec's ``tool_names``.  On match, dispatch a
+          ``WorkflowEvent(kind=spec.name, payload=event.payload)``.
+        - Non-matching tool names return ``{}, None``.
         """
+        # Route tool.* events via ToolSpec
+        if event.kind.startswith("tool."):
+            get_tool_specs = getattr(handler, "get_tool_specs", None)
+            if get_tool_specs is not None:
+                bare_name = event.kind[len("tool.") :]
+                for spec in get_tool_specs():
+                    if bare_name in spec.tool_names:
+                        logical = WorkflowEvent(kind=spec.name, payload=event.payload)
+                        return handler.handle_event(logical, state, ctx)
+            return {}, None
+
+        # Route file events via EventSpec or raw
         get_specs = getattr(handler, "get_event_specs", None)
         if get_specs is None:
             # Legacy handler without specs — pass raw event through

--- a/src/agentmux/workflow/execution_plan.py
+++ b/src/agentmux/workflow/execution_plan.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
 
 _PLAN_FILE_RE = re.compile(r"^plan_\d+\.md$")
 _GROUP_MODES = {"serial", "parallel"}
@@ -33,17 +34,17 @@ def _error(path: Path, message: str) -> RuntimeError:
 
 
 def load_execution_plan(planning_dir: Path) -> ExecutionPlan:
-    path = planning_dir / "execution_plan.json"
+    path = planning_dir / "execution_plan.yaml"
     if not path.is_file():
         raise _error(path, "is required.")
 
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise _error(path, "must contain valid JSON.") from exc
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise _error(path, "must contain valid YAML.") from exc
 
     if not isinstance(payload, dict):
-        raise _error(path, "must be a JSON object.")
+        raise _error(path, "must be a YAML mapping.")
 
     version = payload.get("version")
     if version != 1:

--- a/src/agentmux/workflow/handlers/architecting.py
+++ b/src/agentmux/workflow/handlers/architecting.py
@@ -7,14 +7,16 @@ separation between "What/With what" (architect) and "How/When" (planner).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_ARCHITECTURE_WRITTEN
 from agentmux.workflow.event_router import (
     EventSpec,
+    ToolSpec,
     WorkflowEvent,
-    extract_research_topic,
 )
+from agentmux.workflow.handoff_artifacts import submit_architecture
 from agentmux.workflow.phase_helpers import (
     apply_role_preferences,
     dispatch_research_task,
@@ -30,42 +32,6 @@ if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext
 
 
-def _file_exists(path: str, ctx: PipelineContext, state: dict) -> bool:
-    return (ctx.files.feature_dir / path).exists()
-
-
-_SPECS = (
-    EventSpec(
-        name="architecture_written",
-        watch_paths=(
-            "02_planning/architecture.md",
-            "02_planning/architecture.yaml",
-        ),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="code_research_requested",
-        watch_paths=("03_research/code-*/request.md",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="web_research_requested",
-        watch_paths=("03_research/web-*/request.md",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="code_research_done",
-        watch_paths=("03_research/code-*/done",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="web_research_done",
-        watch_paths=("03_research/web-*/done",),
-        is_ready=_file_exists,
-    ),
-)
-
-
 class ArchitectingHandler:
     """Event-driven handler for architecting phase.
 
@@ -74,8 +40,25 @@ class ArchitectingHandler:
     When architecture.md is written, the phase transitions to 'planning'.
     """
 
-    def get_event_specs(self) -> tuple[EventSpec, ...]:
-        return _SPECS
+    def get_event_specs(self) -> Sequence[EventSpec]:
+        return ()
+
+    def get_tool_specs(self) -> Sequence[ToolSpec]:
+        return (
+            ToolSpec(name="architecture", tool_names=("submit_architecture",)),
+            ToolSpec(
+                name="research_code_req",
+                tool_names=("research_dispatch_code",),
+            ),
+            ToolSpec(
+                name="research_web_req",
+                tool_names=("research_dispatch_web",),
+            ),
+            ToolSpec(
+                name="research_done",
+                tool_names=("submit_research_done",),
+            ),
+        )
 
     def enter(self, state: dict, ctx: PipelineContext) -> dict:
         """Called when entering architecting phase."""
@@ -94,48 +77,31 @@ class ArchitectingHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for architecting phase."""
-        if event.kind == "architecture_written":
-            return self._handle_architecture_written(state, ctx)
+        match event.kind:
+            case "architecture":
+                return self._handle_architecture(event, state, ctx)
+            case "research_code_req":
+                return self._handle_research_code_req(event, state, ctx)
+            case "research_web_req":
+                return self._handle_research_web_req(event, state, ctx)
+            case "research_done":
+                return self._handle_research_done(event, state, ctx)
+            case _:
+                return {}, None
 
-        if event.kind == "code_research_requested":
-            topic = extract_research_topic(event.path or "", "code-")
-            if topic:
-                return dispatch_research_task("code-researcher", topic, state, ctx)
-
-        if event.kind == "web_research_requested":
-            topic = extract_research_topic(event.path or "", "web-")
-            if topic:
-                return dispatch_research_task("web-researcher", topic, state, ctx)
-
-        if event.kind == "code_research_done":
-            topic = extract_research_topic(event.path or "", "code-")
-            if topic:
-                return notify_research_complete(
-                    "code-researcher", topic, state, ctx, "architect"
-                )
-
-        if event.kind == "web_research_done":
-            topic = extract_research_topic(event.path or "", "web-")
-            if topic:
-                return notify_research_complete(
-                    "web-researcher", topic, state, ctx, "architect"
-                )
-
-        return {}, None
-
-    def _handle_architecture_written(
+    def _handle_architecture(
         self,
+        event: WorkflowEvent,
         state: dict,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Handle architecture written event.
+        """Handle architecture submission via tool event."""
+        payload = event.payload.get("payload", {})
 
-        When architecture.md is written, transition to planning phase
-        where the planner will create execution plans.
-        """
-        # Check if architecture file exists
-        if not ctx.files.architecture.exists():
-            return {}, None
+        # Write architecture artifacts (idempotent — guard by existence)
+        yaml_path = ctx.files.planning_dir / "architecture.yaml"
+        if not yaml_path.exists():
+            submit_architecture(ctx.files.feature_dir, payload)
 
         # Apply approved preferences from architect
         apply_role_preferences(ctx, "architect")
@@ -150,3 +116,87 @@ class ArchitectingHandler:
 
         # Transition to planning phase (planner takes over)
         return {"last_event": EVENT_ARCHITECTURE_WRITTEN}, "planning"
+
+    def _handle_research_code_req(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle code research request via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        if not topic:
+            return {}, None
+
+        # Write request.md before dispatching (side-effect ordering requirement)
+        req_dir = ctx.files.research_dir / f"code-{topic}"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        if not req_path.exists():
+            questions = payload.get("questions", [])
+            scope_hints = payload.get("scope_hints", [])
+            content = (
+                f"# Research Request: {topic}\n\n"
+                f"## Context\n{payload.get('context', '')}\n\n"
+                f"## Questions\n"
+                + "\n".join(f"- {q}" for q in questions)
+                + (
+                    "\n\n## Scope Hints\n" + "\n".join(f"- {h}" for h in scope_hints)
+                    if scope_hints
+                    else ""
+                )
+            )
+            req_path.write_text(content, encoding="utf-8")
+
+        return dispatch_research_task("code-researcher", topic, state, ctx)
+
+    def _handle_research_web_req(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle web research request via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        if not topic:
+            return {}, None
+
+        # Write request.md before dispatching (side-effect ordering requirement)
+        req_dir = ctx.files.research_dir / f"web-{topic}"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        if not req_path.exists():
+            questions = payload.get("questions", [])
+            scope_hints = payload.get("scope_hints", [])
+            content = (
+                f"# Research Request: {topic}\n\n"
+                f"## Context\n{payload.get('context', '')}\n\n"
+                f"## Questions\n"
+                + "\n".join(f"- {q}" for q in questions)
+                + (
+                    "\n\n## Scope Hints\n" + "\n".join(f"- {h}" for h in scope_hints)
+                    if scope_hints
+                    else ""
+                )
+            )
+            req_path.write_text(content, encoding="utf-8")
+
+        return dispatch_research_task("web-researcher", topic, state, ctx)
+
+    def _handle_research_done(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle research completion via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        role_type = payload.get("role_type", "")
+        if not topic or not role_type:
+            return {}, None
+
+        role = "code-researcher" if role_type == "code" else "web-researcher"
+        return notify_research_complete(role, topic, state, ctx, "architect")

--- a/src/agentmux/workflow/handlers/architecting.py
+++ b/src/agentmux/workflow/handlers/architecting.py
@@ -37,7 +37,10 @@ def _file_exists(path: str, ctx: PipelineContext, state: dict) -> bool:
 _SPECS = (
     EventSpec(
         name="architecture_written",
-        watch_paths=("02_planning/architecture.md",),
+        watch_paths=(
+            "02_planning/architecture.md",
+            "02_planning/architecture.yaml",
+        ),
         is_ready=_file_exists,
     ),
     EventSpec(

--- a/src/agentmux/workflow/handlers/implementing.py
+++ b/src/agentmux/workflow/handlers/implementing.py
@@ -46,7 +46,7 @@ def _plan_index_from_name(plan_name: str) -> int:
 
 
 def _build_implementation_schedule(*, planning_dir: Path) -> list[dict[str, object]]:
-    """Build implementation schedule from execution_plan.json."""
+    """Build implementation schedule from execution_plan.yaml."""
     execution_plan = load_execution_plan(planning_dir)
 
     schedule: list[dict[str, object]] = []
@@ -71,7 +71,7 @@ def _build_implementation_schedule(*, planning_dir: Path) -> list[dict[str, obje
 
     if len(all_indexes) != len(set(all_indexes)):
         raise RuntimeError(
-            "execution_plan.json must not reuse plan files across groups."
+            "execution_plan.yaml must not reuse plan files across groups."
         )
     if all_indexes:
         max_index = max(all_indexes)
@@ -79,7 +79,7 @@ def _build_implementation_schedule(*, planning_dir: Path) -> list[dict[str, obje
         if missing_indexes:
             missing_csv = ", ".join(str(index) for index in missing_indexes)
             raise RuntimeError(
-                f"execution_plan.json plan indexes must be contiguous "
+                f"execution_plan.yaml plan indexes must be contiguous "
                 f"from 1..{max_index}; missing: {missing_csv}."
             )
     return schedule

--- a/src/agentmux/workflow/handlers/implementing.py
+++ b/src/agentmux/workflow/handlers/implementing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,8 +17,8 @@ from agentmux.workflow.event_catalog import (
 )
 from agentmux.workflow.event_router import (
     EventSpec,
+    ToolSpec,
     WorkflowEvent,
-    extract_subplan_index,
 )
 from agentmux.workflow.execution_plan import load_execution_plan
 from agentmux.workflow.phase_helpers import (
@@ -182,16 +183,11 @@ class ImplementingHandler:
 
         return updates
 
-    def get_event_specs(self) -> tuple[EventSpec, ...]:
-        return (
-            EventSpec(
-                name="done_marker",
-                watch_paths=("05_implementation/done_*",),
-                is_ready=lambda path, ctx, state: (
-                    ctx.files.feature_dir / path
-                ).exists(),
-            ),
-        )
+    def get_event_specs(self) -> Sequence[EventSpec]:
+        return ()
+
+    def get_tool_specs(self) -> Sequence[ToolSpec]:
+        return (ToolSpec(name="done", tool_names=("submit_done",)),)
 
     def handle_event(
         self,
@@ -200,9 +196,14 @@ class ImplementingHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for implementing phase."""
-        if event.kind == "done_marker":
-            subplan_index = extract_subplan_index(event.path or "")
+        if event.kind == "done":
+            payload = event.payload.get("payload", {})
+            subplan_index = payload.get("subplan_index")
             if subplan_index is not None:
+                # Write done_N marker for group-completion tracking (idempotent)
+                done_n_path = ctx.files.implementation_dir / f"done_{subplan_index}"
+                if not done_n_path.exists():
+                    done_n_path.touch()
                 return self._handle_subplan_completed(subplan_index, state, ctx)
         return {}, None
 

--- a/src/agentmux/workflow/handlers/planning.py
+++ b/src/agentmux/workflow/handlers/planning.py
@@ -6,15 +6,20 @@ the architecture document produced by the architect in the architecting phase.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_CHANGES_REQUESTED, EVENT_PLAN_WRITTEN
 from agentmux.workflow.event_router import (
     EventSpec,
+    ToolSpec,
     WorkflowEvent,
-    extract_research_topic,
 )
 from agentmux.workflow.execution_plan import load_execution_plan
+from agentmux.workflow.handoff_artifacts import (
+    submit_execution_plan,
+    submit_subplan,
+)
 from agentmux.workflow.phase_helpers import (
     apply_role_preferences,
     dispatch_research_task,
@@ -32,55 +37,32 @@ if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext
 
 
-def _plan_written_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
-    """Both planning artefacts must exist for the plan to be complete."""
-    return ctx.files.plan.exists() and ctx.files.execution_plan.exists()
-
-
-def _file_exists(path: str, ctx: PipelineContext, state: dict) -> bool:
-    return (ctx.files.feature_dir / path).exists()
-
-
-_SPECS = (
-    EventSpec(
-        name="plan_written",
-        watch_paths=(
-            "02_planning/plan.md",
-            "02_planning/execution_plan.yaml",
-        ),
-        is_ready=_plan_written_ready,
-    ),
-    EventSpec(
-        name="code_research_requested",
-        watch_paths=("03_research/code-*/request.md",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="web_research_requested",
-        watch_paths=("03_research/web-*/request.md",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="code_research_done",
-        watch_paths=("03_research/code-*/done",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="web_research_done",
-        watch_paths=("03_research/web-*/done",),
-        is_ready=_file_exists,
-    ),
-)
-
-
 class PlanningHandler:
     """Event-driven handler for planning phase.
 
     The planner receives the architecture document and creates execution plans.
     """
 
-    def get_event_specs(self) -> tuple[EventSpec, ...]:
-        return _SPECS
+    def get_event_specs(self) -> Sequence[EventSpec]:
+        return ()
+
+    def get_tool_specs(self) -> Sequence[ToolSpec]:
+        return (
+            ToolSpec(name="execution_plan", tool_names=("submit_execution_plan",)),
+            ToolSpec(name="subplan", tool_names=("submit_subplan",)),
+            ToolSpec(
+                name="research_code_req",
+                tool_names=("research_dispatch_code",),
+            ),
+            ToolSpec(
+                name="research_web_req",
+                tool_names=("research_dispatch_web",),
+            ),
+            ToolSpec(
+                name="research_done",
+                tool_names=("submit_research_done",),
+            ),
+        )
 
     def enter(self, state: dict, ctx: PipelineContext) -> dict:
         """Called when entering planning phase.
@@ -111,49 +93,41 @@ class PlanningHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for planning phase."""
-        if event.kind == "plan_written":
-            return self._handle_plan_written(state, ctx)
+        match event.kind:
+            case "execution_plan":
+                return self._handle_execution_plan(event, state, ctx)
+            case "subplan":
+                return self._handle_subplan(event, state, ctx)
+            case "research_code_req":
+                return self._handle_research_code_req(event, state, ctx)
+            case "research_web_req":
+                return self._handle_research_web_req(event, state, ctx)
+            case "research_done":
+                return self._handle_research_done(event, state, ctx)
+            case _:
+                return {}, None
 
-        if event.kind == "code_research_requested":
-            topic = extract_research_topic(event.path or "", "code-")
-            if topic:
-                return dispatch_research_task("code-researcher", topic, state, ctx)
-
-        if event.kind == "web_research_requested":
-            topic = extract_research_topic(event.path or "", "web-")
-            if topic:
-                return dispatch_research_task("web-researcher", topic, state, ctx)
-
-        if event.kind == "code_research_done":
-            topic = extract_research_topic(event.path or "", "code-")
-            if topic:
-                return notify_research_complete(
-                    "code-researcher", topic, state, ctx, "planner"
-                )
-
-        if event.kind == "web_research_done":
-            topic = extract_research_topic(event.path or "", "web-")
-            if topic:
-                return notify_research_complete(
-                    "web-researcher", topic, state, ctx, "planner"
-                )
-
-        return {}, None
-
-    def _handle_plan_written(
+    def _handle_execution_plan(
         self,
+        event: WorkflowEvent,
         state: dict,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Handle plan written event.
+        """Handle execution plan submission via tool event."""
+        payload = event.payload.get("payload", {})
 
-        Both files (plan.md, execution_plan.yaml) must exist.
-        """
+        # Write execution plan artifacts (idempotent — guard by existence)
+        yaml_path = ctx.files.planning_dir / "execution_plan.yaml"
+        wrote_plan = not yaml_path.exists()
+        if wrote_plan:
+            submit_execution_plan(ctx.files.feature_dir, payload)
+
         # Apply approved preferences from planner
         apply_role_preferences(ctx, "planner")
 
-        # Load execution plan and meta
-        load_execution_plan(ctx.files.planning_dir)
+        # Validate only what we just wrote — skip on replay (existing file may differ)
+        if wrote_plan and yaml_path.exists():
+            load_execution_plan(ctx.files.planning_dir)
         meta = load_plan_meta(ctx.files.planning_dir)
         needs_design = bool(meta.get("needs_design")) and "designer" in ctx.agents
 
@@ -168,3 +142,106 @@ class PlanningHandler:
         # Determine next phase
         next_phase = "designing" if needs_design else "implementing"
         return {"last_event": EVENT_PLAN_WRITTEN}, next_phase
+
+    def _handle_subplan(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle subplan submission via tool event."""
+        payload = event.payload.get("payload", {})
+        index = payload.get("index")
+        if index is None:
+            return {"error": "missing subplan index"}, None
+
+        # Write subplan artifacts (idempotent — guard by existence)
+        yaml_path = ctx.files.planning_dir / f"plan_{index}.yaml"
+        if not yaml_path.exists():
+            submit_subplan(ctx.files.feature_dir, payload)
+
+        return {}, None
+
+    def _handle_research_code_req(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle code research request via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        if not topic:
+            return {}, None
+
+        # Write request.md before dispatching (side-effect ordering requirement)
+        req_dir = ctx.files.research_dir / f"code-{topic}"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        if not req_path.exists():
+            questions = payload.get("questions", [])
+            scope_hints = payload.get("scope_hints", [])
+            content = (
+                f"# Research Request: {topic}\n\n"
+                f"## Context\n{payload.get('context', '')}\n\n"
+                f"## Questions\n"
+                + "\n".join(f"- {q}" for q in questions)
+                + (
+                    "\n\n## Scope Hints\n" + "\n".join(f"- {h}" for h in scope_hints)
+                    if scope_hints
+                    else ""
+                )
+            )
+            req_path.write_text(content, encoding="utf-8")
+
+        return dispatch_research_task("code-researcher", topic, state, ctx)
+
+    def _handle_research_web_req(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle web research request via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        if not topic:
+            return {}, None
+
+        # Write request.md before dispatching (side-effect ordering requirement)
+        req_dir = ctx.files.research_dir / f"web-{topic}"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        if not req_path.exists():
+            questions = payload.get("questions", [])
+            scope_hints = payload.get("scope_hints", [])
+            content = (
+                f"# Research Request: {topic}\n\n"
+                f"## Context\n{payload.get('context', '')}\n\n"
+                f"## Questions\n"
+                + "\n".join(f"- {q}" for q in questions)
+                + (
+                    "\n\n## Scope Hints\n" + "\n".join(f"- {h}" for h in scope_hints)
+                    if scope_hints
+                    else ""
+                )
+            )
+            req_path.write_text(content, encoding="utf-8")
+
+        return dispatch_research_task("web-researcher", topic, state, ctx)
+
+    def _handle_research_done(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle research completion via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        role_type = payload.get("role_type", "")  # "code" or "web"
+        if not topic or not role_type:
+            return {}, None
+
+        role = "code-researcher" if role_type == "code" else "web-researcher"
+        return notify_research_complete(role, topic, state, ctx, "planner")

--- a/src/agentmux/workflow/handlers/planning.py
+++ b/src/agentmux/workflow/handlers/planning.py
@@ -33,12 +33,8 @@ if TYPE_CHECKING:
 
 
 def _plan_written_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
-    """All three planning artefacts must exist for the plan to be complete."""
-    return (
-        ctx.files.plan.exists()
-        and ctx.files.execution_plan.exists()
-        and (ctx.files.planning_dir / "plan_meta.json").exists()
-    )
+    """Both planning artefacts must exist for the plan to be complete."""
+    return ctx.files.plan.exists() and ctx.files.execution_plan.exists()
 
 
 def _file_exists(path: str, ctx: PipelineContext, state: dict) -> bool:
@@ -50,8 +46,7 @@ _SPECS = (
         name="plan_written",
         watch_paths=(
             "02_planning/plan.md",
-            "02_planning/execution_plan.json",
-            "02_planning/plan_meta.json",
+            "02_planning/execution_plan.yaml",
         ),
         is_ready=_plan_written_ready,
     ),
@@ -152,7 +147,7 @@ class PlanningHandler:
     ) -> tuple[dict, str | None]:
         """Handle plan written event.
 
-        All three files (plan.md, execution_plan.json, plan_meta.json) must exist.
+        Both files (plan.md, execution_plan.yaml) must exist.
         """
         # Apply approved preferences from planner
         apply_role_preferences(ctx, "planner")

--- a/src/agentmux/workflow/handlers/product_management.py
+++ b/src/agentmux/workflow/handlers/product_management.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_PM_COMPLETED
 from agentmux.workflow.event_router import (
     EventSpec,
+    ToolSpec,
     WorkflowEvent,
-    extract_research_topic,
 )
 from agentmux.workflow.phase_helpers import (
     apply_role_preferences,
@@ -23,39 +24,6 @@ from agentmux.workflow.prompts import (
 
 if TYPE_CHECKING:
     from ..transitions import PipelineContext
-
-
-def _file_exists(path: str, ctx: PipelineContext, state: dict) -> bool:
-    return (ctx.files.feature_dir / path).exists()
-
-
-_SPECS = (
-    EventSpec(
-        name="pm_completed",
-        watch_paths=("01_product_management/done",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="code_research_requested",
-        watch_paths=("03_research/code-*/request.md",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="web_research_requested",
-        watch_paths=("03_research/web-*/request.md",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="code_research_done",
-        watch_paths=("03_research/code-*/done",),
-        is_ready=_file_exists,
-    ),
-    EventSpec(
-        name="web_research_done",
-        watch_paths=("03_research/web-*/done",),
-        is_ready=_file_exists,
-    ),
-)
 
 
 class ProductManagementHandler:
@@ -76,8 +44,25 @@ class ProductManagementHandler:
         send_to_role(ctx, "product-manager", prompt_file)
         return {}  # No state updates
 
-    def get_event_specs(self) -> tuple[EventSpec, ...]:
-        return _SPECS
+    def get_event_specs(self) -> Sequence[EventSpec]:
+        return ()
+
+    def get_tool_specs(self) -> Sequence[ToolSpec]:
+        return (
+            ToolSpec(name="pm_done", tool_names=("submit_pm_done",)),
+            ToolSpec(
+                name="research_code_req",
+                tool_names=("research_dispatch_code",),
+            ),
+            ToolSpec(
+                name="research_web_req",
+                tool_names=("research_dispatch_web",),
+            ),
+            ToolSpec(
+                name="research_done",
+                tool_names=("submit_research_done",),
+            ),
+        )
 
     def handle_event(
         self,
@@ -86,41 +71,24 @@ class ProductManagementHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for product_management phase."""
-        if event.kind == "pm_completed":
-            return self._handle_pm_completed(state, ctx)
+        match event.kind:
+            case "pm_done":
+                return self._handle_pm_done(state, ctx)
+            case "research_code_req":
+                return self._handle_research_code_req(event, state, ctx)
+            case "research_web_req":
+                return self._handle_research_web_req(event, state, ctx)
+            case "research_done":
+                return self._handle_research_done(event, state, ctx)
+            case _:
+                return {}, None
 
-        if event.kind == "code_research_requested":
-            topic = extract_research_topic(event.path or "", "code-")
-            if topic:
-                return dispatch_research_task("code-researcher", topic, state, ctx)
-
-        if event.kind == "web_research_requested":
-            topic = extract_research_topic(event.path or "", "web-")
-            if topic:
-                return dispatch_research_task("web-researcher", topic, state, ctx)
-
-        if event.kind == "code_research_done":
-            topic = extract_research_topic(event.path or "", "code-")
-            if topic:
-                return notify_research_complete(
-                    "code-researcher", topic, state, ctx, "product-manager"
-                )
-
-        if event.kind == "web_research_done":
-            topic = extract_research_topic(event.path or "", "web-")
-            if topic:
-                return notify_research_complete(
-                    "web-researcher", topic, state, ctx, "product-manager"
-                )
-
-        return {}, None
-
-    def _handle_pm_completed(
+    def _handle_pm_done(
         self,
         state: dict,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Handle product management completion."""
+        """Handle product management completion via tool event."""
         # Apply approved preferences
         apply_role_preferences(ctx, "product-manager")
 
@@ -129,3 +97,87 @@ class ProductManagementHandler:
 
         # Transition to architecting
         return {"last_event": EVENT_PM_COMPLETED}, "architecting"
+
+    def _handle_research_code_req(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle code research request via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        if not topic:
+            return {}, None
+
+        # Write request.md before dispatching (side-effect ordering requirement)
+        req_dir = ctx.files.research_dir / f"code-{topic}"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        if not req_path.exists():
+            questions = payload.get("questions", [])
+            scope_hints = payload.get("scope_hints", [])
+            content = (
+                f"# Research Request: {topic}\n\n"
+                f"## Context\n{payload.get('context', '')}\n\n"
+                f"## Questions\n"
+                + "\n".join(f"- {q}" for q in questions)
+                + (
+                    "\n\n## Scope Hints\n" + "\n".join(f"- {h}" for h in scope_hints)
+                    if scope_hints
+                    else ""
+                )
+            )
+            req_path.write_text(content, encoding="utf-8")
+
+        return dispatch_research_task("code-researcher", topic, state, ctx)
+
+    def _handle_research_web_req(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle web research request via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        if not topic:
+            return {}, None
+
+        # Write request.md before dispatching (side-effect ordering requirement)
+        req_dir = ctx.files.research_dir / f"web-{topic}"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        if not req_path.exists():
+            questions = payload.get("questions", [])
+            scope_hints = payload.get("scope_hints", [])
+            content = (
+                f"# Research Request: {topic}\n\n"
+                f"## Context\n{payload.get('context', '')}\n\n"
+                f"## Questions\n"
+                + "\n".join(f"- {q}" for q in questions)
+                + (
+                    "\n\n## Scope Hints\n" + "\n".join(f"- {h}" for h in scope_hints)
+                    if scope_hints
+                    else ""
+                )
+            )
+            req_path.write_text(content, encoding="utf-8")
+
+        return dispatch_research_task("web-researcher", topic, state, ctx)
+
+    def _handle_research_done(
+        self,
+        event: WorkflowEvent,
+        state: dict,
+        ctx: PipelineContext,
+    ) -> tuple[dict, str | None]:
+        """Handle research completion via tool event."""
+        payload = event.payload.get("payload", {})
+        topic = payload.get("topic", "")
+        role_type = payload.get("role_type", "")  # "code" or "web"
+        if not topic or not role_type:
+            return {}, None
+
+        role = "code-researcher" if role_type == "code" else "web-researcher"
+        return notify_research_complete(role, topic, state, ctx, "product-manager")

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from agentmux.agent_labels import role_display_label
@@ -11,10 +11,11 @@ from agentmux.workflow.event_catalog import (
     EVENT_REVIEW_FAILED,
     EVENT_REVIEW_PASSED,
 )
-from agentmux.workflow.event_router import EventSpec, WorkflowEvent
+from agentmux.workflow.event_router import EventSpec, ToolSpec, WorkflowEvent
 from agentmux.workflow.handoff_artifacts import (
     load_review_text,
     review_yaml_has_verdict,
+    submit_review,
 )
 from agentmux.workflow.phase_helpers import (
     load_plan_meta,
@@ -40,38 +41,11 @@ _REVIEWER_ROLE_MAP = {
 }
 
 
-def _review_has_verdict(review_path: Path) -> bool:
-    """Return True when review.md contains a final verdict on its first line."""
-    try:
-        lines = review_path.read_text(encoding="utf-8").splitlines()
-        return bool(lines) and lines[0].strip().lower() in (
-            "verdict: pass",
-            "verdict: fail",
-        )
-    except OSError:
-        return False
-
-
-def _review_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
-    return not state.get("awaiting_summary") and (
-        (ctx.files.review.exists() and _review_has_verdict(ctx.files.review))
-        or review_yaml_has_verdict(ctx.files.review_dir)
-    )
-
-
 def _summary_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
     return bool(state.get("awaiting_summary")) and ctx.files.summary.exists()
 
 
 _SPECS = (
-    EventSpec(
-        name="review_ready",
-        watch_paths=(
-            "06_review/review.md",
-            "06_review/review.yaml",
-        ),
-        is_ready=_review_ready,
-    ),
     EventSpec(
         name="summary_ready",
         watch_paths=("08_completion/summary.md",),
@@ -83,8 +57,11 @@ _SPECS = (
 class ReviewingHandler:
     """Event-driven handler for reviewing phase."""
 
-    def get_event_specs(self) -> tuple[EventSpec, ...]:
+    def get_event_specs(self) -> Sequence[EventSpec]:
         return _SPECS
+
+    def get_tool_specs(self) -> Sequence[ToolSpec]:
+        return (ToolSpec(name="review", tool_names=("submit_review",)),)
 
     def enter(self, state: dict, ctx: PipelineContext) -> dict:
         """Called when entering reviewing phase.
@@ -160,49 +137,50 @@ class ReviewingHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for reviewing phase."""
-        if event.kind == "review_ready":
-            return self._handle_review_written(state, ctx)
-        if event.kind == "summary_ready":
-            return self._handle_summary_written(ctx)
-        return {}, None
+        match event.kind:
+            case "review":
+                return self._handle_review(event, state, ctx)
+            case "summary_ready":
+                return self._handle_summary_written(ctx)
+            case _:
+                return {}, None
 
-    def _handle_review_written(
+    def _handle_review(
         self,
+        event: WorkflowEvent,
         state: dict,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Handle review written event."""
+        """Handle review submission via tool event."""
+        payload = event.payload.get("payload", {})
+
+        # Write review artifacts (idempotent — guard by existence)
+        yaml_path = ctx.files.review_dir / "review.yaml"
+        if not yaml_path.exists():
+            submit_review(ctx.files.feature_dir, payload)
+
+        verdict = payload.get("verdict", "").lower()
+        review_iteration = int(state.get("review_iteration", 0))
+
+        # Archive this review for history (review_0.md, review_1.md, …).
+        archive_path = ctx.files.review_dir / f"review_{review_iteration}.md"
         review_text = load_review_text(
             ctx.files.review_dir,
             materialize_markdown=True,
         )
-        if review_text is None:
-            return {}, None
+        if review_text is not None:
+            archive_path.write_text(review_text, encoding="utf-8")
 
-        first_line = (
-            review_text.splitlines()[0].strip().lower()
-            if review_text.splitlines()
-            else ""
-        )
-
-        review_iteration = int(state.get("review_iteration", 0))
-
-        # Archive this review for history (review_0.md, review_1.md, …).
-        # review.md itself is kept so the summary prompt and monitor can still
-        # reference it by the canonical name.
-        archive_path = ctx.files.review_dir / f"review_{review_iteration}.md"
-        archive_path.write_text(review_text, encoding="utf-8")
-
-        if first_line == "verdict: pass":
+        if verdict == "pass":
             ctx.runtime.finish_many("coder")
             ctx.runtime.kill_primary("coder")
             return self._request_summary(state, ctx)
 
-        if first_line == "verdict: fail":
+        if verdict == "fail":
             if review_iteration >= ctx.max_review_iterations:
                 return {"last_event": EVENT_REVIEW_FAILED}, "completing"
 
-            ctx.files.fix_request.write_text(review_text, encoding="utf-8")
+            ctx.files.fix_request.write_text(review_text or "", encoding="utf-8")
             return {
                 "last_event": EVENT_REVIEW_FAILED,
                 "review_iteration": review_iteration + 1,

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -48,11 +48,34 @@ def _review_has_verdict(review_path: Path) -> bool:
         return False
 
 
+def _review_yaml_has_verdict(review_dir: Path) -> bool:
+    """Return True when review.yaml exists with a valid verdict."""
+    yaml_path = review_dir / "review.yaml"
+    if not yaml_path.exists():
+        return False
+    try:
+        import yaml
+
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        return isinstance(data, dict) and data.get("verdict") in (
+            "pass",
+            "fail",
+        )
+    except Exception:
+        return False
+
+
 def _review_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
     return (
         not state.get("awaiting_summary")
         and ctx.files.review.exists()
         and _review_has_verdict(ctx.files.review)
+    )
+
+
+def _review_yaml_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
+    return not state.get("awaiting_summary") and _review_yaml_has_verdict(
+        ctx.files.review_dir
     )
 
 
@@ -63,8 +86,16 @@ def _summary_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
 _SPECS = (
     EventSpec(
         name="review_ready",
-        watch_paths=("06_review/review.md",),
+        watch_paths=(
+            "06_review/review.md",
+            "06_review/review.yaml",
+        ),
         is_ready=_review_ready,
+    ),
+    EventSpec(
+        name="review_yaml_ready",
+        watch_paths=("06_review/review.yaml",),
+        is_ready=_review_yaml_ready,
     ),
     EventSpec(
         name="summary_ready",
@@ -149,7 +180,7 @@ class ReviewingHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for reviewing phase."""
-        if event.kind == "review_ready":
+        if event.kind in ("review_ready", "review_yaml_ready"):
             return self._handle_review_written(state, ctx)
         if event.kind == "summary_ready":
             return self._handle_summary_written(ctx)

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -12,6 +12,10 @@ from agentmux.workflow.event_catalog import (
     EVENT_REVIEW_PASSED,
 )
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
+from agentmux.workflow.handoff_artifacts import (
+    load_review_text,
+    review_yaml_has_verdict,
+)
 from agentmux.workflow.phase_helpers import (
     load_plan_meta,
     select_reviewer_type,
@@ -48,34 +52,10 @@ def _review_has_verdict(review_path: Path) -> bool:
         return False
 
 
-def _review_yaml_has_verdict(review_dir: Path) -> bool:
-    """Return True when review.yaml exists with a valid verdict."""
-    yaml_path = review_dir / "review.yaml"
-    if not yaml_path.exists():
-        return False
-    try:
-        import yaml
-
-        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-        return isinstance(data, dict) and data.get("verdict") in (
-            "pass",
-            "fail",
-        )
-    except Exception:
-        return False
-
-
 def _review_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
-    return (
-        not state.get("awaiting_summary")
-        and ctx.files.review.exists()
-        and _review_has_verdict(ctx.files.review)
-    )
-
-
-def _review_yaml_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
-    return not state.get("awaiting_summary") and _review_yaml_has_verdict(
-        ctx.files.review_dir
+    return not state.get("awaiting_summary") and (
+        (ctx.files.review.exists() and _review_has_verdict(ctx.files.review))
+        or review_yaml_has_verdict(ctx.files.review_dir)
     )
 
 
@@ -91,11 +71,6 @@ _SPECS = (
             "06_review/review.yaml",
         ),
         is_ready=_review_ready,
-    ),
-    EventSpec(
-        name="review_yaml_ready",
-        watch_paths=("06_review/review.yaml",),
-        is_ready=_review_yaml_ready,
     ),
     EventSpec(
         name="summary_ready",
@@ -116,14 +91,19 @@ class ReviewingHandler:
 
         Sends reviewer prompt based on review_strategy routing.
         """
-        # On resume, if the reviewer already wrote review.md leave it in place.
-        # seed_existing_files() will publish FILE_EVENT_CREATED for it and
-        # handle_event() will process the verdict correctly.
-        if state.get("last_event") == EVENT_RESUMED and ctx.files.review.exists():
+        # On resume, if the reviewer already wrote review output leave it in
+        # place. seed_existing_files() will publish file events and handle_event()
+        # will process the verdict correctly.
+        if state.get("last_event") == EVENT_RESUMED and (
+            ctx.files.review.exists() or review_yaml_has_verdict(ctx.files.review_dir)
+        ):
             return {}
 
         if ctx.files.review.exists():
             ctx.files.review.unlink()
+        review_yaml = ctx.files.review_dir / "review.yaml"
+        if review_yaml.exists():
+            review_yaml.unlink()
 
         # Load plan_meta and determine reviewer type
         plan_meta = load_plan_meta(ctx.files.planning_dir)
@@ -180,7 +160,7 @@ class ReviewingHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events for reviewing phase."""
-        if event.kind in ("review_ready", "review_yaml_ready"):
+        if event.kind == "review_ready":
             return self._handle_review_written(state, ctx)
         if event.kind == "summary_ready":
             return self._handle_summary_written(ctx)
@@ -192,10 +172,13 @@ class ReviewingHandler:
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle review written event."""
-        if not ctx.files.review.exists():
+        review_text = load_review_text(
+            ctx.files.review_dir,
+            materialize_markdown=True,
+        )
+        if review_text is None:
             return {}, None
 
-        review_text = ctx.files.review.read_text(encoding="utf-8")
         first_line = (
             review_text.splitlines()[0].strip().lower()
             if review_text.splitlines()

--- a/src/agentmux/workflow/handoff_artifacts.py
+++ b/src/agentmux/workflow/handoff_artifacts.py
@@ -1,0 +1,228 @@
+"""Helpers for validating and materializing structured handoff artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..shared.models import SESSION_DIR_NAMES
+from .handoff_contracts import validate_submission
+
+_VALID_REVIEW_VERDICTS = {"pass", "fail"}
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    """Write data as YAML, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = yaml.dump(data, default_flow_style=False, sort_keys=False)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_md(path: Path, content: str) -> None:
+    """Write markdown content, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _validate_or_raise(contract_name: str, data: dict[str, Any]) -> None:
+    """Validate data against the named contract; raise on failure."""
+    errors = validate_submission(contract_name, data)
+    if errors:
+        raise ValueError(
+            f"Validation failed for '{contract_name}': " + "; ".join(errors)
+        )
+
+
+def generate_architecture_md(data: dict[str, Any]) -> str:
+    """Generate human-readable markdown from architecture data."""
+    lines = ["# Architecture", ""]
+    lines.extend(["## Solution Overview", "", data["solution_overview"].strip(), ""])
+
+    lines.append("## Components")
+    lines.append("")
+    for comp in data["components"]:
+        lines.append(f"### {comp['name']}")
+        lines.append("")
+        lines.append(f"**Responsibility:** {comp['responsibility']}")
+        interfaces = comp.get("interfaces")
+        if interfaces:
+            lines.append("")
+            lines.append("**Interfaces:**")
+            for iface in interfaces:
+                lines.append(f"- {iface}")
+        lines.append("")
+
+    for section, key in [
+        ("Interfaces and Contracts", "interfaces_and_contracts"),
+        ("Data Models", "data_models"),
+        ("Cross-Cutting Concerns", "cross_cutting_concerns"),
+        ("Technology Choices", "technology_choices"),
+        ("Risks and Mitigations", "risks_and_mitigations"),
+    ]:
+        lines.extend([f"## {section}", "", data[key].strip(), ""])
+
+    if data.get("design_handoff"):
+        lines.extend(["## Design Handoff", "", data["design_handoff"].strip(), ""])
+
+    return "\n".join(lines)
+
+
+def generate_plan_md(data: dict[str, Any]) -> str:
+    """Generate plan.md from plan_overview content."""
+    return data["plan_overview"].strip() + "\n"
+
+
+def generate_subplan_md(data: dict[str, Any]) -> str:
+    """Generate plan_N.md from subplan data."""
+    lines = [f"# {data['title']}", ""]
+    lines.extend(["## Scope", "", data["scope"].strip(), ""])
+    lines.extend(["## Owned Files", ""])
+    for file_path in data["owned_files"]:
+        lines.append(f"- `{file_path}`")
+    lines.append("")
+    lines.extend(["## Dependencies", "", data["dependencies"].strip(), ""])
+    lines.extend(
+        ["## Implementation Approach", "", data["implementation_approach"].strip(), ""]
+    )
+    lines.extend(
+        ["## Acceptance Criteria", "", data["acceptance_criteria"].strip(), ""]
+    )
+    if data.get("isolation_rationale"):
+        lines.extend(
+            ["## Isolation Rationale", "", data["isolation_rationale"].strip(), ""]
+        )
+    return "\n".join(lines)
+
+
+def generate_tasks_md(data: dict[str, Any]) -> str:
+    """Generate tasks_N.md checklist from subplan tasks."""
+    lines = [f"# Tasks: {data['title']}", ""]
+    for task in data["tasks"]:
+        lines.append(f"- [ ] {task}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_review_md(data: dict[str, Any]) -> str:
+    """Generate review.md with verdict on first line for runtime compatibility."""
+    verdict = data["verdict"]
+    lines = [f"verdict: {verdict}", ""]
+    lines.extend(["## Summary", "", data["summary"].strip(), ""])
+
+    if verdict == "fail" and data.get("findings"):
+        lines.append("## Findings")
+        lines.append("")
+        for i, finding in enumerate(data["findings"], 1):
+            lines.append(f"### Finding {i}")
+            lines.append("")
+            if finding.get("location"):
+                lines.append(f"**Location:** `{finding['location']}`")
+            lines.append(f"**Issue:** {finding['issue']}")
+            if finding.get("severity"):
+                lines.append(f"**Severity:** {finding['severity']}")
+            lines.append(f"**Recommendation:** {finding['recommendation']}")
+            lines.append("")
+
+    if verdict == "pass" and data.get("commit_message"):
+        lines.extend(
+            ["## Suggested Commit Message", "", data["commit_message"].strip(), ""]
+        )
+
+    return "\n".join(lines)
+
+
+def submit_architecture(feature_dir: Path, data: dict[str, Any]) -> str:
+    """Validate and write architecture handoff artifacts."""
+    _validate_or_raise("architecture", data)
+    planning_dir = feature_dir / SESSION_DIR_NAMES["planning"]
+    planning_dir.mkdir(parents=True, exist_ok=True)
+    _write_yaml(planning_dir / "architecture.yaml", data)
+    _write_md(planning_dir / "architecture.md", generate_architecture_md(data))
+    return "Architecture submitted. Files: architecture.yaml, architecture.md"
+
+
+def submit_execution_plan(feature_dir: Path, data: dict[str, Any]) -> str:
+    """Validate and write execution plan artifacts."""
+    _validate_or_raise("execution_plan", data)
+    planning_dir = feature_dir / SESSION_DIR_NAMES["planning"]
+    planning_dir.mkdir(parents=True, exist_ok=True)
+
+    yaml_data = {
+        "version": 1,
+        "review_strategy": data["review_strategy"],
+        "needs_design": data["needs_design"],
+        "needs_docs": data["needs_docs"],
+        "doc_files": data["doc_files"],
+        "groups": data["groups"],
+    }
+    _write_yaml(planning_dir / "execution_plan.yaml", yaml_data)
+    _write_md(planning_dir / "plan.md", generate_plan_md(data))
+    return "Execution plan submitted. Files: execution_plan.yaml, plan.md"
+
+
+def submit_subplan(feature_dir: Path, data: dict[str, Any]) -> str:
+    """Validate and write subplan artifacts."""
+    _validate_or_raise("subplan", data)
+    planning_dir = feature_dir / SESSION_DIR_NAMES["planning"]
+    planning_dir.mkdir(parents=True, exist_ok=True)
+
+    index = data["index"]
+    _write_yaml(planning_dir / f"plan_{index}.yaml", data)
+    _write_md(planning_dir / f"plan_{index}.md", generate_subplan_md(data))
+    _write_md(planning_dir / f"tasks_{index}.md", generate_tasks_md(data))
+    return (
+        f"Sub-plan {index} submitted. "
+        f"Files: plan_{index}.yaml, plan_{index}.md, tasks_{index}.md"
+    )
+
+
+def submit_review(feature_dir: Path, data: dict[str, Any]) -> str:
+    """Validate and write review artifacts."""
+    _validate_or_raise("review", data)
+    review_dir = feature_dir / SESSION_DIR_NAMES["review"]
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_yaml(review_dir / "review.yaml", data)
+    _write_md(review_dir / "review.md", generate_review_md(data))
+    return (
+        f"Review submitted (verdict: {data['verdict']}). Files: review.yaml, review.md"
+    )
+
+
+def _load_review_yaml_data(review_dir: Path) -> dict[str, Any] | None:
+    yaml_path = review_dir / "review.yaml"
+    if not yaml_path.exists():
+        return None
+    try:
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict) or data.get("verdict") not in _VALID_REVIEW_VERDICTS:
+        return None
+    return None if validate_submission("review", data) else data
+
+
+def review_yaml_has_verdict(review_dir: Path) -> bool:
+    """Return True when review.yaml contains a valid review submission."""
+    return _load_review_yaml_data(review_dir) is not None
+
+
+def load_review_text(
+    review_dir: Path, *, materialize_markdown: bool = False
+) -> str | None:
+    """Load the review text, falling back to canonical review.yaml when present."""
+    markdown_path = review_dir / "review.md"
+    yaml_data = _load_review_yaml_data(review_dir)
+    if yaml_data is not None:
+        rendered = generate_review_md(yaml_data)
+        if materialize_markdown and not markdown_path.exists():
+            _write_md(markdown_path, rendered)
+        return rendered
+    if not markdown_path.exists():
+        return None
+    try:
+        return markdown_path.read_text(encoding="utf-8")
+    except OSError:
+        return None

--- a/src/agentmux/workflow/handoff_contracts.py
+++ b/src/agentmux/workflow/handoff_contracts.py
@@ -369,6 +369,10 @@ def validate_submission(contract_name: str, data: dict[str, Any]) -> list[str]:
 
         value = data[fld.name]
 
+        # Optional fields: treat empty string as "not provided" — skip type check
+        if not fld.required and isinstance(value, str) and not value.strip():
+            continue
+
         if not _check_type(value, fld.type):
             errors.append(
                 f"Field '{fld.name}' has invalid type "

--- a/src/agentmux/workflow/handoff_contracts.py
+++ b/src/agentmux/workflow/handoff_contracts.py
@@ -1,0 +1,536 @@
+"""Handoff contract definitions for structured agent submissions.
+
+Defines the schema/interface for each MCP submission tool's parameters.
+Used by:
+- MCP submit tools for input validation
+- Prompt rendering for fallback YAML examples (non-MCP providers)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Field specification
+# ---------------------------------------------------------------------------
+
+_VALID_VERDICTS = {"pass", "fail"}
+_VALID_MODES = {"serial", "parallel"}
+_VALID_SEVERITIES = {"low", "medium", "high"}
+_VALID_FOCUS_AREAS = {
+    "security",
+    "performance",
+    "testing",
+    "error-handling",
+    "accessibility",
+    "documentation",
+    "maintainability",
+}
+_VALID_FINDING_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Specification for a single field in a handoff contract."""
+
+    name: str
+    type: str  # "str", "bool", "int", "list[str]", etc.
+    required: bool = True
+    description: str = ""
+    allowed_values: frozenset[str] | None = None
+    example: Any = None
+
+
+@dataclass(frozen=True)
+class HandoffContract:
+    """Contract definition for a handoff submission."""
+
+    name: str
+    description: str
+    fields: tuple[FieldSpec, ...]
+    yaml_file: str  # relative path within feature dir
+    md_file: str  # generated markdown companion
+
+    def field_names(self) -> set[str]:
+        return {f.name for f in self.fields}
+
+    def required_fields(self) -> set[str]:
+        return {f.name for f in self.fields if f.required}
+
+
+# ---------------------------------------------------------------------------
+# Contract: Architecture
+# ---------------------------------------------------------------------------
+
+ARCHITECTURE_CONTRACT = HandoffContract(
+    name="architecture",
+    description="Technical architecture document produced by the architect.",
+    yaml_file="02_planning/architecture.yaml",
+    md_file="02_planning/architecture.md",
+    fields=(
+        FieldSpec(
+            name="solution_overview",
+            type="str",
+            description="High-level approach and rationale.",
+            example="Use a plugin-based architecture with dynamic loading.",
+        ),
+        FieldSpec(
+            name="components",
+            type="list[dict]",
+            description=(
+                "System components. Each: {name, responsibility, interfaces: [...]}."
+            ),
+            example=[
+                {
+                    "name": "AuthService",
+                    "responsibility": "Handles user authentication",
+                    "interfaces": ["login()", "logout()", "verify_token()"],
+                }
+            ],
+        ),
+        FieldSpec(
+            name="interfaces_and_contracts",
+            type="str",
+            description="API boundaries, data formats, protocols.",
+        ),
+        FieldSpec(
+            name="data_models",
+            type="str",
+            description="Key entities, relationships, storage.",
+        ),
+        FieldSpec(
+            name="cross_cutting_concerns",
+            type="str",
+            description="Error handling, logging, security, testing strategy.",
+        ),
+        FieldSpec(
+            name="technology_choices",
+            type="str",
+            description="Tools, libraries, frameworks with rationale.",
+        ),
+        FieldSpec(
+            name="risks_and_mitigations",
+            type="str",
+            description="Known risks and mitigation strategies.",
+        ),
+        FieldSpec(
+            name="design_handoff",
+            type="str",
+            required=False,
+            description="Optional notes for the designer if UI work is needed.",
+        ),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Contract: Execution Plan (merged plan_meta + execution_plan)
+# ---------------------------------------------------------------------------
+
+EXECUTION_PLAN_CONTRACT = HandoffContract(
+    name="execution_plan",
+    description="Merged execution plan with scheduling groups and metadata.",
+    yaml_file="02_planning/execution_plan.yaml",
+    md_file="02_planning/plan.md",
+    fields=(
+        FieldSpec(
+            name="groups",
+            type="list[dict]",
+            description=(
+                "Execution groups. Each: "
+                "{group_id, mode: 'serial'|'parallel', plans: [{file, name}]}."
+            ),
+            example=[
+                {
+                    "group_id": "core",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Core setup"}],
+                }
+            ],
+        ),
+        FieldSpec(
+            name="review_strategy",
+            type="dict",
+            description=(
+                "Review configuration: {severity: low|medium|high, focus: [...]}."
+            ),
+            example={"severity": "medium", "focus": ["security", "testing"]},
+        ),
+        FieldSpec(
+            name="needs_design",
+            type="bool",
+            description="Whether a design phase is required.",
+            example=False,
+        ),
+        FieldSpec(
+            name="needs_docs",
+            type="bool",
+            description="Whether documentation updates are needed.",
+            example=True,
+        ),
+        FieldSpec(
+            name="doc_files",
+            type="list[str]",
+            description="Documentation files to create or update.",
+            example=["docs/api.md"],
+        ),
+        FieldSpec(
+            name="plan_overview",
+            type="str",
+            description="Human-readable plan summary (becomes plan.md content).",
+        ),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Contract: Subplan
+# ---------------------------------------------------------------------------
+
+SUBPLAN_CONTRACT = HandoffContract(
+    name="subplan",
+    description="Individual execution sub-plan for the coder.",
+    yaml_file="02_planning/plan_{index}.yaml",
+    md_file="02_planning/plan_{index}.md",
+    fields=(
+        FieldSpec(
+            name="index",
+            type="int",
+            description="Sub-plan number (1, 2, 3, ...).",
+            example=1,
+        ),
+        FieldSpec(
+            name="title",
+            type="str",
+            description="Short descriptive title.",
+            example="Implement user authentication module",
+        ),
+        FieldSpec(
+            name="scope",
+            type="str",
+            description="What this sub-plan covers.",
+        ),
+        FieldSpec(
+            name="owned_files",
+            type="list[str]",
+            description="Files created or modified (for parallel isolation).",
+            example=["src/auth.py", "tests/test_auth.py"],
+        ),
+        FieldSpec(
+            name="dependencies",
+            type="str",
+            description="What this sub-plan depends on.",
+        ),
+        FieldSpec(
+            name="implementation_approach",
+            type="str",
+            description="How to implement — step-by-step approach.",
+        ),
+        FieldSpec(
+            name="acceptance_criteria",
+            type="str",
+            description="Testable criteria for completion.",
+        ),
+        FieldSpec(
+            name="tasks",
+            type="list[str]",
+            description="Task checklist items for progress tracking.",
+            example=["Create auth module", "Add login endpoint", "Write tests"],
+        ),
+        FieldSpec(
+            name="isolation_rationale",
+            type="str",
+            required=False,
+            description="Why this sub-plan is safe for parallel execution.",
+        ),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Contract: Review
+# ---------------------------------------------------------------------------
+
+REVIEW_CONTRACT = HandoffContract(
+    name="review",
+    description="Code review verdict and findings.",
+    yaml_file="06_review/review.yaml",
+    md_file="06_review/review.md",
+    fields=(
+        FieldSpec(
+            name="verdict",
+            type="str",
+            description="Review outcome: 'pass' or 'fail'.",
+            allowed_values=frozenset(_VALID_VERDICTS),
+            example="pass",
+        ),
+        FieldSpec(
+            name="summary",
+            type="str",
+            description="What was reviewed and the outcome.",
+        ),
+        FieldSpec(
+            name="findings",
+            type="list[dict]",
+            required=False,
+            description=(
+                "On fail: list of issues. "
+                "Each: {location, issue, severity, recommendation}."
+            ),
+            example=[
+                {
+                    "location": "src/auth.py:42",
+                    "issue": "Missing input validation",
+                    "severity": "high",
+                    "recommendation": "Add email format check before database lookup.",
+                }
+            ],
+        ),
+        FieldSpec(
+            name="commit_message",
+            type="str",
+            required=False,
+            description="Suggested commit message (on pass).",
+        ),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Contract registry
+# ---------------------------------------------------------------------------
+
+CONTRACTS: dict[str, HandoffContract] = {
+    c.name: c
+    for c in (
+        ARCHITECTURE_CONTRACT,
+        EXECUTION_PLAN_CONTRACT,
+        SUBPLAN_CONTRACT,
+        REVIEW_CONTRACT,
+    )
+}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class ValidationError(Exception):
+    """Raised when a submission fails contract validation."""
+
+    def __init__(self, contract_name: str, errors: list[str]) -> None:
+        self.contract_name = contract_name
+        self.errors = errors
+        super().__init__(
+            f"Handoff validation failed for '{contract_name}': {'; '.join(errors)}"
+        )
+
+
+def _check_type(value: Any, type_str: str) -> bool:  # noqa: PLR0911
+    """Loose type check against a FieldSpec type string."""
+    if type_str == "str":
+        return isinstance(value, str) and bool(value.strip())
+    if type_str in ("optional[str]",):
+        return value is None or (isinstance(value, str) and bool(value.strip()))
+    if type_str == "bool":
+        return isinstance(value, bool)
+    if type_str == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_str == "list[str]":
+        return isinstance(value, list) and all(
+            isinstance(v, str) and v.strip() for v in value
+        )
+    if type_str == "list[dict]":
+        return isinstance(value, list) and all(isinstance(v, dict) for v in value)
+    if type_str == "dict":
+        return isinstance(value, dict)
+    return True
+
+
+def validate_submission(contract_name: str, data: dict[str, Any]) -> list[str]:
+    """Validate *data* against the named contract.
+
+    Returns a list of human-readable error strings (empty == valid).
+    """
+    contract = CONTRACTS.get(contract_name)
+    if contract is None:
+        return [f"Unknown contract: {contract_name}"]
+
+    errors: list[str] = []
+
+    # Required fields
+    for fld in contract.fields:
+        if fld.required and fld.name not in data:
+            errors.append(f"Missing required field: {fld.name}")
+            continue
+
+        if fld.name not in data:
+            continue
+
+        value = data[fld.name]
+
+        if not _check_type(value, fld.type):
+            errors.append(
+                f"Field '{fld.name}' has invalid type "
+                f"(expected {fld.type}, got {type(value).__name__})."
+            )
+            continue
+
+        if (
+            fld.allowed_values
+            and isinstance(value, str)
+            and value not in fld.allowed_values
+        ):
+            errors.append(
+                f"Field '{fld.name}' must be one of: "
+                f"{', '.join(sorted(fld.allowed_values))} (got '{value}')."
+            )
+
+    # Contract-specific validation
+    if contract_name == "architecture":
+        _validate_architecture(data, errors)
+    elif contract_name == "execution_plan":
+        _validate_execution_plan(data, errors)
+    elif contract_name == "subplan":
+        _validate_subplan(data, errors)
+    elif contract_name == "review":
+        _validate_review(data, errors)
+
+    return errors
+
+
+def _validate_architecture(data: dict[str, Any], errors: list[str]) -> None:
+    components = data.get("components")
+    if isinstance(components, list):
+        for i, comp in enumerate(components, 1):
+            if not isinstance(comp, dict):
+                continue
+            if not comp.get("name"):
+                errors.append(f"components[{i}] missing 'name'.")
+            if not comp.get("responsibility"):
+                errors.append(f"components[{i}] missing 'responsibility'.")
+
+
+def _validate_execution_plan(data: dict[str, Any], errors: list[str]) -> None:
+    groups = data.get("groups")
+    if isinstance(groups, list) and len(groups) == 0:
+        errors.append("groups must contain at least one group.")
+    if isinstance(groups, list):
+        seen_ids: set[str] = set()
+        for i, grp in enumerate(groups, 1):
+            if not isinstance(grp, dict):
+                errors.append(f"groups[{i}] must be a mapping.")
+                continue
+            gid = grp.get("group_id", "")
+            if not gid:
+                errors.append(f"groups[{i}] missing 'group_id'.")
+            elif gid in seen_ids:
+                errors.append(f"groups[{i}] has duplicate group_id '{gid}'.")
+            else:
+                seen_ids.add(gid)
+            mode = grp.get("mode", "")
+            if mode not in _VALID_MODES:
+                errors.append(
+                    f"groups[{i}].mode must be 'serial' or 'parallel' (got '{mode}')."
+                )
+            plans = grp.get("plans")
+            if not isinstance(plans, list) or not plans:
+                errors.append(f"groups[{i}].plans must be a non-empty list.")
+            elif isinstance(plans, list):
+                for j, p in enumerate(plans, 1):
+                    if not isinstance(p, dict):
+                        errors.append(f"groups[{i}].plans[{j}] must be a mapping.")
+                    elif not p.get("file") or not p.get("name"):
+                        errors.append(
+                            f"groups[{i}].plans[{j}] must have 'file' and 'name'."
+                        )
+
+    strategy = data.get("review_strategy")
+    if isinstance(strategy, dict):
+        sev = strategy.get("severity", "")
+        if sev and sev not in _VALID_SEVERITIES:
+            errors.append(
+                f"review_strategy.severity must be one of: "
+                f"{', '.join(sorted(_VALID_SEVERITIES))} (got '{sev}')."
+            )
+
+
+def _validate_subplan(data: dict[str, Any], errors: list[str]) -> None:
+    idx = data.get("index")
+    if isinstance(idx, int) and idx < 1:
+        errors.append("index must be >= 1.")
+
+    tasks = data.get("tasks")
+    if isinstance(tasks, list) and len(tasks) == 0:
+        errors.append("tasks must contain at least one item.")
+
+    owned = data.get("owned_files")
+    if isinstance(owned, list) and len(owned) == 0:
+        errors.append("owned_files must contain at least one item.")
+
+
+def _validate_review(data: dict[str, Any], errors: list[str]) -> None:
+    verdict = data.get("verdict")
+    findings = data.get("findings")
+
+    if verdict == "fail":
+        if not findings or not isinstance(findings, list) or len(findings) == 0:
+            errors.append("A 'fail' verdict requires non-empty 'findings'.")
+        elif isinstance(findings, list):
+            for i, finding in enumerate(findings, 1):
+                if not isinstance(finding, dict):
+                    errors.append(f"findings[{i}] must be a mapping.")
+                    continue
+                if not finding.get("issue"):
+                    errors.append(f"findings[{i}] missing 'issue'.")
+                if not finding.get("recommendation"):
+                    errors.append(f"findings[{i}] missing 'recommendation'.")
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering helper
+# ---------------------------------------------------------------------------
+
+
+def render_contract_prompt(contract_name: str) -> str:
+    """Render a compact YAML example for embedding in agent prompts.
+
+    Used as fallback documentation when agents cannot use MCP tools.
+    """
+    contract = CONTRACTS.get(contract_name)
+    if contract is None:
+        return f"<!-- unknown contract: {contract_name} -->"
+
+    lines = [
+        f"### {contract.description}",
+        "",
+        f"Write `{contract.yaml_file}` with this structure:",
+        "",
+        "```yaml",
+    ]
+    for fld in contract.fields:
+        optional = "" if fld.required else "  # optional"
+        if fld.example is not None:
+            lines.append(f"{fld.name}: {_yaml_inline(fld.example)}{optional}")
+        else:
+            lines.append(f"{fld.name}: ...{optional}")
+    lines.extend(["```", ""])
+    return "\n".join(lines)
+
+
+def _yaml_inline(value: Any) -> str:
+    """Produce a compact inline YAML representation for examples."""
+    if isinstance(value, str):
+        return f'"{value}"' if " " in value or not value else value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+        if all(isinstance(v, str) for v in value):
+            return "[" + ", ".join(v for v in value) + "]"
+        return "[ ... ]"
+    if isinstance(value, dict):
+        parts = [f"{k}: {_yaml_inline(v)}" for k, v in value.items()]
+        return "{" + ", ".join(parts) + "}"
+    return str(value)

--- a/src/agentmux/workflow/handoff_contracts.py
+++ b/src/agentmux/workflow/handoff_contracts.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import yaml
+
 # ---------------------------------------------------------------------------
 # Field specification
 # ---------------------------------------------------------------------------
@@ -518,19 +520,12 @@ def render_contract_prompt(contract_name: str) -> str:
 
 def _yaml_inline(value: Any) -> str:
     """Produce a compact inline YAML representation for examples."""
-    if isinstance(value, str):
-        return f'"{value}"' if " " in value or not value else value
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, int):
-        return str(value)
-    if isinstance(value, list):
-        if not value:
-            return "[]"
-        if all(isinstance(v, str) for v in value):
-            return "[" + ", ".join(v for v in value) + "]"
-        return "[ ... ]"
-    if isinstance(value, dict):
-        parts = [f"{k}: {_yaml_inline(v)}" for k, v in value.items()]
-        return "{" + ", ".join(parts) + "}"
-    return str(value)
+    rendered = yaml.safe_dump(
+        value,
+        default_flow_style=True,
+        sort_keys=False,
+        width=10_000,
+    ).strip()
+    if rendered.endswith("\n..."):
+        rendered = rendered[: -len("\n...")].rstrip()
+    return rendered

--- a/src/agentmux/workflow/orchestrator.py
+++ b/src/agentmux/workflow/orchestrator.py
@@ -11,6 +11,7 @@ from ..runtime.interruption_sources import (
     INTERRUPTION_EVENT_PANE_EXITED,
     InterruptionEventSource,
 )
+from ..runtime.tool_events import ToolCallEventSource
 from ..sessions.state_store import cleanup_feature_dir, load_state
 from ..shared.models import BATCH_AGENT_ROLES, GitHubConfig, WorkflowSettings
 from .event_router import WorkflowEvent, WorkflowEventRouter
@@ -55,10 +56,11 @@ class PipelineOrchestrator:
         )
 
     def build_event_bus(self, files, runtime, wake_event: threading.Event) -> EventBus:
-        """Build the event bus with file and interruption sources."""
+        """Build the event bus with file, tool-call, and interruption sources."""
         bus = EventBus(
             sources=[
                 FileEventSource(files.feature_dir),
+                ToolCallEventSource(files.feature_dir),
                 InterruptionEventSource(runtime),
             ]
         )

--- a/src/agentmux/workflow/phase_helpers.py
+++ b/src/agentmux/workflow/phase_helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ..sessions.state_store import now_iso, read_json_resilient, write_state
+from ..sessions.state_store import now_iso, write_state
 from .transitions import PipelineContext
 
 
@@ -56,7 +56,22 @@ def reset_markers(feature_dir: Path, pattern: str) -> None:
 
 
 def load_plan_meta(planning_dir: Path) -> dict[str, object]:
-    return read_json_resilient(planning_dir / "plan_meta.json", {})
+    import yaml
+
+    path = planning_dir / "execution_plan.yaml"
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return {}
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    meta_keys = {"needs_design", "needs_docs", "doc_files", "review_strategy"}
+    return {k: v for k, v in data.items() if k in meta_keys}
 
 
 # =============================================================================
@@ -198,7 +213,7 @@ def select_reviewer_type(plan_meta: dict) -> str:
     """Select the appropriate reviewer type based on plan_meta review_strategy.
 
     Args:
-        plan_meta: The plan_meta dictionary from 02_planning/plan_meta.json
+        plan_meta: The plan_meta dictionary from 02_planning/execution_plan.yaml
 
     Returns:
         One of "logic" | "quality" | "expert"

--- a/src/agentmux/workflow/phase_registry.py
+++ b/src/agentmux/workflow/phase_registry.py
@@ -11,7 +11,6 @@ To add a new phase:
 
 from __future__ import annotations
 
-import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -128,16 +127,16 @@ def _fixing_done(feature_dir: Path, state: dict[str, Any]) -> bool:
 
 def _designing_needed_and_done(feature_dir: Path, state: dict[str, Any]) -> bool:
     """True when the design artifact exists (or the phase is not needed)."""
-    plan_meta_path = feature_dir / "02_planning" / "plan_meta.json"
-    if not plan_meta_path.exists():
-        return True  # No plan_meta → designing not needed → treat as done
+    import yaml
+
+    ep_path = feature_dir / "02_planning" / "execution_plan.yaml"
+    if not ep_path.exists():
+        return True  # No execution plan → designing not needed → treat as done
     try:
-        plan_meta: dict[str, Any] = json.loads(
-            plan_meta_path.read_text(encoding="utf-8")
-        )
-    except json.JSONDecodeError:
+        data: dict[str, Any] = yaml.safe_load(ep_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
         return True
-    if not bool(plan_meta.get("needs_design")):
+    if not isinstance(data, dict) or not bool(data.get("needs_design")):
         return True  # Phase not required for this run
     return (feature_dir / "04_design" / "design.md").exists()
 
@@ -145,13 +144,15 @@ def _designing_needed_and_done(feature_dir: Path, state: dict[str, Any]) -> bool
 def _reviewing_startup_role(
     feature_dir: Path, state: dict[str, Any], agents: dict[str, Any]
 ) -> str | None:
+    import yaml
+
     _ = state
-    plan_meta_path = feature_dir / "02_planning" / "plan_meta.json"
+    ep_path = feature_dir / "02_planning" / "execution_plan.yaml"
     plan_meta: dict[str, Any] = {}
-    if plan_meta_path.exists():
+    if ep_path.exists():
         try:
-            loaded = json.loads(plan_meta_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+            loaded = yaml.safe_load(ep_path.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError):
             loaded = {}
         if isinstance(loaded, dict):
             plan_meta = loaded

--- a/src/agentmux/workflow/phase_registry.py
+++ b/src/agentmux/workflow/phase_registry.py
@@ -36,6 +36,7 @@ from .handlers.implementing import ImplementingHandler
 from .handlers.planning import PlanningHandler
 from .handlers.product_management import ProductManagementHandler
 from .handlers.reviewing import ReviewingHandler
+from .handoff_artifacts import review_yaml_has_verdict
 from .phase_helpers import select_reviewer_type
 
 # ---------------------------------------------------------------------------
@@ -95,13 +96,13 @@ def _implementing_done(feature_dir: Path, state: dict[str, Any]) -> bool:
 def _reviewing_done(feature_dir: Path, state: dict[str, Any]) -> bool:
     """True when the reviewing phase has completed.
 
-    In a fix iteration review.md is processed and deleted before transitioning to
-    fixing.  We use fix_request.md + done_1 presence to distinguish:
+    In a fix iteration review output is processed and deleted before transitioning
+    to fixing. We use fix_request.md + done_1 presence to distinguish:
     - done_1 missing → review ran, fix needed → reviewing IS done
     - done_1 exists  → fix applied, follow-up review pending → reviewing NOT done
     """
     review_dir = feature_dir / "06_review"
-    if (review_dir / "review.md").exists():
+    if (review_dir / "review.md").exists() or review_yaml_has_verdict(review_dir):
         return True  # Reviewer wrote output; orchestrator may not have processed it yet
     fix_iteration = (review_dir / "fix_request.md").exists() and int(
         state.get("review_iteration", 0)

--- a/src/agentmux/workflow/prompts.py
+++ b/src/agentmux/workflow/prompts.py
@@ -385,7 +385,7 @@ def build_coder_subplan_prompt(
 def build_coder_whole_plan_prompt(files: RuntimeFiles) -> str:
     """Build a single combined prompt for single-coder mode (e.g. copilot).
 
-    Reads all sub-plans from execution_plan.json and embeds their content
+    Reads all sub-plans from execution_plan.yaml and embeds their content
     inline so one coder instance can implement the full plan using internal
     sub-agents.  The coder is instructed to write each done_N marker as it
     finishes the corresponding plan.
@@ -400,7 +400,7 @@ def build_coder_whole_plan_prompt(files: RuntimeFiles) -> str:
             match = re.match(r"^plan_(\d+)\.md$", plan_ref.file)
             if match is None:
                 raise RuntimeError(
-                    f"Unexpected plan file name in execution_plan.json: {plan_ref.file}"
+                    f"Unexpected plan file name in execution_plan.yaml: {plan_ref.file}"
                 )
             index = int(match.group(1))
             all_marker_indexes.append(index)

--- a/tests/integration/test_event_driven_workflow.py
+++ b/tests/integration/test_event_driven_workflow.py
@@ -110,8 +110,10 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
         )
         return ctx, files.state
 
-    def _write_execution_plan(self, ctx: PipelineContext) -> None:
+    def _write_execution_plan(self, ctx: PipelineContext, **meta: object) -> None:
         """Write a simple execution plan."""
+        import yaml
+
         planning_dir = ctx.files.planning_dir
         planning_dir.mkdir(parents=True, exist_ok=True)
         (planning_dir / "plan_1.md").write_text(
@@ -120,19 +122,20 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
         (planning_dir / "tasks_1.md").write_text(
             "# Tasks for plan 1\n\n- [ ] task\n", encoding="utf-8"
         )
-        (planning_dir / "execution_plan.json").write_text(
-            json.dumps(
+
+        data: dict[str, object] = {
+            "version": 1,
+            "groups": [
                 {
-                    "version": 1,
-                    "groups": [
-                        {
-                            "group_id": "g1",
-                            "mode": "serial",
-                            "plans": [{"file": "plan_1.md", "name": "implementation"}],
-                        }
-                    ],
+                    "group_id": "g1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "implementation"}],
                 }
-            ),
+            ],
+        }
+        data.update(meta)
+        (planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(data, default_flow_style=False),
             encoding="utf-8",
         )
 
@@ -182,10 +185,7 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             # 3. Create plan files to trigger transition to implementing
             ctx.files.plan.write_text("# Test Plan\n", encoding="utf-8")
             ctx.files.tasks.write_text("# Tasks\n- [ ] task\n", encoding="utf-8")
-            (ctx.files.planning_dir / "plan_meta.json").write_text(
-                json.dumps({"needs_design": False}), encoding="utf-8"
-            )
-            self._write_execution_plan(ctx)
+            self._write_execution_plan(ctx, needs_design=False)
 
             # Handle plan creation
             event = WorkflowEvent(kind="file.created", path="02_planning/plan.md")
@@ -195,7 +195,7 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             router.handle(event, load_state(state_path), ctx)
 
             event = WorkflowEvent(
-                kind="file.created", path="02_planning/plan_meta.json"
+                kind="file.created", path="02_planning/execution_plan.yaml"
             )
             updates, next_phase = router.handle(event, load_state(state_path), ctx)
 

--- a/tests/integration/test_event_driven_workflow.py
+++ b/tests/integration/test_event_driven_workflow.py
@@ -1,7 +1,7 @@
 """Integration test for event-driven workflow.
 
-This test simulates a complete workflow using file events to verify
-the event-driven architecture works end-to-end.
+This test simulates a complete workflow using MCP tool events to verify
+the tool-event-driven architecture works end-to-end.
 """
 
 from __future__ import annotations
@@ -72,7 +72,7 @@ class FakeRuntime:
 
 
 class TestEventDrivenWorkflowIntegration(unittest.TestCase):
-    """Integration test simulating complete workflow with events."""
+    """Integration test simulating complete workflow with tool events."""
 
     def _make_ctx(self, feature_dir: Path) -> tuple[PipelineContext, Path]:
         """Create pipeline context and state path."""
@@ -110,10 +110,8 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
         )
         return ctx, files.state
 
-    def _write_execution_plan(self, ctx: PipelineContext, **meta: object) -> None:
-        """Write a simple execution plan."""
-        import yaml
-
+    def _write_plan_files(self, ctx: PipelineContext) -> None:
+        """Write plan_1.md and tasks_1.md so coder prompts can be built."""
         planning_dir = ctx.files.planning_dir
         planning_dir.mkdir(parents=True, exist_ok=True)
         (planning_dir / "plan_1.md").write_text(
@@ -123,24 +121,8 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             "# Tasks for plan 1\n\n- [ ] task\n", encoding="utf-8"
         )
 
-        data: dict[str, object] = {
-            "version": 1,
-            "groups": [
-                {
-                    "group_id": "g1",
-                    "mode": "serial",
-                    "plans": [{"file": "plan_1.md", "name": "implementation"}],
-                }
-            ],
-        }
-        data.update(meta)
-        (planning_dir / "execution_plan.yaml").write_text(
-            yaml.dump(data, default_flow_style=False),
-            encoding="utf-8",
-        )
-
     def test_full_workflow_with_events(self):
-        """Simulate a complete workflow using file events."""
+        """Simulate a complete workflow using MCP tool events."""
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td) / "feature"
             ctx, state_path = self._make_ctx(feature_dir)
@@ -148,94 +130,143 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             # Create router
             router = WorkflowEventRouter(PHASE_HANDLERS)
 
-            # 1. Start in product_management phase
+            # 1. Start in product_management phase — pm submits done via MCP tool
             state = load_state(state_path)
             state["phase"] = "product_management"
             write_state(state_path, state)
 
-            # Write the done marker that the event represents
-            pm_dir = feature_dir / "01_product_management"
-            pm_dir.mkdir(parents=True, exist_ok=True)
-            (pm_dir / "done").touch()
-
             event = WorkflowEvent(
-                kind="file.created", path="01_product_management/done"
+                kind="tool.submit_pm_done",
+                payload={"payload": {}},
             )
-            updates, next_phase = router.handle(event, load_state(state_path), ctx)
+            updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Verify transition to architecting
             state = load_state(state_path)
             self.assertEqual("architecting", state["phase"])
-            self.assertEqual("pm_completed", state["last_event"])
+            self.assertEqual("pm_completed", state.get("last_event"))
 
-            # 2. Create architecture.md to trigger transition to planning
+            # 2. Architect submits architecture via MCP tool
             ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-            ctx.files.architecture.write_text("# Test Architecture\n", encoding="utf-8")
 
             event = WorkflowEvent(
-                kind="file.created", path="02_planning/architecture.md"
+                kind="tool.submit_architecture",
+                payload={
+                    "payload": {
+                        "solution_overview": "Simple layered architecture",
+                        "components": [
+                            {
+                                "name": "Core",
+                                "responsibility": "Main logic",
+                                "interfaces": ["run()"],
+                            }
+                        ],
+                        "interfaces_and_contracts": "Internal Python APIs",
+                        "data_models": "Feature state stored in JSON",
+                        "cross_cutting_concerns": "Logging, error handling",
+                        "technology_choices": "Python stdlib",
+                        "risks_and_mitigations": "None significant",
+                    }
+                },
             )
-            updates, next_phase = router.handle(event, load_state(state_path), ctx)
+            updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Verify transition to planning
             state = load_state(state_path)
             self.assertEqual("planning", state["phase"])
-            self.assertEqual("architecture_written", state["last_event"])
 
-            # 3. Create plan files to trigger transition to implementing
-            ctx.files.plan.write_text("# Test Plan\n", encoding="utf-8")
-            ctx.files.tasks.write_text("# Tasks\n- [ ] task\n", encoding="utf-8")
-            self._write_execution_plan(ctx, needs_design=False)
+            # 3. Planner submits subplan and execution plan via MCP tools
+            self._write_plan_files(ctx)
 
-            # Handle plan creation
-            event = WorkflowEvent(kind="file.created", path="02_planning/plan.md")
-            router.handle(event, load_state(state_path), ctx)
-
-            event = WorkflowEvent(kind="file.created", path="02_planning/tasks.md")
+            event = WorkflowEvent(
+                kind="tool.submit_subplan",
+                payload={
+                    "payload": {
+                        "index": 1,
+                        "title": "Implementation",
+                        "scope": "Implement the feature",
+                        "owned_files": ["src/feature.py"],
+                        "dependencies": "None",
+                        "implementation_approach": "Write the code",
+                        "acceptance_criteria": "Tests pass",
+                        "tasks": ["Implement feature", "Write tests"],
+                        "isolation_rationale": "",
+                    }
+                },
+            )
             router.handle(event, load_state(state_path), ctx)
 
             event = WorkflowEvent(
-                kind="file.created", path="02_planning/execution_plan.yaml"
+                kind="tool.submit_execution_plan",
+                payload={
+                    "payload": {
+                        "plan_overview": "Single-phase implementation",
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "serial",
+                                "plans": [
+                                    {"file": "plan_1.md", "name": "Implementation"}
+                                ],
+                            }
+                        ],
+                        "review_strategy": {"severity": "medium", "focus": []},
+                        "needs_design": False,
+                        "needs_docs": False,
+                        "doc_files": [],
+                    }
+                },
             )
-            updates, next_phase = router.handle(event, load_state(state_path), ctx)
+            updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Verify transition to implementing
             state = load_state(state_path)
             self.assertEqual("implementing", state["phase"])
             self.assertEqual("plan_written", state["last_event"])
 
-            # 4. Create done marker to trigger transition to reviewing
+            # 4. Coder submits done via MCP tool
             ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.implementation_dir / "done_1").touch()
 
-            event = WorkflowEvent(kind="file.created", path="05_implementation/done_1")
-            updates, next_phase = router.handle(event, load_state(state_path), ctx)
+            event = WorkflowEvent(
+                kind="tool.submit_done",
+                payload={"payload": {"subplan_index": 1}},
+            )
+            updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Verify transition to reviewing
             state = load_state(state_path)
             self.assertEqual("reviewing", state["phase"])
             self.assertEqual("implementation_completed", state["last_event"])
 
-            # 5. Create review.md with pass verdict — reviewer asked for summary
+            # 5. Reviewer submits review (pass) via MCP tool
             ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
-            ctx.files.review.write_text("verdict: pass\n", encoding="utf-8")
 
-            event = WorkflowEvent(kind="file.created", path="06_review/review.md")
-            updates, next_phase = router.handle(event, load_state(state_path), ctx)
+            event = WorkflowEvent(
+                kind="tool.submit_review",
+                payload={
+                    "payload": {
+                        "verdict": "pass",
+                        "summary": "All checks pass, implementation is solid.",
+                        "findings": [],
+                        "commit_message": "feat: implement feature",
+                    }
+                },
+            )
+            updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Still in reviewing, awaiting summary from reviewer
             state = load_state(state_path)
             self.assertEqual("reviewing", state["phase"])
             self.assertTrue(state.get("awaiting_summary"))
 
-            # 5b. Reviewer writes summary — kill reviewer + transition to completing
+            # 5b. Reviewer writes summary.md — triggers summary_ready EventSpec
             ctx.files.summary.parent.mkdir(parents=True, exist_ok=True)
             ctx.files.summary.write_text(
                 "## Summary\nImplemented the feature.\n", encoding="utf-8"
             )
 
             event = WorkflowEvent(kind="file.created", path="08_completion/summary.md")
-            updates, next_phase = router.handle(event, load_state(state_path), ctx)
+            updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Verify transition to completing
             state = load_state(state_path)
@@ -249,9 +280,11 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             )
 
             # Mock the completion service to avoid git operations
-            with patch(
-                "agentmux.workflow.handlers.completing.CompletionService.finalize_approval"
-            ) as mock_finalize:
+            cs_path = (
+                "agentmux.workflow.handlers.completing"
+                ".CompletionService.finalize_approval"
+            )
+            with patch(cs_path) as mock_finalize:
                 mock_finalize.return_value = MagicMock(
                     commit_hash="abc123",
                     pr_url=None,
@@ -267,26 +300,29 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             self.assertEqual(0, exit_code)
 
     def test_workflow_handles_research_tasks(self):
-        """Test that research tasks are properly dispatched and completed."""
+        """Test research tasks dispatched and completed via tool events."""
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td) / "feature"
             ctx, state_path = self._make_ctx(feature_dir)
 
             router = WorkflowEventRouter(PHASE_HANDLERS)
 
-            # Start in planning phase
+            # Start in architecting phase (research is dispatched from architecting)
             state = load_state(state_path)
-            state["phase"] = "planning"
+            state["phase"] = "architecting"
             write_state(state_path, state)
 
-            # Create research request
-            research_dir = ctx.files.research_dir / "code-auth"
-            research_dir.mkdir(parents=True, exist_ok=True)
-            (research_dir / "request.md").write_text("research auth", encoding="utf-8")
-
-            # Handle research request
+            # Architect dispatches code research via MCP tool
             event = WorkflowEvent(
-                kind="file.created", path="03_research/code-auth/request.md"
+                kind="tool.research_dispatch_code",
+                payload={
+                    "payload": {
+                        "topic": "auth",
+                        "context": "Need to understand authentication flow",
+                        "questions": ["How does the auth module work?"],
+                        "scope_hints": ["src/auth/"],
+                    }
+                },
             )
 
             with (
@@ -299,18 +335,25 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
                 mock_build.return_value = "research prompt"
                 updates, next_phase = router.handle(event, load_state(state_path), ctx)
 
-            # Verify research task was dispatched
+            # Verify research task was dispatched and request.md was written
             self.assertIn("research_tasks", updates)
             self.assertEqual("dispatched", updates["research_tasks"].get("auth"))
+            req_path = ctx.files.research_dir / "code-auth" / "request.md"
+            self.assertTrue(req_path.exists())
 
-            # Simulate research completion
+            # Simulate research completion via MCP tool
             state = load_state(state_path)
             state["research_tasks"] = {"auth": "dispatched"}
             write_state(state_path, state)
-            (research_dir / "done").touch()
 
             event = WorkflowEvent(
-                kind="file.created", path="03_research/code-auth/done"
+                kind="tool.submit_research_done",
+                payload={
+                    "payload": {
+                        "topic": "auth",
+                        "role_type": "code",
+                    }
+                },
             )
             updates, next_phase = router.handle(event, load_state(state_path), ctx)
 
@@ -318,9 +361,9 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             self.assertIn("research_tasks", updates)
             self.assertEqual("done", updates["research_tasks"].get("auth"))
 
-            # Verify planner was notified
+            # Verify architect was notified
             self.assertTrue(
-                any("planner" in role for role, _ in ctx.runtime.notifications)
+                any("architect" in role for role, _ in ctx.runtime.notifications)
             )
 
 

--- a/tests/integration/test_tool_event_pipeline.py
+++ b/tests/integration/test_tool_event_pipeline.py
@@ -1,0 +1,187 @@
+"""Integration smoke test: tool_events.jsonl → EventBus pipeline.
+
+Tests that ToolCallEventSource correctly reads tool_events.jsonl and
+publishes SessionEvent objects to the EventBus without requiring tmux
+or real agents.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentmux.runtime.event_bus import EventBus, SessionEvent
+from agentmux.runtime.tool_events import ToolCallEventSource, append_tool_event
+
+
+class FakeEventBus:
+    """Minimal EventBus stand-in that captures published events."""
+
+    def __init__(self) -> None:
+        self.events: list[SessionEvent] = []
+
+    def publish(self, event: SessionEvent) -> None:
+        self.events.append(event)
+
+
+class TestToolEventPipeline(unittest.TestCase):
+    """Smoke tests for the tool_events.jsonl → EventBus pipeline."""
+
+    def test_append_tool_event_writes_jsonl(self) -> None:
+        """append_tool_event writes a valid JSONL line to the log file."""
+        import json
+
+        with tempfile.TemporaryDirectory() as td:
+            log_path = Path(td) / "tool_events.jsonl"
+            append_tool_event(log_path, "submit_done", {"subplan_index": 1})
+
+            self.assertTrue(log_path.exists())
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(1, len(lines))
+            entry = json.loads(lines[0])
+            self.assertEqual("submit_done", entry["tool"])
+            self.assertEqual({"subplan_index": 1}, entry["payload"])
+            self.assertIn("timestamp", entry)
+
+    def test_append_tool_event_appends_multiple_lines(self) -> None:
+        """Multiple append_tool_event calls produce multiple lines."""
+        import json
+
+        with tempfile.TemporaryDirectory() as td:
+            log_path = Path(td) / "tool_events.jsonl"
+            append_tool_event(log_path, "submit_done", {"subplan_index": 1})
+            append_tool_event(log_path, "submit_review", {"verdict": "pass"})
+
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(2, len(lines))
+            self.assertEqual("submit_done", json.loads(lines[0])["tool"])
+            self.assertEqual("submit_review", json.loads(lines[1])["tool"])
+
+    def test_seed_existing_emits_event_for_each_line(self) -> None:
+        """_seed_existing publishes a SessionEvent per JSONL line."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            log_path = feature_dir / "tool_events.jsonl"
+            append_tool_event(log_path, "submit_done", {"subplan_index": 1})
+
+            source = ToolCallEventSource(feature_dir=feature_dir)
+            bus = FakeEventBus()
+            source._seed_existing(bus)
+
+            self.assertEqual(1, len(bus.events))
+            event = bus.events[0]
+            self.assertEqual("tool.submit_done", event.kind)
+            self.assertEqual("submit_done", event.payload.get("tool"))
+            self.assertEqual({"subplan_index": 1}, event.payload.get("payload"))
+            self.assertEqual("tool_call", event.source)
+
+    def test_seed_existing_emits_events_for_multiple_lines(self) -> None:
+        """_seed_existing emits one event per JSONL line."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            log_path = feature_dir / "tool_events.jsonl"
+            append_tool_event(log_path, "submit_done", {"subplan_index": 1})
+            append_tool_event(log_path, "submit_review", {"verdict": "pass"})
+
+            source = ToolCallEventSource(feature_dir=feature_dir)
+            bus = FakeEventBus()
+            source._seed_existing(bus)
+
+            self.assertEqual(2, len(bus.events))
+            self.assertEqual("tool.submit_done", bus.events[0].kind)
+            self.assertEqual("tool.submit_review", bus.events[1].kind)
+
+    def test_seed_existing_noop_when_file_missing(self) -> None:
+        """_seed_existing does nothing when tool_events.jsonl is absent."""
+        with tempfile.TemporaryDirectory() as td:
+            source = ToolCallEventSource(feature_dir=Path(td))
+            bus = FakeEventBus()
+            source._seed_existing(bus)
+
+            self.assertEqual(0, len(bus.events))
+
+    def test_seed_existing_skips_malformed_lines(self) -> None:
+        """_seed_existing skips non-JSON lines without crashing."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            log_path = feature_dir / "tool_events.jsonl"
+            log_path.write_text("not-json\n", encoding="utf-8")
+
+            source = ToolCallEventSource(feature_dir=feature_dir)
+            bus = FakeEventBus()
+            source._seed_existing(bus)
+
+            self.assertEqual(0, len(bus.events))
+
+    def test_on_modified_emits_only_new_lines(self) -> None:
+        """_on_modified emits only lines added after the initial seed."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            log_path = feature_dir / "tool_events.jsonl"
+            append_tool_event(log_path, "submit_done", {"subplan_index": 1})
+
+            source = ToolCallEventSource(feature_dir=feature_dir)
+            bus = FakeEventBus()
+            # Seed to advance the offset past the first line
+            source._seed_existing(bus)
+            self.assertEqual(1, len(bus.events))
+
+            # Append a new event after the seed
+            append_tool_event(log_path, "submit_review", {"verdict": "pass"})
+            source._on_modified(bus)
+
+            # Should only see the new event (total = 2, but _on_modified adds 1)
+            self.assertEqual(2, len(bus.events))
+            self.assertEqual("tool.submit_review", bus.events[1].kind)
+
+    def test_emit_line_produces_correct_session_event(self) -> None:
+        """_emit_line builds a SessionEvent with kind=tool.<name>."""
+        import json
+
+        with tempfile.TemporaryDirectory() as td:
+            source = ToolCallEventSource(feature_dir=Path(td))
+            bus = FakeEventBus()
+            entry = {
+                "tool": "submit_done",
+                "timestamp": "2026-04-08T12:00:00+00:00",
+                "payload": {"subplan_index": 3},
+            }
+            source._emit_line(json.dumps(entry), bus)
+
+            self.assertEqual(1, len(bus.events))
+            event = bus.events[0]
+            self.assertIsInstance(event, SessionEvent)
+            self.assertEqual("tool.submit_done", event.kind)
+            self.assertEqual("tool_call", event.source)
+            self.assertEqual("submit_done", event.payload.get("tool"))
+            self.assertEqual({"subplan_index": 3}, event.payload.get("payload"))
+
+    def test_tool_call_event_source_integrates_with_real_event_bus(self) -> None:
+        """ToolCallEventSource publishes to a real EventBus via _seed_existing."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            log_path = feature_dir / "tool_events.jsonl"
+            append_tool_event(
+                log_path,
+                "submit_done",
+                {"subplan_index": 1},
+            )
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(received.append)
+
+            source = ToolCallEventSource(feature_dir=feature_dir)
+            # Directly seed (bypasses watchdog — no filesystem watching needed)
+            source._seed_existing(bus)
+
+            self.assertEqual(1, len(received))
+            event = received[0]
+            self.assertEqual("tool.submit_done", event.kind)
+            self.assertEqual("submit_done", event.payload.get("tool"))
+            self.assertEqual({"subplan_index": 1}, event.payload.get("payload"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/mcp/test_copilot_configurator.py
+++ b/tests/integrations/mcp/test_copilot_configurator.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentmux.integrations.mcp import CopilotConfigurator, McpServerSpec
+
+
+class CopilotConfiguratorTests(unittest.TestCase):
+    """Tests for CopilotConfigurator class."""
+
+    def _server(self) -> McpServerSpec:
+        return McpServerSpec(
+            name="agentmux-research",
+            module="agentmux.integrations.mcp_research_server",
+            env={},
+        )
+
+    def setUp(self) -> None:
+        self.configurator = CopilotConfigurator()
+
+    def test_provider_is_copilot(self) -> None:
+        """provider attribute equals 'copilot'."""
+        self.assertEqual(self.configurator.provider, "copilot")
+
+    def test_config_path_returns_home_copilot_mcp_config(self) -> None:
+        """config_path(project_dir) → ~/.copilot/mcp-config.json."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                result = self.configurator.config_path(project_dir)
+                expected = home_dir / ".copilot" / "mcp-config.json"
+                self.assertEqual(result, expected)
+
+    # --- has_server tests ---
+
+    def test_has_server_false_when_config_missing(self) -> None:
+        """has_server returns False when config file does not exist."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.assertFalse(
+                    self.configurator.has_server(self._server(), project_dir)
+                )
+
+    def test_has_server_false_when_config_empty(self) -> None:
+        """has_server returns False when config exists but has no mcpServers."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text("{}", encoding="utf-8")
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.assertFalse(
+                    self.configurator.has_server(self._server(), project_dir)
+                )
+
+    def test_has_server_false_when_server_not_present(self) -> None:
+        """has_server returns False when config exists but server entry is absent."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps({"mcpServers": {"other-server": {}}}), encoding="utf-8"
+            )
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.assertFalse(
+                    self.configurator.has_server(self._server(), project_dir)
+                )
+
+    def test_has_server_true_when_server_present(self) -> None:
+        """has_server returns True when server entry exists in mcpServers."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "agentmux-research": {
+                                "type": "local",
+                                "command": sys.executable,
+                                "args": [
+                                    "-m",
+                                    "agentmux.integrations.mcp_research_server",
+                                ],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.assertTrue(
+                    self.configurator.has_server(self._server(), project_dir)
+                )
+
+    # --- install tests ---
+
+    def test_install_creates_config_when_absent(self) -> None:
+        """install creates config file and adds server entry when file is absent."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.install(self._server(), project_dir)
+
+            self.assertTrue(config_path.exists())
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertIn("mcpServers", data)
+            server = data["mcpServers"]["agentmux-research"]
+            self.assertEqual("local", server["type"])
+            self.assertEqual(sys.executable, server["command"])
+            self.assertEqual(
+                ["-m", "agentmux.integrations.mcp_research_server"], server["args"]
+            )
+            self.assertTrue(server["enabled"])
+
+    def test_install_adds_server_to_existing_config(self) -> None:
+        """install preserves existing config and adds server entry."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "playwright": {
+                                "type": "local",
+                                "command": "npx",
+                                "args": ["@playwright/mcp@latest"],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.install(self._server(), project_dir)
+
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertIn("playwright", data["mcpServers"])
+            self.assertIn("agentmux-research", data["mcpServers"])
+
+    def test_install_is_idempotent(self) -> None:
+        """install called twice does not duplicate the server entry."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.install(self._server(), project_dir)
+                self.configurator.install(self._server(), project_dir)
+
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                1, len([k for k in data["mcpServers"] if k == "agentmux-research"])
+            )
+            server = data["mcpServers"]["agentmux-research"]
+            self.assertEqual("local", server["type"])
+            self.assertEqual(sys.executable, server["command"])
+
+    def test_install_refreshes_existing_entry(self) -> None:
+        """install overwrites an existing server entry with fresh values."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "agentmux-research": {
+                                "type": "local",
+                                "command": "old-python",
+                                "args": ["-m", "old.module"],
+                                "enabled": True,
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.install(self._server(), project_dir)
+
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            server = data["mcpServers"]["agentmux-research"]
+            self.assertEqual(sys.executable, server["command"])
+            self.assertEqual(
+                ["-m", "agentmux.integrations.mcp_research_server"], server["args"]
+            )
+
+    # --- prompt_message tests ---
+
+    def test_prompt_message_contains_path_and_provider(self) -> None:
+        """prompt_message includes copilot provider label and config path."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                msg = self.configurator.prompt_message(
+                    self._server(), project_dir, "architect"
+                )
+
+            self.assertIn("copilot", msg)
+            self.assertIn("architect", msg)
+            self.assertIn(str(home_dir / ".copilot" / "mcp-config.json"), msg)
+
+    # --- uninstall tests ---
+
+    def test_uninstall_removes_server_entry(self) -> None:
+        """uninstall removes the server entry after install."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.install(self._server(), project_dir)
+                self.configurator.uninstall(self._server(), project_dir)
+
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("agentmux-research", data["mcpServers"])
+
+    def test_uninstall_safe_when_entry_absent(self) -> None:
+        """uninstall is a no-op when server entry was never present."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "playwright": {
+                                "type": "local",
+                                "command": "npx",
+                                "args": ["@playwright/mcp@latest"],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.uninstall(self._server(), project_dir)
+
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertIn("playwright", data["mcpServers"])
+            self.assertNotIn("agentmux-research", data["mcpServers"])
+
+    def test_uninstall_safe_when_config_missing(self) -> None:
+        """uninstall is a no-op when config file does not exist."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                # Should not raise
+                self.configurator.uninstall(self._server(), project_dir)
+
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            self.assertFalse(config_path.exists())
+
+    def test_uninstall_preserves_other_servers(self) -> None:
+        """uninstall removes only the target server, preserving others."""
+        with tempfile.TemporaryDirectory() as td:
+            home_dir = Path(td)
+            project_dir = home_dir / "project"
+            project_dir.mkdir()
+            config_path = home_dir / ".copilot" / "mcp-config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "agentmux-research": {
+                                "type": "local",
+                                "command": sys.executable,
+                                "args": [
+                                    "-m",
+                                    "agentmux.integrations.mcp_research_server",
+                                ],
+                                "enabled": True,
+                            },
+                            "playwright": {
+                                "type": "local",
+                                "command": "npx",
+                                "args": ["@playwright/mcp@latest"],
+                            },
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "agentmux.integrations.mcp.configurators.Path.home",
+                return_value=home_dir,
+            ):
+                self.configurator.uninstall(self._server(), project_dir)
+
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("agentmux-research", data["mcpServers"])
+            self.assertIn("playwright", data["mcpServers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_file_events.py
+++ b/tests/runtime/test_file_events.py
@@ -31,6 +31,7 @@ class RuntimeFileExclusionTests(unittest.TestCase):
             "runtime_state.json",
             "created_files.log",
             "status_log.txt",
+            "tool_events.jsonl",
         }
         self.assertEqual(RUNTIME_FILE_NAMES, expected_files)
 

--- a/tests/runtime/test_tool_events.py
+++ b/tests/runtime/test_tool_events.py
@@ -1,0 +1,283 @@
+"""Tests for runtime/tool_events.py — ToolCallEventSource and append_tool_event."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from agentmux.runtime.event_bus import EventBus, SessionEvent
+from agentmux.runtime.tool_events import ToolCallEventSource, append_tool_event
+
+
+class TestAppendToolEvent(unittest.TestCase):
+    """Tests for the append_tool_event helper."""
+
+    def test_creates_log_on_first_write(self) -> None:
+        """append_tool_event creates the log file on first call."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "subdir" / "tool_events.jsonl"
+            self.assertFalse(log_path.exists())
+
+            append_tool_event(log_path, "test_tool", {"key": "value"})
+
+            self.assertTrue(log_path.exists())
+
+    def test_writes_valid_json_line(self) -> None:
+        """Each line written is valid JSON with tool, timestamp, payload keys."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "tool_events.jsonl"
+
+            append_tool_event(log_path, "my_tool", {"foo": "bar"})
+
+            lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 1)
+            entry = json.loads(lines[0])
+            self.assertEqual(entry["tool"], "my_tool")
+            self.assertIn("timestamp", entry)
+            self.assertEqual(entry["payload"], {"foo": "bar"})
+
+    def test_appends_on_subsequent_calls(self) -> None:
+        """Subsequent calls append without truncating."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "tool_events.jsonl"
+
+            append_tool_event(log_path, "tool_a", {"a": 1})
+            append_tool_event(log_path, "tool_b", {"b": 2})
+            append_tool_event(log_path, "tool_c", {"c": 3})
+
+            lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 3)
+
+            entries = [json.loads(line) for line in lines]
+            self.assertEqual(entries[0]["tool"], "tool_a")
+            self.assertEqual(entries[1]["tool"], "tool_b")
+            self.assertEqual(entries[2]["tool"], "tool_c")
+
+
+class TestToolCallEventSourceSeeding(unittest.TestCase):
+    """Tests for ToolCallEventSource.start() seeding of existing entries."""
+
+    def test_seeds_existing_entries(self) -> None:
+        """start() reads all existing lines and emits SessionEvents."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            log_path = feature_dir / "tool_events.jsonl"
+
+            # Pre-populate the log
+            entries = [
+                {
+                    "tool": "submit_architecture",
+                    "timestamp": "2024-01-01T00:00:00",
+                    "payload": {"status": "ok"},
+                },
+                {
+                    "tool": "submit_plan",
+                    "timestamp": "2024-01-01T00:01:00",
+                    "payload": {"status": "ok"},
+                },
+            ]
+            log_path.write_text(
+                "\n".join(json.dumps(e) for e in entries) + "\n",
+                encoding="utf-8",
+            )
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+            source.stop()
+
+            self.assertEqual(len(received), 2)
+            self.assertEqual(received[0].kind, "tool.submit_architecture")
+            self.assertEqual(received[0].source, "tool_call")
+            self.assertEqual(received[0].payload.get("payload"), {"status": "ok"})
+            self.assertEqual(received[0].payload.get("tool"), "submit_architecture")
+            self.assertEqual(received[1].kind, "tool.submit_plan")
+
+    def test_seeds_empty_log(self) -> None:
+        """start() with an empty log emits no events."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            log_path = feature_dir / "tool_events.jsonl"
+            log_path.touch()
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+            source.stop()
+
+            self.assertEqual(len(received), 0)
+
+    def test_seeds_no_log_file(self) -> None:
+        """start() with no log file emits no events and does not crash."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+            source.stop()
+
+            self.assertEqual(len(received), 0)
+
+
+try:
+    import watchdog.observers  # noqa: F401
+
+    WATCHDOG_AVAILABLE = True
+except ImportError:
+    WATCHDOG_AVAILABLE = False
+
+
+class TestToolCallEventSourceTailing(unittest.TestCase):
+    """Tests for ToolCallEventSource tailing of new lines after start()."""
+
+    @unittest.skipUnless(WATCHDOG_AVAILABLE, "watchdog not installed")
+    def test_tails_new_lines_after_start(self) -> None:
+        """Lines appended after start() produce new SessionEvent emissions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            log_path = feature_dir / "tool_events.jsonl"
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+
+            # Append a new line
+            append_tool_event(log_path, "new_tool", {"data": "test"})
+
+            # Give watchdog time to pick up the change
+            time.sleep(0.5)
+
+            source.stop()
+
+            self.assertEqual(len(received), 1)
+            self.assertEqual(received[0].kind, "tool.new_tool")
+            self.assertEqual(received[0].payload.get("payload"), {"data": "test"})
+            self.assertEqual(received[0].payload.get("tool"), "new_tool")
+
+    @unittest.skipUnless(WATCHDOG_AVAILABLE, "watchdog not installed")
+    def test_tails_multiple_new_lines(self) -> None:
+        """Multiple lines appended after start() each produce an event."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            log_path = feature_dir / "tool_events.jsonl"
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+
+            append_tool_event(log_path, "tool_x", {"x": 1})
+            time.sleep(0.3)
+            append_tool_event(log_path, "tool_y", {"y": 2})
+            time.sleep(0.3)
+
+            source.stop()
+
+            self.assertEqual(len(received), 2)
+            kinds = {e.kind for e in received}
+            self.assertIn("tool.tool_x", kinds)
+            self.assertIn("tool.tool_y", kinds)
+
+
+class TestToolCallEventSourceStop(unittest.TestCase):
+    """Tests for ToolCallEventSource.stop() behavior."""
+
+    def test_stop_without_start(self) -> None:
+        """stop() before start() is a safe no-op."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            source = ToolCallEventSource(feature_dir)
+            source.stop()  # Should not raise
+
+    def test_double_stop(self) -> None:
+        """Second stop() call is safe (no-op)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            bus = EventBus()
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+            source.stop()
+            source.stop()  # Should not raise
+
+
+class TestToolCallEventSourceMalformedLines(unittest.TestCase):
+    """Tests for malformed JSON line handling."""
+
+    def test_malformed_lines_skipped_with_warning(self) -> None:
+        """Malformed JSON lines are skipped; valid lines before/after are emitted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            log_path = feature_dir / "tool_events.jsonl"
+
+            valid1 = {
+                "tool": "good_tool",
+                "timestamp": "2024-01-01T00:00:00",
+                "payload": {},
+            }
+            valid2 = {
+                "tool": "another_good",
+                "timestamp": "2024-01-01T00:01:00",
+                "payload": {},
+            }
+
+            content = (
+                json.dumps(valid1)
+                + "\n"
+                + "this is not json\n"
+                + json.dumps(valid2)
+                + "\n"
+            )
+            log_path.write_text(content, encoding="utf-8")
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+            source.stop()
+
+            # Both valid lines should be emitted, malformed one skipped
+            self.assertEqual(len(received), 2)
+            self.assertEqual(received[0].kind, "tool.good_tool")
+            self.assertEqual(received[1].kind, "tool.another_good")
+
+    def test_all_malformed_lines(self) -> None:
+        """If all lines are malformed, no events are emitted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feature_dir = Path(tmpdir)
+            log_path = feature_dir / "tool_events.jsonl"
+            log_path.write_text("garbage\nmore garbage\n", encoding="utf-8")
+
+            received: list[SessionEvent] = []
+            bus = EventBus()
+            bus.register(lambda event: received.append(event))
+
+            source = ToolCallEventSource(feature_dir)
+            source.start(bus)
+            source.stop()
+
+            self.assertEqual(len(received), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_code_researcher_requirements.py
+++ b/tests/test_code_researcher_requirements.py
@@ -278,37 +278,30 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             write_state(state_path, state)
 
-            (feature_dir / RESEARCH_DIR / "code-auth-module").mkdir(
-                parents=True, exist_ok=True
-            )
-            (feature_dir / RESEARCH_DIR / "code-auth-module" / "request.md").write_text(
-                "investigate auth",
-                encoding="utf-8",
-            )
-            stale_done = feature_dir / RESEARCH_DIR / "code-auth-module" / "done"
-            stale_done.touch()
-
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="code_research_requested",
-                path="03_research/code-auth-module/request.md",
-                payload={},
+                kind="research_code_req",
+                payload={
+                    "payload": {
+                        "topic": "auth-module",
+                        "context": "Investigate auth module",
+                        "questions": ["How does auth work?"],
+                        "scope_hints": ["src/auth/"],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
             )
 
             self.assertIsNone(next_phase)
-            self.assertFalse(stale_done.exists())
-            # spawn_task now receives the research directory, not the prompt file
-            # The call stores the directory name: "code-auth-module"
+            # spawn_task receives the research directory
+            research_dir = feature_dir / RESEARCH_DIR / "code-auth-module"
             self.assertEqual(
                 ("spawn_task", "code-researcher", "auth-module", "code-auth-module"),
                 ctx.runtime.calls[-1],
             )
-            self.assertTrue(
-                (feature_dir / RESEARCH_DIR / "code-auth-module" / "prompt.md").exists()
-            )
+            self.assertTrue((research_dir / "request.md").exists())
             self.assertEqual(
                 "dispatched", updates.get("research_tasks", {}).get("auth-module")
             )
@@ -324,16 +317,10 @@ class CodeResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             state["research_tasks"] = {"auth-module": "dispatched"}
             write_state(state_path, state)
-            (feature_dir / RESEARCH_DIR / "code-auth-module").mkdir(
-                parents=True, exist_ok=True
-            )
-            (feature_dir / RESEARCH_DIR / "code-auth-module" / "done").touch()
-
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="code_research_done",
-                path="03_research/code-auth-module/done",
-                payload={},
+                kind="research_done",
+                payload={"payload": {"topic": "auth-module", "role_type": "code"}},
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx

--- a/tests/test_designer_requirements.py
+++ b/tests/test_designer_requirements.py
@@ -268,9 +268,25 @@ class DesignerRequirementsTests(unittest.TestCase):
 
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="plan_written",
-                path="02_planning/execution_plan.yaml",
-                payload={},
+                kind="execution_plan",
+                payload={
+                    "payload": {
+                        "plan_overview": "Implementation plan",
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "serial",
+                                "plans": [
+                                    {"file": "plan_1.md", "name": "implementation"}
+                                ],
+                            }
+                        ],
+                        "review_strategy": {"severity": "medium", "focus": []},
+                        "needs_design": True,
+                        "needs_docs": False,
+                        "doc_files": [],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx

--- a/tests/test_designer_requirements.py
+++ b/tests/test_designer_requirements.py
@@ -108,7 +108,9 @@ def _make_ctx(
     return ctx, files.state
 
 
-def _write_execution_plan(feature_dir: Path, *, name: str = "implementation") -> None:
+def _write_execution_plan(
+    feature_dir: Path, *, name: str = "implementation", **meta: object
+) -> None:
     planning_dir = feature_dir / PLANNING_DIR
     planning_dir.mkdir(parents=True, exist_ok=True)
     (planning_dir / "plan_1.md").write_text(
@@ -117,19 +119,21 @@ def _write_execution_plan(feature_dir: Path, *, name: str = "implementation") ->
     (planning_dir / "tasks_1.md").write_text(
         "# Tasks for plan 1\n\n- [ ] task\n", encoding="utf-8"
     )
-    (planning_dir / "execution_plan.json").write_text(
-        json.dumps(
+    import yaml
+
+    data: dict[str, object] = {
+        "version": 1,
+        "groups": [
             {
-                "version": 1,
-                "groups": [
-                    {
-                        "group_id": "g1",
-                        "mode": "serial",
-                        "plans": [{"file": "plan_1.md", "name": name}],
-                    }
-                ],
+                "group_id": "g1",
+                "mode": "serial",
+                "plans": [{"file": "plan_1.md", "name": name}],
             }
-        ),
+        ],
+    }
+    data.update(meta)
+    (planning_dir / "execution_plan.yaml").write_text(
+        yaml.dump(data, default_flow_style=False),
         encoding="utf-8",
     )
 
@@ -252,7 +256,7 @@ class DesignerRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "planning"
             write_state(state_path, state)
-            _write_execution_plan(feature_dir, name="implementation")
+            _write_execution_plan(feature_dir, name="implementation", needs_design=True)
             (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
             # Write all three required files for plan completion
             (feature_dir / PLANNING_DIR / "plan.md").write_text(
@@ -261,14 +265,11 @@ class DesignerRequirementsTests(unittest.TestCase):
             (feature_dir / PLANNING_DIR / "tasks.md").write_text(
                 "# Tasks\n\n- [ ] task\n", encoding="utf-8"
             )
-            (feature_dir / PLANNING_DIR / "plan_meta.json").write_text(
-                '{"needs_design": true}\n', encoding="utf-8"
-            )
 
             handler = PlanningHandler()
             event = WorkflowEvent(
                 kind="plan_written",
-                path="02_planning/plan_meta.json",
+                path="02_planning/execution_plan.yaml",
                 payload={},
             )
             updates, next_phase = handler.handle_event(

--- a/tests/test_execution_plan_requirements.py
+++ b/tests/test_execution_plan_requirements.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import json
 import tempfile
 import unittest
 from pathlib import Path
+
+import yaml
 
 from agentmux.workflow.execution_plan import load_execution_plan
 
@@ -25,8 +26,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
             planning_dir.mkdir(parents=True, exist_ok=True)
             (planning_dir / "plan_1.md").write_text("# Plan 1\n", encoding="utf-8")
             (planning_dir / "plan_2.md").write_text("# Plan 2\n", encoding="utf-8")
-            (planning_dir / "execution_plan.json").write_text(
-                json.dumps(
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
                     {
                         "version": 1,
                         "groups": [
@@ -41,7 +42,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
                                 "plans": [{"file": "plan_2.md", "name": "API wiring"}],
                             },
                         ],
-                    }
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )
@@ -61,14 +63,15 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
             planning_dir = Path(td) / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
             (planning_dir / "plan_1.md").write_text("# Plan 1\n", encoding="utf-8")
-            (planning_dir / "execution_plan.json").write_text(
-                json.dumps(
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
                     {
                         "version": 1,
                         "groups": [
                             {"group_id": "g1", "mode": "serial", "plans": ["plan_1.md"]}
                         ],
-                    }
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )
@@ -80,8 +83,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             planning_dir = Path(td) / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
-            (planning_dir / "execution_plan.json").write_text(
-                json.dumps(
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
                     {
                         "version": 1,
                         "groups": [
@@ -91,7 +94,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
                                 "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
                             }
                         ],
-                    }
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )
@@ -103,8 +107,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             planning_dir = Path(td) / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
-            (planning_dir / "execution_plan.json").write_text(
-                json.dumps({"version": 1, "groups": {}}),
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump({"version": 1, "groups": {}}, default_flow_style=False),
                 encoding="utf-8",
             )
 
@@ -117,8 +121,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
             planning_dir.mkdir(parents=True, exist_ok=True)
             (planning_dir / "plan_1.md").write_text("# Plan 1\n", encoding="utf-8")
             (planning_dir / "plan_2.md").write_text("# Plan 2\n", encoding="utf-8")
-            (planning_dir / "execution_plan.json").write_text(
-                json.dumps(
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
                     {
                         "version": 1,
                         "groups": [
@@ -133,7 +137,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
                                 "plans": [{"file": "plan_2.md", "name": "Plan 2"}],
                             },
                         ],
-                    }
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )
@@ -146,8 +151,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
             planning_dir = Path(td) / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
             (planning_dir / "plan_1.md").write_text("# Plan 1\n", encoding="utf-8")
-            (planning_dir / "execution_plan.json").write_text(
-                json.dumps(
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
                     {
                         "version": 1,
                         "groups": [
@@ -157,7 +162,8 @@ class ExecutionPlanRequirementsTests(unittest.TestCase):
                                 "plans": [{"file": "plan_1.md"}],
                             }
                         ],
-                    }
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )

--- a/tests/test_github_integration_requirements.py
+++ b/tests/test_github_integration_requirements.py
@@ -12,6 +12,7 @@ import agentmux.pipeline.application as application
 from agentmux.configuration import load_layered_config
 from agentmux.integrations.github import (
     GitHubBootstrapper,
+    _format_issue_comments,
     assemble_pr_body,
     check_gh_authenticated,
     check_gh_available,
@@ -89,25 +90,70 @@ class GitHubHelpersTests(unittest.TestCase):
             self.assertFalse(check_gh_available())
             self.assertFalse(check_gh_authenticated())
 
-    def test_fetch_issue_returns_title_and_body(self) -> None:
+    def test_fetch_issue_returns_title_body_and_comments(self) -> None:
         with patch(
             "agentmux.integrations.github.subprocess.run",
             return_value=subprocess.CompletedProcess(
-                args=["gh", "issue", "view", "42", "--json", "title,body"],
+                args=["gh", "issue", "view", "42", "--json", "title,body,comments"],
                 returncode=0,
-                stdout=json.dumps({"title": "Fix auth", "body": "Issue details"}),
+                stdout=json.dumps(
+                    {
+                        "title": "Fix auth",
+                        "body": "Issue details",
+                        "comments": [],
+                    }
+                ),
                 stderr="",
             ),
         ) as run_mock:
             issue = fetch_issue("42")
 
-        self.assertEqual({"title": "Fix auth", "body": "Issue details"}, issue)
+        self.assertEqual(
+            {
+                "title": "Fix auth",
+                "body": "Issue details",
+                "comments": [],
+            },
+            issue,
+        )
         run_mock.assert_called_once_with(
-            ["gh", "issue", "view", "42", "--json", "title,body"],
+            ["gh", "issue", "view", "42", "--json", "title,body,comments"],
             capture_output=True,
             text=True,
             check=True,
         )
+
+    def test_fetch_issue_returns_comments_when_present(self) -> None:
+        comments_payload = [
+            {
+                "author": {"login": "alice"},
+                "body": "I can reproduce this.",
+                "createdAt": "2026-04-01T10:00:00Z",
+            },
+            {
+                "author": {"login": "bob"},
+                "body": "Fixed in #43.",
+                "createdAt": "2026-04-02T14:30:00Z",
+            },
+        ]
+        with patch(
+            "agentmux.integrations.github.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["gh", "issue", "view", "42", "--json", "title,body,comments"],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "title": "Fix auth",
+                        "body": "Issue details",
+                        "comments": comments_payload,
+                    }
+                ),
+                stderr="",
+            ),
+        ):
+            issue = fetch_issue("42")
+
+        self.assertEqual(comments_payload, issue["comments"])
 
     def test_fetch_issue_raises_actionable_error_on_failure(self) -> None:
         with (
@@ -115,7 +161,7 @@ class GitHubHelpersTests(unittest.TestCase):
                 "agentmux.integrations.github.subprocess.run",
                 side_effect=subprocess.CalledProcessError(
                     returncode=1,
-                    cmd=["gh", "issue", "view", "42", "--json", "title,body"],
+                    cmd=["gh", "issue", "view", "42", "--json", "title,body,comments"],
                     stderr="not found",
                 ),
             ),
@@ -327,6 +373,7 @@ class PipelineIssueTriggerTests(unittest.TestCase):
                     return_value={
                         "title": "Fix API auth flow",
                         "body": "Issue-sourced requirements",
+                        "comments": [],
                     },
                 ),
                 patch("agentmux.sessions.datetime") as datetime_mock,
@@ -469,6 +516,147 @@ class GitHubBootstrapperTests(unittest.TestCase):
 
         self.assertFalse(available)
         self.assertIn("gh CLI not available", "\n".join(messages))
+
+    def test_resolve_issue_includes_comments_in_prompt_text(self) -> None:
+        comments_payload = [
+            {
+                "author": {"login": "alice"},
+                "body": "I can reproduce this on Linux.",
+                "createdAt": "2026-04-01T10:00:00Z",
+            },
+        ]
+        messages: list[str] = []
+        bootstrapper = GitHubBootstrapper(
+            Path("/tmp/project"), GitHubConfig(), output=messages.append
+        )
+
+        with (
+            patch("agentmux.integrations.github.check_gh_available", return_value=True),
+            patch(
+                "agentmux.integrations.github.check_gh_authenticated",
+                return_value=True,
+            ),
+            patch(
+                "agentmux.integrations.github.fetch_issue",
+                return_value={
+                    "title": "Fix auth flow",
+                    "body": "The auth endpoint returns 500.",
+                    "comments": comments_payload,
+                },
+            ),
+            patch(
+                "agentmux.integrations.github.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["git", "pull"], returncode=0, stdout="", stderr=""
+                ),
+            ),
+        ):
+            result = bootstrapper.resolve_issue("42")
+
+        self.assertIn("The auth endpoint returns 500.", result.prompt_text)
+        self.assertIn("## Issue Comments", result.prompt_text)
+        self.assertIn("alice", result.prompt_text)
+        self.assertIn("I can reproduce this on Linux.", result.prompt_text)
+        self.assertEqual("Fix auth flow", result.slug_source)
+        self.assertEqual("42", result.issue_number)
+
+    def test_resolve_issue_without_comments_has_no_comments_section(self) -> None:
+        messages: list[str] = []
+        bootstrapper = GitHubBootstrapper(
+            Path("/tmp/project"), GitHubConfig(), output=messages.append
+        )
+
+        with (
+            patch("agentmux.integrations.github.check_gh_available", return_value=True),
+            patch(
+                "agentmux.integrations.github.check_gh_authenticated",
+                return_value=True,
+            ),
+            patch(
+                "agentmux.integrations.github.fetch_issue",
+                return_value={
+                    "title": "Simple task",
+                    "body": "Do something simple.",
+                    "comments": [],
+                },
+            ),
+            patch(
+                "agentmux.integrations.github.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["git", "pull"], returncode=0, stdout="", stderr=""
+                ),
+            ),
+        ):
+            result = bootstrapper.resolve_issue("10")
+
+        self.assertEqual("Do something simple.", result.prompt_text)
+        self.assertNotIn("## Issue Comments", result.prompt_text)
+        self.assertEqual("", result.comments_text)
+
+
+class FormatIssueCommentsTests(unittest.TestCase):
+    def test_empty_comments_returns_empty_string(self) -> None:
+        self.assertEqual("", _format_issue_comments([]))
+
+    def test_single_comment_is_formatted(self) -> None:
+        comments = [
+            {
+                "author": {"login": "alice"},
+                "body": "Looks good to me.",
+                "createdAt": "2026-04-01T10:00:00Z",
+            },
+        ]
+        result = _format_issue_comments(comments)
+
+        self.assertIn("## Issue Comments", result)
+        self.assertIn("### alice", result)
+        self.assertIn("2026-04-01T10:00:00Z", result)
+        self.assertIn("Looks good to me.", result)
+
+    def test_multiple_comments_are_formatted(self) -> None:
+        comments = [
+            {
+                "author": {"login": "alice"},
+                "body": "First comment.",
+                "createdAt": "2026-04-01T10:00:00Z",
+            },
+            {
+                "author": {"login": "bob"},
+                "body": "Second comment.",
+                "createdAt": "2026-04-02T14:30:00Z",
+            },
+        ]
+        result = _format_issue_comments(comments)
+
+        self.assertIn("### alice", result)
+        self.assertIn("First comment.", result)
+        self.assertIn("### bob", result)
+        self.assertIn("Second comment.", result)
+
+    def test_comment_without_author_shows_unknown(self) -> None:
+        comments = [
+            {
+                "body": "Anonymous comment.",
+                "createdAt": "2026-04-01T10:00:00Z",
+            },
+        ]
+        result = _format_issue_comments(comments)
+
+        self.assertIn("### Unknown", result)
+        self.assertIn("Anonymous comment.", result)
+
+    def test_comment_without_created_at_shows_no_date(self) -> None:
+        comments = [
+            {
+                "author": {"login": "charlie"},
+                "body": "No date comment.",
+            },
+        ]
+        result = _format_issue_comments(comments)
+
+        self.assertIn("### charlie", result)
+        self.assertNotIn("()", result)
+        self.assertIn("No date comment.", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_handoff_contracts.py
+++ b/tests/test_handoff_contracts.py
@@ -1,0 +1,292 @@
+"""Tests for handoff contract definitions, validation, and prompt rendering."""
+
+from __future__ import annotations
+
+import unittest
+
+from agentmux.workflow.handoff_contracts import (
+    ARCHITECTURE_CONTRACT,
+    CONTRACTS,
+    EXECUTION_PLAN_CONTRACT,
+    REVIEW_CONTRACT,
+    SUBPLAN_CONTRACT,
+    ValidationError,
+    render_contract_prompt,
+    validate_submission,
+)
+
+
+class TestContractRegistry(unittest.TestCase):
+    def test_all_contracts_registered(self):
+        self.assertIn("architecture", CONTRACTS)
+        self.assertIn("execution_plan", CONTRACTS)
+        self.assertIn("subplan", CONTRACTS)
+        self.assertIn("review", CONTRACTS)
+        self.assertEqual(len(CONTRACTS), 4)
+
+    def test_contract_field_names(self):
+        self.assertIn("solution_overview", ARCHITECTURE_CONTRACT.field_names())
+        self.assertIn("groups", EXECUTION_PLAN_CONTRACT.field_names())
+        self.assertIn("index", SUBPLAN_CONTRACT.field_names())
+        self.assertIn("verdict", REVIEW_CONTRACT.field_names())
+
+    def test_required_fields_subset_of_all(self):
+        for contract in CONTRACTS.values():
+            self.assertTrue(contract.required_fields() <= contract.field_names())
+
+
+class TestValidateArchitecture(unittest.TestCase):
+    def _valid_data(self):
+        return {
+            "solution_overview": "High-level approach",
+            "components": [
+                {
+                    "name": "AuthService",
+                    "responsibility": "Auth",
+                    "interfaces": ["login()"],
+                }
+            ],
+            "interfaces_and_contracts": "REST API",
+            "data_models": "User, Session",
+            "cross_cutting_concerns": "Logging",
+            "technology_choices": "Python + FastAPI",
+            "risks_and_mitigations": "None identified",
+        }
+
+    def test_valid_submission(self):
+        errors = validate_submission("architecture", self._valid_data())
+        self.assertEqual(errors, [])
+
+    def test_missing_required_field(self):
+        data = self._valid_data()
+        del data["solution_overview"]
+        errors = validate_submission("architecture", data)
+        self.assertTrue(any("solution_overview" in e for e in errors))
+
+    def test_optional_field_omitted(self):
+        data = self._valid_data()
+        # design_handoff is optional
+        self.assertNotIn("design_handoff", data)
+        errors = validate_submission("architecture", data)
+        self.assertEqual(errors, [])
+
+    def test_component_missing_name(self):
+        data = self._valid_data()
+        data["components"] = [{"responsibility": "Auth", "interfaces": []}]
+        errors = validate_submission("architecture", data)
+        self.assertTrue(any("name" in e for e in errors))
+
+    def test_component_missing_responsibility(self):
+        data = self._valid_data()
+        data["components"] = [{"name": "Svc", "interfaces": []}]
+        errors = validate_submission("architecture", data)
+        self.assertTrue(any("responsibility" in e for e in errors))
+
+    def test_wrong_type_for_components(self):
+        data = self._valid_data()
+        data["components"] = "not a list"
+        errors = validate_submission("architecture", data)
+        self.assertTrue(any("invalid type" in e for e in errors))
+
+
+class TestValidateExecutionPlan(unittest.TestCase):
+    def _valid_data(self):
+        return {
+            "groups": [
+                {
+                    "group_id": "core",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Setup"}],
+                }
+            ],
+            "review_strategy": {"severity": "medium", "focus": ["security"]},
+            "needs_design": False,
+            "needs_docs": True,
+            "doc_files": ["docs/api.md"],
+            "plan_overview": "This plan sets up core modules.",
+        }
+
+    def test_valid_submission(self):
+        errors = validate_submission("execution_plan", self._valid_data())
+        self.assertEqual(errors, [])
+
+    def test_duplicate_group_id(self):
+        data = self._valid_data()
+        data["groups"].append(
+            {
+                "group_id": "core",
+                "mode": "parallel",
+                "plans": [{"file": "plan_2.md", "name": "Extra"}],
+            }
+        )
+        errors = validate_submission("execution_plan", data)
+        self.assertTrue(any("duplicate" in e for e in errors))
+
+    def test_invalid_mode(self):
+        data = self._valid_data()
+        data["groups"][0]["mode"] = "concurrent"
+        errors = validate_submission("execution_plan", data)
+        self.assertTrue(any("mode" in e for e in errors))
+
+    def test_invalid_severity(self):
+        data = self._valid_data()
+        data["review_strategy"]["severity"] = "extreme"
+        errors = validate_submission("execution_plan", data)
+        self.assertTrue(any("severity" in e for e in errors))
+
+    def test_plan_entry_missing_file(self):
+        data = self._valid_data()
+        data["groups"][0]["plans"] = [{"name": "Missing file"}]
+        errors = validate_submission("execution_plan", data)
+        self.assertTrue(any("file" in e and "name" in e for e in errors))
+
+    def test_empty_groups_list(self):
+        data = self._valid_data()
+        data["groups"] = []
+        errors = validate_submission("execution_plan", data)
+        self.assertTrue(any("at least one" in e or "non-empty" in e for e in errors))
+
+
+class TestValidateSubplan(unittest.TestCase):
+    def _valid_data(self):
+        return {
+            "index": 1,
+            "title": "Auth module",
+            "scope": "User authentication",
+            "owned_files": ["src/auth.py"],
+            "dependencies": "None",
+            "implementation_approach": "Step by step",
+            "acceptance_criteria": "All tests pass",
+            "tasks": ["Create module", "Write tests"],
+        }
+
+    def test_valid_submission(self):
+        errors = validate_submission("subplan", self._valid_data())
+        self.assertEqual(errors, [])
+
+    def test_index_below_one(self):
+        data = self._valid_data()
+        data["index"] = 0
+        errors = validate_submission("subplan", data)
+        self.assertTrue(any("index" in e for e in errors))
+
+    def test_empty_tasks(self):
+        data = self._valid_data()
+        data["tasks"] = []
+        errors = validate_submission("subplan", data)
+        self.assertTrue(any("tasks" in e for e in errors))
+
+    def test_empty_owned_files(self):
+        data = self._valid_data()
+        data["owned_files"] = []
+        errors = validate_submission("subplan", data)
+        self.assertTrue(any("owned_files" in e for e in errors))
+
+    def test_optional_isolation_rationale(self):
+        data = self._valid_data()
+        data["isolation_rationale"] = "No shared state"
+        errors = validate_submission("subplan", data)
+        self.assertEqual(errors, [])
+
+
+class TestValidateReview(unittest.TestCase):
+    def test_pass_verdict_valid(self):
+        data = {"verdict": "pass", "summary": "All good"}
+        errors = validate_submission("review", data)
+        self.assertEqual(errors, [])
+
+    def test_pass_with_commit_message(self):
+        data = {
+            "verdict": "pass",
+            "summary": "All good",
+            "commit_message": "feat: add auth",
+        }
+        errors = validate_submission("review", data)
+        self.assertEqual(errors, [])
+
+    def test_fail_requires_findings(self):
+        data = {"verdict": "fail", "summary": "Issues found"}
+        errors = validate_submission("review", data)
+        self.assertTrue(any("findings" in e for e in errors))
+
+    def test_fail_with_valid_findings(self):
+        data = {
+            "verdict": "fail",
+            "summary": "Issues found",
+            "findings": [
+                {
+                    "location": "src/auth.py:42",
+                    "issue": "Missing validation",
+                    "severity": "high",
+                    "recommendation": "Add check",
+                }
+            ],
+        }
+        errors = validate_submission("review", data)
+        self.assertEqual(errors, [])
+
+    def test_fail_finding_missing_issue(self):
+        data = {
+            "verdict": "fail",
+            "summary": "Issues",
+            "findings": [{"recommendation": "Fix it"}],
+        }
+        errors = validate_submission("review", data)
+        self.assertTrue(any("issue" in e for e in errors))
+
+    def test_fail_finding_missing_recommendation(self):
+        data = {
+            "verdict": "fail",
+            "summary": "Issues",
+            "findings": [{"issue": "Bug"}],
+        }
+        errors = validate_submission("review", data)
+        self.assertTrue(any("recommendation" in e for e in errors))
+
+    def test_invalid_verdict(self):
+        data = {"verdict": "maybe", "summary": "Unsure"}
+        errors = validate_submission("review", data)
+        self.assertTrue(any("verdict" in e for e in errors))
+
+
+class TestValidationError(unittest.TestCase):
+    def test_error_attributes(self):
+        err = ValidationError("review", ["bad field", "missing thing"])
+        self.assertEqual(err.contract_name, "review")
+        self.assertEqual(len(err.errors), 2)
+        self.assertIn("review", str(err))
+
+
+class TestUnknownContract(unittest.TestCase):
+    def test_unknown_contract_name(self):
+        errors = validate_submission("nonexistent", {"x": 1})
+        self.assertEqual(errors, ["Unknown contract: nonexistent"])
+
+
+class TestRenderContractPrompt(unittest.TestCase):
+    def test_renders_all_contracts(self):
+        for name in CONTRACTS:
+            text = render_contract_prompt(name)
+            self.assertIn("```yaml", text)
+            self.assertIn("```", text)
+
+    def test_unknown_contract_returns_comment(self):
+        text = render_contract_prompt("nonexistent")
+        self.assertIn("unknown contract", text)
+
+    def test_architecture_prompt_has_key_fields(self):
+        text = render_contract_prompt("architecture")
+        self.assertIn("solution_overview", text)
+        self.assertIn("components", text)
+
+    def test_optional_fields_marked(self):
+        text = render_contract_prompt("architecture")
+        self.assertIn("# optional", text)
+
+    def test_review_prompt_has_verdict(self):
+        text = render_contract_prompt("review")
+        self.assertIn("verdict", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_handoff_contracts.py
+++ b/tests/test_handoff_contracts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import unittest
 
+import yaml
+
 from agentmux.workflow.handoff_contracts import (
     ARCHITECTURE_CONTRACT,
     CONTRACTS,
@@ -264,6 +266,12 @@ class TestUnknownContract(unittest.TestCase):
 
 
 class TestRenderContractPrompt(unittest.TestCase):
+    @staticmethod
+    def _extract_yaml_block(text: str) -> str:
+        start = text.index("```yaml") + len("```yaml")
+        end = text.index("```", start)
+        return text[start:end].strip()
+
     def test_renders_all_contracts(self):
         for name in CONTRACTS:
             text = render_contract_prompt(name)
@@ -286,6 +294,26 @@ class TestRenderContractPrompt(unittest.TestCase):
     def test_review_prompt_has_verdict(self):
         text = render_contract_prompt("review")
         self.assertIn("verdict", text)
+
+    def test_architecture_prompt_examples_parse_with_component_structure(self):
+        text = render_contract_prompt("architecture")
+        parsed = yaml.safe_load(self._extract_yaml_block(text))
+
+        self.assertEqual(parsed["components"][0]["name"], "AuthService")
+        self.assertEqual(
+            parsed["components"][0]["responsibility"],
+            "Handles user authentication",
+        )
+
+    def test_subplan_prompt_examples_parse_list_values(self):
+        text = render_contract_prompt("subplan")
+        parsed = yaml.safe_load(self._extract_yaml_block(text))
+
+        self.assertEqual(
+            parsed["tasks"],
+            ["Create auth module", "Add login endpoint", "Write tests"],
+        )
+        self.assertEqual(parsed["owned_files"], ["src/auth.py", "tests/test_auth.py"])
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_pipeline_requirements.py
+++ b/tests/test_mcp_pipeline_requirements.py
@@ -386,8 +386,8 @@ class McpPipelineRequirementsTests(unittest.TestCase):
             product_prompt = build_product_manager_prompt(files)
 
             for prompt in (architect_prompt, product_prompt):
-                self.assertIn("agentmux_research_dispatch_code", prompt)
-                self.assertIn("agentmux_research_dispatch_web", prompt)
+                self.assertIn("research_dispatch_code", prompt)
+                self.assertIn("research_dispatch_web", prompt)
                 self.assertNotIn("agentmux_research_await", prompt)
                 self.assertIn(f'feature_dir="{feature_dir}"', prompt)
                 self.assertIn("scope_hints=[", prompt)

--- a/tests/test_mcp_research_server_requirements.py
+++ b/tests/test_mcp_research_server_requirements.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
 
 import agentmux.integrations.mcp_research_server as mcp_research_server
-from agentmux.shared.models import SESSION_DIR_NAMES
 
 
 class McpResearchServerRequirementsTests(unittest.TestCase):
-    def test_dispatch_code_creates_request_with_expected_sections(self) -> None:
+    def test_dispatch_code_appends_to_log_with_expected_payload(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            result = mcp_research_server.agentmux_research_dispatch_code(
+            result = mcp_research_server.research_dispatch_code(
                 topic="auth-module",
                 context="Planning auth changes",
                 questions=[
@@ -23,27 +23,25 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints=["agentmux/", "tests/"],
             )
 
-            request_path = (
-                feature_dir
-                / SESSION_DIR_NAMES["research"]
-                / "code-auth-module"
-                / "request.md"
-            )
-            request = request_path.read_text(encoding="utf-8")
+            log_path = feature_dir / "tool_events.jsonl"
+            self.assertTrue(log_path.exists())
+            entries = [
+                json.loads(line) for line in log_path.read_text().strip().splitlines()
+            ]
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["tool"], "research_dispatch_code")
+            payload = entries[0]["payload"]
+            self.assertEqual(payload["topic"], "auth-module")
+            self.assertEqual(payload["research_type"], "code")
+            self.assertEqual(payload["context"], "Planning auth changes")
+            self.assertIn("Where is auth middleware defined?", payload["questions"])
+            self.assertEqual(payload["scope_hints"], ["agentmux/", "tests/"])
             self.assertEqual("Code research on 'auth-module' dispatched.", result)
-            self.assertIn("## Context", request)
-            self.assertIn("Planning auth changes", request)
-            self.assertIn("## Questions", request)
-            self.assertIn("1. Where is auth middleware defined?", request)
-            self.assertIn("2. What services call it?", request)
-            self.assertIn("## Scope hints", request)
-            self.assertIn("- agentmux/", request)
-            self.assertIn("- tests/", request)
 
-    def test_dispatch_web_creates_request_and_handles_empty_scope_hints(self) -> None:
+    def test_dispatch_web_appends_and_handles_empty_scope_hints(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            result = mcp_research_server.agentmux_research_dispatch_web(
+            result = mcp_research_server.research_dispatch_web(
                 topic="sdk-compat",
                 context="Need latest SDK compatibility matrix",
                 questions=["Which SDK versions support MCP?"],
@@ -51,21 +49,19 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints=None,
             )
 
-            request_path = (
-                feature_dir
-                / SESSION_DIR_NAMES["research"]
-                / "web-sdk-compat"
-                / "request.md"
-            )
-            request = request_path.read_text(encoding="utf-8")
+            log_path = feature_dir / "tool_events.jsonl"
+            entries = [
+                json.loads(line) for line in log_path.read_text().strip().splitlines()
+            ]
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["payload"]["research_type"], "web")
+            self.assertIsNone(entries[0]["payload"]["scope_hints"])
             self.assertEqual("Web research on 'sdk-compat' dispatched.", result)
-            self.assertIn("## Scope hints", request)
-            self.assertIn("- (none provided)", request)
 
     def test_dispatch_code_accepts_scope_hints_as_single_string(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            mcp_research_server.agentmux_research_dispatch_code(
+            mcp_research_server.research_dispatch_code(
                 topic="planning-conventions",
                 context="Understand planning conventions",
                 questions=["Which tests constrain planning artifacts?"],
@@ -73,18 +69,19 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints="Start with prompts and planning tests.",
             )
 
-            request = (
-                feature_dir
-                / SESSION_DIR_NAMES["research"]
-                / "code-planning-conventions"
-                / "request.md"
-            ).read_text(encoding="utf-8")
-            self.assertIn("- Start with prompts and planning tests.", request)
+            log_path = feature_dir / "tool_events.jsonl"
+            entries = [
+                json.loads(line) for line in log_path.read_text().strip().splitlines()
+            ]
+            self.assertEqual(
+                entries[0]["payload"]["scope_hints"],
+                ["Start with prompts and planning tests."],
+            )
 
     def test_dispatch_code_treats_blank_scope_hints_string_as_none(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
-            mcp_research_server.agentmux_research_dispatch_code(
+            mcp_research_server.research_dispatch_code(
                 topic="feature-surface",
                 context="Survey likely feature surfaces",
                 questions=["What are the likely extension points?"],
@@ -92,19 +89,17 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
                 scope_hints="   ",
             )
 
-            request = (
-                feature_dir
-                / SESSION_DIR_NAMES["research"]
-                / "code-feature-surface"
-                / "request.md"
-            ).read_text(encoding="utf-8")
-            self.assertIn("- (none provided)", request)
+            log_path = feature_dir / "tool_events.jsonl"
+            entries = [
+                json.loads(line) for line in log_path.read_text().strip().splitlines()
+            ]
+            self.assertIsNone(entries[0]["payload"]["scope_hints"])
 
     def test_dispatch_rejects_invalid_topic_slug(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)
             with self.assertRaises(ValueError):
-                mcp_research_server.agentmux_research_dispatch_code(
+                mcp_research_server.research_dispatch_code(
                     topic="Auth_Module",
                     context="x",
                     questions=["q"],
@@ -114,16 +109,30 @@ class McpResearchServerRequirementsTests(unittest.TestCase):
 
     def test_module_no_longer_exposes_blocking_await_tool(self) -> None:
         self.assertFalse(hasattr(mcp_research_server, "agentmux_research_await"))
+        self.assertFalse(hasattr(mcp_research_server, "research_await"))
 
     def test_dispatch_rejects_missing_feature_dir(self) -> None:
         with self.assertRaises(RuntimeError):
-            mcp_research_server.agentmux_research_dispatch_code(
+            mcp_research_server.research_dispatch_code(
                 topic="runtime",
                 context="Planning runtime changes",
                 questions=["Where is runtime created?"],
                 feature_dir=None,
                 scope_hints=None,
             )
+
+    def test_dispatch_does_not_write_request_md(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            mcp_research_server.research_dispatch_code(
+                topic="test-topic",
+                context="x",
+                questions=["q"],
+                feature_dir=str(feature_dir),
+            )
+            # No request.md should exist anywhere
+            for p in feature_dir.rglob("request.md"):
+                self.fail(f"request.md should not exist: {p}")
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_server_refactor.py
+++ b/tests/test_mcp_server_refactor.py
@@ -1,0 +1,462 @@
+"""Tests for refactored MCP research server tools (Sub-plan 2).
+
+All tools are now pure: they validate inputs, append to tool_events.jsonl,
+and return a confirmation string. They write NO files other than the log.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import agentmux.integrations.mcp_research_server as mrs
+
+
+class _FeatureDirMixin:
+    """Mixin providing a temporary feature directory with FEATURE_DIR env."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.feature_dir = Path(self._tmpdir.name)
+        os.environ["FEATURE_DIR"] = str(self.feature_dir)
+
+    def tearDown(self):
+        os.environ.pop("FEATURE_DIR", None)
+        self._tmpdir.cleanup()
+
+    def _read_log_entries(self):
+        log_path = self.feature_dir / "tool_events.jsonl"
+        if not log_path.exists():
+            return []
+        return [json.loads(line) for line in log_path.read_text().strip().splitlines()]
+
+
+class TestResearchDispatchCode(_FeatureDirMixin, unittest.TestCase):
+    """Tests for renamed research_dispatch_code tool."""
+
+    def test_validates_topic_and_appends_to_log(self):
+        result = mrs.research_dispatch_code(
+            topic="auth-module",
+            context="Planning auth changes",
+            questions=["Where is auth middleware?"],
+            feature_dir=str(self.feature_dir),
+            scope_hints=["src/"],
+        )
+        self.assertEqual("Code research on 'auth-module' dispatched.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "research_dispatch_code")
+        self.assertEqual(entries[0]["payload"]["topic"], "auth-module")
+        self.assertEqual(entries[0]["payload"]["research_type"], "code")
+        self.assertEqual(entries[0]["payload"]["context"], "Planning auth changes")
+
+    def test_does_not_write_request_md(self):
+        mrs.research_dispatch_code(
+            topic="test-topic",
+            context="x",
+            questions=["q"],
+            feature_dir=str(self.feature_dir),
+        )
+        # No request.md should be created anywhere
+        for p in self.feature_dir.rglob("request.md"):
+            self.fail(f"request.md should not exist: {p}")
+
+    def test_rejects_invalid_topic(self):
+        with self.assertRaises(ValueError):
+            mrs.research_dispatch_code(
+                topic="Bad_Topic",
+                context="x",
+                questions=["q"],
+                feature_dir=str(self.feature_dir),
+            )
+
+    def test_rejects_empty_questions(self):
+        with self.assertRaises(ValueError):
+            mrs.research_dispatch_code(
+                topic="valid-topic",
+                context="x",
+                questions=["", "  "],
+                feature_dir=str(self.feature_dir),
+            )
+
+
+class TestResearchDispatchWeb(_FeatureDirMixin, unittest.TestCase):
+    """Tests for renamed research_dispatch_web tool."""
+
+    def test_validates_and_appends_with_web_type(self):
+        result = mrs.research_dispatch_web(
+            topic="sdk-compat",
+            context="SDK matrix needed",
+            questions=["Which SDKs support MCP?"],
+            feature_dir=str(self.feature_dir),
+        )
+        self.assertEqual("Web research on 'sdk-compat' dispatched.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "research_dispatch_web")
+        self.assertEqual(entries[0]["payload"]["research_type"], "web")
+
+    def test_does_not_write_request_md(self):
+        mrs.research_dispatch_web(
+            topic="test-topic",
+            context="x",
+            questions=["q"],
+            feature_dir=str(self.feature_dir),
+        )
+        for p in self.feature_dir.rglob("request.md"):
+            self.fail(f"request.md should not exist: {p}")
+
+
+class TestSubmitArchitecture(_FeatureDirMixin, unittest.TestCase):
+    """Tests for renamed submit_architecture tool."""
+
+    def _defaults(self, **overrides):
+        defaults = {
+            "solution_overview": "Plugin architecture",
+            "components": [{"name": "Core", "responsibility": "Main loop"}],
+            "interfaces_and_contracts": "REST API",
+            "data_models": "User, Session",
+            "cross_cutting_concerns": "Logging",
+            "technology_choices": "Python",
+            "risks_and_mitigations": "None",
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_validates_and_appends(self):
+        result = mrs.submit_architecture(**self._defaults())
+        self.assertIn("Architecture submitted", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_architecture")
+        self.assertEqual(
+            entries[0]["payload"]["solution_overview"], "Plugin architecture"
+        )
+
+    def test_does_not_write_files(self):
+        mrs.submit_architecture(**self._defaults())
+        self.assertFalse(
+            (self.feature_dir / "02_planning" / "architecture.yaml").exists()
+        )
+        self.assertFalse(
+            (self.feature_dir / "02_planning" / "architecture.md").exists()
+        )
+
+    def test_validation_error_on_empty_field(self):
+        with self.assertRaises(ValueError) as ctx:
+            mrs.submit_architecture(
+                solution_overview="",
+                components=[],
+                interfaces_and_contracts="x",
+                data_models="x",
+                cross_cutting_concerns="x",
+                technology_choices="x",
+                risks_and_mitigations="x",
+                feature_dir=str(self.feature_dir),
+            )
+        self.assertIn("solution_overview", str(ctx.exception))
+
+    def test_optional_design_handoff_in_payload(self):
+        mrs.submit_architecture(**self._defaults(design_handoff="UI mockups needed"))
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["design_handoff"], "UI mockups needed")
+
+
+class TestSubmitExecutionPlan(_FeatureDirMixin, unittest.TestCase):
+    """Tests for renamed submit_execution_plan tool."""
+
+    def _defaults(self, **overrides):
+        defaults = {
+            "groups": [
+                {
+                    "group_id": "core",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Setup"}],
+                }
+            ],
+            "review_strategy": {"severity": "medium", "focus": ["security"]},
+            "needs_design": False,
+            "needs_docs": True,
+            "doc_files": ["docs/api.md"],
+            "plan_overview": "# Plan\n\nSetup core modules.",
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_validates_and_appends(self):
+        result = mrs.submit_execution_plan(**self._defaults())
+        self.assertIn("Execution plan submitted", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_execution_plan")
+        self.assertEqual(entries[0]["payload"]["needs_design"], False)
+
+    def test_does_not_write_files(self):
+        mrs.submit_execution_plan(**self._defaults())
+        self.assertFalse(
+            (self.feature_dir / "02_planning" / "execution_plan.yaml").exists()
+        )
+        self.assertFalse((self.feature_dir / "02_planning" / "plan.md").exists())
+
+    def test_validation_error_on_bad_mode(self):
+        with self.assertRaises(ValueError) as ctx:
+            mrs.submit_execution_plan(
+                groups=[
+                    {
+                        "group_id": "g1",
+                        "mode": "bad",
+                        "plans": [{"file": "p.md", "name": "x"}],
+                    }
+                ],
+                review_strategy={"severity": "medium", "focus": []},
+                needs_design=False,
+                needs_docs=False,
+                doc_files=[],
+                plan_overview="Overview",
+                feature_dir=str(self.feature_dir),
+            )
+        self.assertIn("mode", str(ctx.exception))
+
+
+class TestSubmitSubplan(_FeatureDirMixin, unittest.TestCase):
+    """Tests for renamed submit_subplan tool."""
+
+    def _defaults(self, **overrides):
+        defaults = {
+            "index": 1,
+            "title": "Auth module",
+            "scope": "User authentication",
+            "owned_files": ["src/auth.py"],
+            "dependencies": "None",
+            "implementation_approach": "Step by step",
+            "acceptance_criteria": "Tests pass",
+            "tasks": ["Create module", "Write tests"],
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_validates_and_appends(self):
+        result = mrs.submit_subplan(**self._defaults())
+        self.assertIn("Sub-plan 1 submitted", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_subplan")
+        self.assertEqual(entries[0]["payload"]["index"], 1)
+
+    def test_does_not_write_files(self):
+        mrs.submit_subplan(**self._defaults())
+        self.assertFalse((self.feature_dir / "02_planning" / "plan_1.yaml").exists())
+        self.assertFalse((self.feature_dir / "02_planning" / "plan_1.md").exists())
+        self.assertFalse((self.feature_dir / "02_planning" / "tasks_1.md").exists())
+
+    def test_validation_error_on_index_zero(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_subplan(
+                index=0,
+                title="Bad",
+                scope="x",
+                owned_files=["f.py"],
+                dependencies="none",
+                implementation_approach="x",
+                acceptance_criteria="x",
+                tasks=["t"],
+                feature_dir=str(self.feature_dir),
+            )
+
+    def test_optional_isolation_rationale_in_payload(self):
+        mrs.submit_subplan(**self._defaults(isolation_rationale="No shared state"))
+        entries = self._read_log_entries()
+        self.assertEqual(
+            entries[0]["payload"]["isolation_rationale"], "No shared state"
+        )
+
+
+class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
+    """Tests for renamed submit_review tool."""
+
+    def test_pass_validates_and_appends(self):
+        result = mrs.submit_review(
+            verdict="pass",
+            summary="All checks passed",
+            feature_dir=str(self.feature_dir),
+        )
+        self.assertIn("verdict: pass", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_review")
+        self.assertEqual(entries[0]["payload"]["verdict"], "pass")
+
+    def test_fail_with_findings_appends(self):
+        result = mrs.submit_review(
+            verdict="fail",
+            summary="Issues found",
+            feature_dir=str(self.feature_dir),
+            findings=[
+                {
+                    "location": "src/x.py:10",
+                    "issue": "Missing validation",
+                    "severity": "high",
+                    "recommendation": "Add check",
+                }
+            ],
+        )
+        self.assertIn("verdict: fail", result)
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["verdict"], "fail")
+        self.assertEqual(len(entries[0]["payload"]["findings"]), 1)
+
+    def test_does_not_write_files(self):
+        mrs.submit_review(
+            verdict="pass",
+            summary="OK",
+            feature_dir=str(self.feature_dir),
+        )
+        self.assertFalse((self.feature_dir / "06_review" / "review.yaml").exists())
+        self.assertFalse((self.feature_dir / "06_review" / "review.md").exists())
+
+    def test_fail_without_findings_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            mrs.submit_review(
+                verdict="fail",
+                summary="Bad",
+                feature_dir=str(self.feature_dir),
+            )
+        self.assertIn("findings", str(ctx.exception))
+
+    def test_invalid_verdict_raises(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_review(
+                verdict="maybe",
+                summary="Unsure",
+                feature_dir=str(self.feature_dir),
+            )
+
+    def test_commit_message_in_payload(self):
+        mrs.submit_review(
+            verdict="pass",
+            summary="OK",
+            feature_dir=str(self.feature_dir),
+            commit_message="feat: add auth",
+        )
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["commit_message"], "feat: add auth")
+
+
+class TestSubmitDone(_FeatureDirMixin, unittest.TestCase):
+    """Tests for new submit_done tool."""
+
+    def test_valid_index_appends_and_returns_confirmation(self):
+        result = mrs.submit_done(subplan_index=1, feature_dir=str(self.feature_dir))
+        self.assertEqual("Sub-plan 1 marked done.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_done")
+        self.assertEqual(entries[0]["payload"]["subplan_index"], 1)
+
+    def test_rejects_index_zero(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_done(subplan_index=0, feature_dir=str(self.feature_dir))
+
+    def test_rejects_negative_index(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_done(subplan_index=-1, feature_dir=str(self.feature_dir))
+
+    def test_rejects_non_integer(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_done(subplan_index="1", feature_dir=str(self.feature_dir))
+
+    def test_accepts_higher_index(self):
+        result = mrs.submit_done(subplan_index=5, feature_dir=str(self.feature_dir))
+        self.assertEqual("Sub-plan 5 marked done.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["subplan_index"], 5)
+
+
+class TestSubmitResearchDone(_FeatureDirMixin, unittest.TestCase):
+    """Tests for new submit_research_done tool."""
+
+    def test_valid_code_type_appends(self):
+        result = mrs.submit_research_done(
+            topic="auth-module", type="code", feature_dir=str(self.feature_dir)
+        )
+        self.assertEqual("Research on 'auth-module' (code) marked done.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_research_done")
+        self.assertEqual(entries[0]["payload"]["topic"], "auth-module")
+        self.assertEqual(entries[0]["payload"]["type"], "code")
+
+    def test_valid_web_type_appends(self):
+        result = mrs.submit_research_done(
+            topic="sdk-compat", type="web", feature_dir=str(self.feature_dir)
+        )
+        self.assertEqual("Research on 'sdk-compat' (web) marked done.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["type"], "web")
+
+    def test_rejects_invalid_topic_slug(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_research_done(
+                topic="Bad_Topic", type="code", feature_dir=str(self.feature_dir)
+            )
+
+    def test_rejects_invalid_type(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_research_done(
+                topic="valid-topic", type="invalid", feature_dir=str(self.feature_dir)
+            )
+
+    def test_rejects_empty_topic(self):
+        with self.assertRaises(ValueError):
+            mrs.submit_research_done(
+                topic="", type="code", feature_dir=str(self.feature_dir)
+            )
+
+
+class TestSubmitPmDone(_FeatureDirMixin, unittest.TestCase):
+    """Tests for new submit_pm_done tool."""
+
+    def test_appends_and_returns_confirmation(self):
+        result = mrs.submit_pm_done(feature_dir=str(self.feature_dir))
+        self.assertEqual("Product management phase done.", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_pm_done")
+        self.assertEqual(entries[0]["payload"], {})
+
+
+class TestNoHandoffArtifactsImport(unittest.TestCase):
+    """Verify handoff_artifacts is no longer imported in mcp_research_server."""
+
+    def test_no_handoff_artifacts_import(self):
+        import inspect
+
+        source = inspect.getsource(mrs)
+        self.assertNotIn("handoff_artifacts", source)
+
+
+class TestNoAgentmuxPrefix(unittest.TestCase):
+    """Verify no tool name has agentmux_ prefix."""
+
+    def test_no_agentmux_prefix_on_tools(self):
+        tool_funcs = [
+            name
+            for name in dir(mrs)
+            if name.startswith(("research_dispatch_", "submit_"))
+            and not name.startswith("_")
+        ]
+        for name in tool_funcs:
+            self.assertFalse(
+                name.startswith("agentmux_"),
+                f"Tool {name} still has agentmux_ prefix",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_submit_tools.py
+++ b/tests/test_mcp_submit_tools.py
@@ -1,13 +1,17 @@
-"""Tests for MCP submission tools (architecture, execution_plan, subplan, review)."""
+"""Tests for MCP submission tools (architecture, execution_plan, subplan, review).
+
+After Sub-plan 2 refactoring, all tools are pure: they validate inputs,
+append to tool_events.jsonl, and return a confirmation string. They write
+NO files other than the log.
+"""
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
-
-import yaml
 
 
 class SubmitToolTestBase(unittest.TestCase):
@@ -16,21 +20,22 @@ class SubmitToolTestBase(unittest.TestCase):
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.feature_dir = Path(self._tmpdir.name)
-        self.planning_dir = self.feature_dir / "02_planning"
-        self.review_dir = self.feature_dir / "06_review"
-        # Set FEATURE_DIR so _feature_dir() can resolve it
         os.environ["FEATURE_DIR"] = str(self.feature_dir)
 
     def tearDown(self):
         os.environ.pop("FEATURE_DIR", None)
         self._tmpdir.cleanup()
 
+    def _read_log_entries(self):
+        log_path = self.feature_dir / "tool_events.jsonl"
+        if not log_path.exists():
+            return []
+        return [json.loads(line) for line in log_path.read_text().strip().splitlines()]
+
 
 class TestSubmitArchitecture(SubmitToolTestBase):
     def _submit(self, **overrides):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_architecture,
-        )
+        from agentmux.integrations.mcp_research_server import submit_architecture
 
         defaults = {
             "solution_overview": "Plugin architecture",
@@ -49,42 +54,39 @@ class TestSubmitArchitecture(SubmitToolTestBase):
             "feature_dir": str(self.feature_dir),
         }
         defaults.update(overrides)
-        return agentmux_submit_architecture(**defaults)
+        return submit_architecture(**defaults)
 
-    def test_creates_yaml_and_md(self):
+    def test_appends_to_log(self):
         result = self._submit()
         self.assertIn("Architecture submitted", result)
-        self.assertTrue((self.planning_dir / "architecture.yaml").exists())
-        self.assertTrue((self.planning_dir / "architecture.md").exists())
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_architecture")
+        self.assertEqual(
+            entries[0]["payload"]["solution_overview"], "Plugin architecture"
+        )
+        self.assertEqual(len(entries[0]["payload"]["components"]), 1)
+        self.assertEqual(entries[0]["payload"]["components"][0]["name"], "Core")
 
-    def test_yaml_content_valid(self):
+    def test_does_not_write_files(self):
         self._submit()
-        data = yaml.safe_load((self.planning_dir / "architecture.yaml").read_text())
-        self.assertEqual(data["solution_overview"], "Plugin architecture")
-        self.assertEqual(len(data["components"]), 1)
-        self.assertEqual(data["components"][0]["name"], "Core")
-
-    def test_md_has_sections(self):
-        self._submit()
-        md = (self.planning_dir / "architecture.md").read_text()
-        self.assertIn("# Architecture", md)
-        self.assertIn("## Solution Overview", md)
-        self.assertIn("## Components", md)
-        self.assertIn("### Core", md)
-
-    def test_optional_design_handoff(self):
-        self._submit(design_handoff="UI mockups needed")
-        md = (self.planning_dir / "architecture.md").read_text()
-        self.assertIn("## Design Handoff", md)
-        self.assertIn("UI mockups needed", md)
-
-    def test_validation_error_missing_field(self):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_architecture,
+        self.assertFalse(
+            (self.feature_dir / "02_planning" / "architecture.yaml").exists()
+        )
+        self.assertFalse(
+            (self.feature_dir / "02_planning" / "architecture.md").exists()
         )
 
+    def test_optional_design_handoff_in_payload(self):
+        self._submit(design_handoff="UI mockups needed")
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["design_handoff"], "UI mockups needed")
+
+    def test_validation_error_missing_field(self):
+        from agentmux.integrations.mcp_research_server import submit_architecture
+
         with self.assertRaises(ValueError) as ctx:
-            agentmux_submit_architecture(
+            submit_architecture(
                 solution_overview="",  # empty = invalid
                 components=[],
                 interfaces_and_contracts="x",
@@ -99,9 +101,7 @@ class TestSubmitArchitecture(SubmitToolTestBase):
 
 class TestSubmitExecutionPlan(SubmitToolTestBase):
     def _submit(self, **overrides):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_execution_plan,
-        )
+        from agentmux.integrations.mcp_research_server import submit_execution_plan
 
         defaults = {
             "groups": [
@@ -119,35 +119,31 @@ class TestSubmitExecutionPlan(SubmitToolTestBase):
             "feature_dir": str(self.feature_dir),
         }
         defaults.update(overrides)
-        return agentmux_submit_execution_plan(**defaults)
+        return submit_execution_plan(**defaults)
 
-    def test_creates_yaml_and_plan_md(self):
+    def test_appends_to_log(self):
         result = self._submit()
         self.assertIn("Execution plan submitted", result)
-        self.assertTrue((self.planning_dir / "execution_plan.yaml").exists())
-        self.assertTrue((self.planning_dir / "plan.md").exists())
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_execution_plan")
+        self.assertFalse(entries[0]["payload"]["needs_design"])
+        self.assertTrue(entries[0]["payload"]["needs_docs"])
+        self.assertEqual(entries[0]["payload"]["review_strategy"]["severity"], "medium")
+        self.assertEqual(len(entries[0]["payload"]["groups"]), 1)
 
-    def test_yaml_has_version_and_merged_fields(self):
+    def test_does_not_write_files(self):
         self._submit()
-        data = yaml.safe_load((self.planning_dir / "execution_plan.yaml").read_text())
-        self.assertEqual(data["version"], 1)
-        self.assertFalse(data["needs_design"])
-        self.assertTrue(data["needs_docs"])
-        self.assertEqual(data["review_strategy"]["severity"], "medium")
-        self.assertEqual(len(data["groups"]), 1)
-
-    def test_plan_md_content(self):
-        self._submit()
-        md = (self.planning_dir / "plan.md").read_text()
-        self.assertIn("Setup core modules", md)
+        self.assertFalse(
+            (self.feature_dir / "02_planning" / "execution_plan.yaml").exists()
+        )
+        self.assertFalse((self.feature_dir / "02_planning" / "plan.md").exists())
 
     def test_validation_error_invalid_mode(self):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_execution_plan,
-        )
+        from agentmux.integrations.mcp_research_server import submit_execution_plan
 
         with self.assertRaises(ValueError) as ctx:
-            agentmux_submit_execution_plan(
+            submit_execution_plan(
                 groups=[
                     {
                         "group_id": "g1",
@@ -167,9 +163,7 @@ class TestSubmitExecutionPlan(SubmitToolTestBase):
 
 class TestSubmitSubplan(SubmitToolTestBase):
     def _submit(self, **overrides):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_subplan,
-        )
+        from agentmux.integrations.mcp_research_server import submit_subplan
 
         defaults = {
             "index": 1,
@@ -183,48 +177,38 @@ class TestSubmitSubplan(SubmitToolTestBase):
             "feature_dir": str(self.feature_dir),
         }
         defaults.update(overrides)
-        return agentmux_submit_subplan(**defaults)
+        return submit_subplan(**defaults)
 
-    def test_creates_three_files(self):
+    def test_appends_to_log(self):
         result = self._submit()
         self.assertIn("Sub-plan 1 submitted", result)
-        self.assertTrue((self.planning_dir / "plan_1.yaml").exists())
-        self.assertTrue((self.planning_dir / "plan_1.md").exists())
-        self.assertTrue((self.planning_dir / "tasks_1.md").exists())
-
-    def test_yaml_content(self):
-        self._submit()
-        data = yaml.safe_load((self.planning_dir / "plan_1.yaml").read_text())
-        self.assertEqual(data["index"], 1)
-        self.assertEqual(data["title"], "Auth module")
-        self.assertEqual(data["tasks"], ["Create module", "Write tests"])
-
-    def test_md_has_sections(self):
-        self._submit()
-        md = (self.planning_dir / "plan_1.md").read_text()
-        self.assertIn("# Auth module", md)
-        self.assertIn("## Scope", md)
-        self.assertIn("## Owned Files", md)
-        self.assertIn("`src/auth.py`", md)
-
-    def test_tasks_md_has_checklist(self):
-        self._submit()
-        tasks = (self.planning_dir / "tasks_1.md").read_text()
-        self.assertIn("- [ ] Create module", tasks)
-        self.assertIn("- [ ] Write tests", tasks)
-
-    def test_optional_isolation_rationale(self):
-        self._submit(isolation_rationale="No shared state")
-        md = (self.planning_dir / "plan_1.md").read_text()
-        self.assertIn("## Isolation Rationale", md)
-
-    def test_validation_error_index_zero(self):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_subplan,
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_subplan")
+        self.assertEqual(entries[0]["payload"]["index"], 1)
+        self.assertEqual(entries[0]["payload"]["title"], "Auth module")
+        self.assertEqual(
+            entries[0]["payload"]["tasks"], ["Create module", "Write tests"]
         )
 
+    def test_does_not_write_files(self):
+        self._submit()
+        self.assertFalse((self.feature_dir / "02_planning" / "plan_1.yaml").exists())
+        self.assertFalse((self.feature_dir / "02_planning" / "plan_1.md").exists())
+        self.assertFalse((self.feature_dir / "02_planning" / "tasks_1.md").exists())
+
+    def test_optional_isolation_rationale_in_payload(self):
+        self._submit(isolation_rationale="No shared state")
+        entries = self._read_log_entries()
+        self.assertEqual(
+            entries[0]["payload"]["isolation_rationale"], "No shared state"
+        )
+
+    def test_validation_error_index_zero(self):
+        from agentmux.integrations.mcp_research_server import submit_subplan
+
         with self.assertRaises(ValueError):
-            agentmux_submit_subplan(
+            submit_subplan(
                 index=0,
                 title="Bad",
                 scope="x",
@@ -238,16 +222,13 @@ class TestSubmitSubplan(SubmitToolTestBase):
 
     def test_different_index(self):
         self._submit(index=3, title="Third plan")
-        self.assertTrue((self.planning_dir / "plan_3.yaml").exists())
-        self.assertTrue((self.planning_dir / "plan_3.md").exists())
-        self.assertTrue((self.planning_dir / "tasks_3.md").exists())
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["index"], 3)
 
 
 class TestSubmitReview(SubmitToolTestBase):
     def _submit(self, **overrides):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_review,
-        )
+        from agentmux.integrations.mcp_research_server import submit_review
 
         defaults = {
             "verdict": "pass",
@@ -255,28 +236,22 @@ class TestSubmitReview(SubmitToolTestBase):
             "feature_dir": str(self.feature_dir),
         }
         defaults.update(overrides)
-        return agentmux_submit_review(**defaults)
+        return submit_review(**defaults)
 
-    def test_pass_creates_files(self):
+    def test_pass_appends_to_log(self):
         result = self._submit()
         self.assertIn("verdict: pass", result)
-        self.assertTrue((self.review_dir / "review.yaml").exists())
-        self.assertTrue((self.review_dir / "review.md").exists())
-
-    def test_pass_md_first_line_verdict(self):
-        self._submit()
-        md = (self.review_dir / "review.md").read_text()
-        first_line = md.splitlines()[0]
-        self.assertEqual(first_line, "verdict: pass")
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_review")
+        self.assertEqual(entries[0]["payload"]["verdict"], "pass")
 
     def test_pass_with_commit_message(self):
         self._submit(commit_message="feat: add auth")
-        md = (self.review_dir / "review.md").read_text()
-        self.assertIn("feat: add auth", md)
-        data = yaml.safe_load((self.review_dir / "review.yaml").read_text())
-        self.assertEqual(data["commit_message"], "feat: add auth")
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["commit_message"], "feat: add auth")
 
-    def test_fail_creates_files(self):
+    def test_fail_appends_with_findings(self):
         result = self._submit(
             verdict="fail",
             summary="Issues found",
@@ -290,33 +265,20 @@ class TestSubmitReview(SubmitToolTestBase):
             ],
         )
         self.assertIn("verdict: fail", result)
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"]["verdict"], "fail")
+        self.assertEqual(len(entries[0]["payload"]["findings"]), 1)
 
-    def test_fail_md_has_findings(self):
-        self._submit(
-            verdict="fail",
-            summary="Issues found",
-            findings=[
-                {
-                    "location": "src/x.py:10",
-                    "issue": "Missing validation",
-                    "severity": "high",
-                    "recommendation": "Add check",
-                }
-            ],
-        )
-        md = (self.review_dir / "review.md").read_text()
-        self.assertEqual(md.splitlines()[0], "verdict: fail")
-        self.assertIn("## Findings", md)
-        self.assertIn("Missing validation", md)
-        self.assertIn("`src/x.py:10`", md)
+    def test_does_not_write_files(self):
+        self._submit()
+        self.assertFalse((self.feature_dir / "06_review" / "review.yaml").exists())
+        self.assertFalse((self.feature_dir / "06_review" / "review.md").exists())
 
     def test_fail_without_findings_raises(self):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_review,
-        )
+        from agentmux.integrations.mcp_research_server import submit_review
 
         with self.assertRaises(ValueError) as ctx:
-            agentmux_submit_review(
+            submit_review(
                 verdict="fail",
                 summary="Bad",
                 feature_dir=str(self.feature_dir),
@@ -324,12 +286,10 @@ class TestSubmitReview(SubmitToolTestBase):
         self.assertIn("findings", str(ctx.exception))
 
     def test_invalid_verdict_raises(self):
-        from agentmux.integrations.mcp_research_server import (
-            agentmux_submit_review,
-        )
+        from agentmux.integrations.mcp_research_server import submit_review
 
         with self.assertRaises(ValueError):
-            agentmux_submit_review(
+            submit_review(
                 verdict="maybe",
                 summary="Unsure",
                 feature_dir=str(self.feature_dir),

--- a/tests/test_mcp_submit_tools.py
+++ b/tests/test_mcp_submit_tools.py
@@ -1,0 +1,340 @@
+"""Tests for MCP submission tools (architecture, execution_plan, subplan, review)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+class SubmitToolTestBase(unittest.TestCase):
+    """Base class providing a temporary feature directory."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.feature_dir = Path(self._tmpdir.name)
+        self.planning_dir = self.feature_dir / "02_planning"
+        self.review_dir = self.feature_dir / "06_review"
+        # Set FEATURE_DIR so _feature_dir() can resolve it
+        os.environ["FEATURE_DIR"] = str(self.feature_dir)
+
+    def tearDown(self):
+        os.environ.pop("FEATURE_DIR", None)
+        self._tmpdir.cleanup()
+
+
+class TestSubmitArchitecture(SubmitToolTestBase):
+    def _submit(self, **overrides):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_architecture,
+        )
+
+        defaults = {
+            "solution_overview": "Plugin architecture",
+            "components": [
+                {
+                    "name": "Core",
+                    "responsibility": "Main loop",
+                    "interfaces": ["run()"],
+                }
+            ],
+            "interfaces_and_contracts": "REST API",
+            "data_models": "User, Session",
+            "cross_cutting_concerns": "Logging, auth",
+            "technology_choices": "Python",
+            "risks_and_mitigations": "None",
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return agentmux_submit_architecture(**defaults)
+
+    def test_creates_yaml_and_md(self):
+        result = self._submit()
+        self.assertIn("Architecture submitted", result)
+        self.assertTrue((self.planning_dir / "architecture.yaml").exists())
+        self.assertTrue((self.planning_dir / "architecture.md").exists())
+
+    def test_yaml_content_valid(self):
+        self._submit()
+        data = yaml.safe_load((self.planning_dir / "architecture.yaml").read_text())
+        self.assertEqual(data["solution_overview"], "Plugin architecture")
+        self.assertEqual(len(data["components"]), 1)
+        self.assertEqual(data["components"][0]["name"], "Core")
+
+    def test_md_has_sections(self):
+        self._submit()
+        md = (self.planning_dir / "architecture.md").read_text()
+        self.assertIn("# Architecture", md)
+        self.assertIn("## Solution Overview", md)
+        self.assertIn("## Components", md)
+        self.assertIn("### Core", md)
+
+    def test_optional_design_handoff(self):
+        self._submit(design_handoff="UI mockups needed")
+        md = (self.planning_dir / "architecture.md").read_text()
+        self.assertIn("## Design Handoff", md)
+        self.assertIn("UI mockups needed", md)
+
+    def test_validation_error_missing_field(self):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_architecture,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            agentmux_submit_architecture(
+                solution_overview="",  # empty = invalid
+                components=[],
+                interfaces_and_contracts="x",
+                data_models="x",
+                cross_cutting_concerns="x",
+                technology_choices="x",
+                risks_and_mitigations="x",
+                feature_dir=str(self.feature_dir),
+            )
+        self.assertIn("solution_overview", str(ctx.exception))
+
+
+class TestSubmitExecutionPlan(SubmitToolTestBase):
+    def _submit(self, **overrides):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_execution_plan,
+        )
+
+        defaults = {
+            "groups": [
+                {
+                    "group_id": "core",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Setup"}],
+                }
+            ],
+            "review_strategy": {"severity": "medium", "focus": ["security"]},
+            "needs_design": False,
+            "needs_docs": True,
+            "doc_files": ["docs/api.md"],
+            "plan_overview": "# Plan\n\nSetup core modules.",
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return agentmux_submit_execution_plan(**defaults)
+
+    def test_creates_yaml_and_plan_md(self):
+        result = self._submit()
+        self.assertIn("Execution plan submitted", result)
+        self.assertTrue((self.planning_dir / "execution_plan.yaml").exists())
+        self.assertTrue((self.planning_dir / "plan.md").exists())
+
+    def test_yaml_has_version_and_merged_fields(self):
+        self._submit()
+        data = yaml.safe_load((self.planning_dir / "execution_plan.yaml").read_text())
+        self.assertEqual(data["version"], 1)
+        self.assertFalse(data["needs_design"])
+        self.assertTrue(data["needs_docs"])
+        self.assertEqual(data["review_strategy"]["severity"], "medium")
+        self.assertEqual(len(data["groups"]), 1)
+
+    def test_plan_md_content(self):
+        self._submit()
+        md = (self.planning_dir / "plan.md").read_text()
+        self.assertIn("Setup core modules", md)
+
+    def test_validation_error_invalid_mode(self):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_execution_plan,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            agentmux_submit_execution_plan(
+                groups=[
+                    {
+                        "group_id": "g1",
+                        "mode": "bad",
+                        "plans": [{"file": "p.md", "name": "x"}],
+                    }
+                ],
+                review_strategy={"severity": "medium", "focus": []},
+                needs_design=False,
+                needs_docs=False,
+                doc_files=[],
+                plan_overview="Overview",
+                feature_dir=str(self.feature_dir),
+            )
+        self.assertIn("mode", str(ctx.exception))
+
+
+class TestSubmitSubplan(SubmitToolTestBase):
+    def _submit(self, **overrides):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_subplan,
+        )
+
+        defaults = {
+            "index": 1,
+            "title": "Auth module",
+            "scope": "User authentication",
+            "owned_files": ["src/auth.py"],
+            "dependencies": "None",
+            "implementation_approach": "Step by step",
+            "acceptance_criteria": "Tests pass",
+            "tasks": ["Create module", "Write tests"],
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return agentmux_submit_subplan(**defaults)
+
+    def test_creates_three_files(self):
+        result = self._submit()
+        self.assertIn("Sub-plan 1 submitted", result)
+        self.assertTrue((self.planning_dir / "plan_1.yaml").exists())
+        self.assertTrue((self.planning_dir / "plan_1.md").exists())
+        self.assertTrue((self.planning_dir / "tasks_1.md").exists())
+
+    def test_yaml_content(self):
+        self._submit()
+        data = yaml.safe_load((self.planning_dir / "plan_1.yaml").read_text())
+        self.assertEqual(data["index"], 1)
+        self.assertEqual(data["title"], "Auth module")
+        self.assertEqual(data["tasks"], ["Create module", "Write tests"])
+
+    def test_md_has_sections(self):
+        self._submit()
+        md = (self.planning_dir / "plan_1.md").read_text()
+        self.assertIn("# Auth module", md)
+        self.assertIn("## Scope", md)
+        self.assertIn("## Owned Files", md)
+        self.assertIn("`src/auth.py`", md)
+
+    def test_tasks_md_has_checklist(self):
+        self._submit()
+        tasks = (self.planning_dir / "tasks_1.md").read_text()
+        self.assertIn("- [ ] Create module", tasks)
+        self.assertIn("- [ ] Write tests", tasks)
+
+    def test_optional_isolation_rationale(self):
+        self._submit(isolation_rationale="No shared state")
+        md = (self.planning_dir / "plan_1.md").read_text()
+        self.assertIn("## Isolation Rationale", md)
+
+    def test_validation_error_index_zero(self):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_subplan,
+        )
+
+        with self.assertRaises(ValueError):
+            agentmux_submit_subplan(
+                index=0,
+                title="Bad",
+                scope="x",
+                owned_files=["f.py"],
+                dependencies="none",
+                implementation_approach="x",
+                acceptance_criteria="x",
+                tasks=["t"],
+                feature_dir=str(self.feature_dir),
+            )
+
+    def test_different_index(self):
+        self._submit(index=3, title="Third plan")
+        self.assertTrue((self.planning_dir / "plan_3.yaml").exists())
+        self.assertTrue((self.planning_dir / "plan_3.md").exists())
+        self.assertTrue((self.planning_dir / "tasks_3.md").exists())
+
+
+class TestSubmitReview(SubmitToolTestBase):
+    def _submit(self, **overrides):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_review,
+        )
+
+        defaults = {
+            "verdict": "pass",
+            "summary": "All checks passed",
+            "feature_dir": str(self.feature_dir),
+        }
+        defaults.update(overrides)
+        return agentmux_submit_review(**defaults)
+
+    def test_pass_creates_files(self):
+        result = self._submit()
+        self.assertIn("verdict: pass", result)
+        self.assertTrue((self.review_dir / "review.yaml").exists())
+        self.assertTrue((self.review_dir / "review.md").exists())
+
+    def test_pass_md_first_line_verdict(self):
+        self._submit()
+        md = (self.review_dir / "review.md").read_text()
+        first_line = md.splitlines()[0]
+        self.assertEqual(first_line, "verdict: pass")
+
+    def test_pass_with_commit_message(self):
+        self._submit(commit_message="feat: add auth")
+        md = (self.review_dir / "review.md").read_text()
+        self.assertIn("feat: add auth", md)
+        data = yaml.safe_load((self.review_dir / "review.yaml").read_text())
+        self.assertEqual(data["commit_message"], "feat: add auth")
+
+    def test_fail_creates_files(self):
+        result = self._submit(
+            verdict="fail",
+            summary="Issues found",
+            findings=[
+                {
+                    "location": "src/x.py:10",
+                    "issue": "Missing validation",
+                    "severity": "high",
+                    "recommendation": "Add check",
+                }
+            ],
+        )
+        self.assertIn("verdict: fail", result)
+
+    def test_fail_md_has_findings(self):
+        self._submit(
+            verdict="fail",
+            summary="Issues found",
+            findings=[
+                {
+                    "location": "src/x.py:10",
+                    "issue": "Missing validation",
+                    "severity": "high",
+                    "recommendation": "Add check",
+                }
+            ],
+        )
+        md = (self.review_dir / "review.md").read_text()
+        self.assertEqual(md.splitlines()[0], "verdict: fail")
+        self.assertIn("## Findings", md)
+        self.assertIn("Missing validation", md)
+        self.assertIn("`src/x.py:10`", md)
+
+    def test_fail_without_findings_raises(self):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_review,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            agentmux_submit_review(
+                verdict="fail",
+                summary="Bad",
+                feature_dir=str(self.feature_dir),
+            )
+        self.assertIn("findings", str(ctx.exception))
+
+    def test_invalid_verdict_raises(self):
+        from agentmux.integrations.mcp_research_server import (
+            agentmux_submit_review,
+        )
+
+        with self.assertRaises(ValueError):
+            agentmux_submit_review(
+                verdict="maybe",
+                summary="Unsure",
+                feature_dir=str(self.feature_dir),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import patch
 
+import yaml
+
 from agentmux import monitor
 from agentmux.agent_labels import role_display_label
 from agentmux.monitor.state_reader import (
@@ -36,7 +38,7 @@ def _make_test_files(feature_dir: Path) -> RuntimeFiles:
         tasks=feature_dir / SESSION_DIR_NAMES["planning"] / "tasks.md",
         execution_plan=feature_dir
         / SESSION_DIR_NAMES["planning"]
-        / "execution_plan.json",
+        / "execution_plan.yaml",
         design=feature_dir / SESSION_DIR_NAMES["design"] / "design.md",
         review=feature_dir / SESSION_DIR_NAMES["review"] / "review.md",
         fix_request=feature_dir / SESSION_DIR_NAMES["review"] / "fix_request.md",
@@ -466,10 +468,19 @@ class MonitorTests(unittest.TestCase):
             (planning_dir / "plan_2.md").write_text(
                 "## Sub-plan 2: API wiring\n", encoding="utf-8"
             )
-            (planning_dir / "execution_plan.json").write_text(
-                (
-                    '{"version": 1, "groups": [{"group_id": "g1", "mode": "parallel", '
-                    '"plans": [{"file": "plan_2.md", "name": "API wiring"}]}]}'
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "version": 1,
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "parallel",
+                                "plans": [{"file": "plan_2.md", "name": "API wiring"}],
+                            }
+                        ],
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )

--- a/tests/test_on_demand_prompt_handlers.py
+++ b/tests/test_on_demand_prompt_handlers.py
@@ -260,11 +260,9 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             self.assertEqual("parallel", state.get("implementation_group_mode"))
 
             ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.implementation_dir / "done_1").write_text("", encoding="utf-8")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_1",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 1}},
             )
             updates, next_phase = handler.handle_event(event, state, ctx)
             state.update(updates)

--- a/tests/test_on_demand_prompt_handlers.py
+++ b/tests/test_on_demand_prompt_handlers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -129,8 +128,10 @@ def _write_execution_plan(
             f"# Tasks for plan {index}\n\n- [ ] execute sub-plan {index}\n",
             encoding="utf-8",
         )
-    (planning_dir / "execution_plan.json").write_text(
-        json.dumps(
+    import yaml
+
+    (planning_dir / "execution_plan.yaml").write_text(
+        yaml.dump(
             {
                 "version": 1,
                 "groups": [
@@ -143,7 +144,8 @@ def _write_execution_plan(
                         ],
                     }
                 ],
-            }
+            },
+            default_flow_style=False,
         ),
         encoding="utf-8",
     )

--- a/tests/test_phase_directories_requirements.py
+++ b/tests/test_phase_directories_requirements.py
@@ -93,7 +93,7 @@ class PhaseDirectoryRequirementsTests(unittest.TestCase):
             self.assertEqual(feature_dir / "02_planning" / "plan.md", files.plan)
             self.assertEqual(feature_dir / "02_planning" / "tasks.md", files.tasks)
             self.assertEqual(
-                feature_dir / "02_planning" / "execution_plan.json",
+                feature_dir / "02_planning" / "execution_plan.yaml",
                 files.execution_plan,
             )
             self.assertEqual(feature_dir / "04_design" / "design.md", files.design)
@@ -153,8 +153,11 @@ class PhaseDirectoryRequirementsTests(unittest.TestCase):
             feature_dir = Path(td)
             planning_dir = feature_dir / "02_planning"
             planning_dir.mkdir(parents=True, exist_ok=True)
-            (planning_dir / "plan_meta.json").write_text(
-                '{"needs_design": true}', encoding="utf-8"
+            import yaml
+
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump({"needs_design": True}, default_flow_style=False),
+                encoding="utf-8",
             )
 
             meta = load_plan_meta(planning_dir)
@@ -169,10 +172,21 @@ class PhaseDirectoryRequirementsTests(unittest.TestCase):
             (planning_dir / "plan_1.md").write_text(
                 "## Sub-plan 1: API wiring\n", encoding="utf-8"
             )
-            (planning_dir / "execution_plan.json").write_text(
-                (
-                    '{"version": 1, "groups": [{"group_id": "g1", "mode": "serial", '
-                    '"plans": [{"file": "plan_1.md", "name": "API wiring"}]}]}'
+            import yaml
+
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "version": 1,
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "serial",
+                                "plans": [{"file": "plan_1.md", "name": "API wiring"}],
+                            }
+                        ],
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )

--- a/tests/test_preference_memory_workflow_requirements.py
+++ b/tests/test_preference_memory_workflow_requirements.py
@@ -80,24 +80,32 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_execution_plan(files, *, name: str = "implementation") -> None:
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(payload, default_flow_style=False), encoding="utf-8")
+
+
+def _write_execution_plan(
+    files, *, name: str = "implementation", **meta: object
+) -> None:
     files.planning_dir.mkdir(parents=True, exist_ok=True)
     (files.planning_dir / "plan_1.md").write_text(
         f"## Sub-plan 1: {name}\n", encoding="utf-8"
     )
-    _write_json(
-        files.execution_plan,
-        {
-            "version": 1,
-            "groups": [
-                {
-                    "group_id": "g1",
-                    "mode": "serial",
-                    "plans": [{"file": "plan_1.md", "name": name}],
-                }
-            ],
-        },
-    )
+    data: dict[str, object] = {
+        "version": 1,
+        "groups": [
+            {
+                "group_id": "g1",
+                "mode": "serial",
+                "plans": [{"file": "plan_1.md", "name": name}],
+            }
+        ],
+    }
+    data.update(meta)
+    _write_yaml(files.execution_plan, data)
 
 
 class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
@@ -173,10 +181,7 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "planning"
             write_state(state_path, state)
-            _write_execution_plan(ctx.files)
-            _write_json(
-                ctx.files.planning_dir / "plan_meta.json", {"needs_design": False}
-            )
+            _write_execution_plan(ctx.files, needs_design=False)
             # Write required files for plan completion
             (ctx.files.planning_dir / "plan.md").write_text(
                 "# Plan\n", encoding="utf-8"
@@ -200,7 +205,7 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
             handler = PlanningHandler()
             event = WorkflowEvent(
                 kind="plan_written",
-                path="02_planning/plan_meta.json",
+                path="02_planning/execution_plan.yaml",
                 payload={},
             )
             updates, next_phase = handler.handle_event(
@@ -229,15 +234,12 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "planning"
             write_state(state_path, state)
-            _write_execution_plan(ctx.files)
-            _write_json(
-                ctx.files.planning_dir / "plan_meta.json", {"needs_design": False}
-            )
+            _write_execution_plan(ctx.files, needs_design=False)
 
             handler = PlanningHandler()
             event = WorkflowEvent(
                 kind="plan_written",
-                path="02_planning/plan_meta.json",
+                path="02_planning/execution_plan.yaml",
                 payload={},
             )
             updates, next_phase = handler.handle_event(

--- a/tests/test_preference_memory_workflow_requirements.py
+++ b/tests/test_preference_memory_workflow_requirements.py
@@ -131,9 +131,8 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
 
             handler = ProductManagementHandler()
             event = WorkflowEvent(
-                kind="pm_completed",
-                path="01_product_management/done",
-                payload={},
+                kind="pm_done",
+                payload={"payload": {}},
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -162,9 +161,8 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
 
             handler = ProductManagementHandler()
             event = WorkflowEvent(
-                kind="pm_completed",
-                path="01_product_management/done",
-                payload={},
+                kind="pm_done",
+                payload={"payload": {}},
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -204,9 +202,25 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
 
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="plan_written",
-                path="02_planning/execution_plan.yaml",
-                payload={},
+                kind="execution_plan",
+                payload={
+                    "payload": {
+                        "plan_overview": "Implementation plan",
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "serial",
+                                "plans": [
+                                    {"file": "plan_1.md", "name": "implementation"}
+                                ],
+                            }
+                        ],
+                        "review_strategy": {"severity": "medium", "focus": []},
+                        "needs_design": False,
+                        "needs_docs": False,
+                        "doc_files": [],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -238,9 +252,25 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
 
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="plan_written",
-                path="02_planning/execution_plan.yaml",
-                payload={},
+                kind="execution_plan",
+                payload={
+                    "payload": {
+                        "plan_overview": "Implementation plan",
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "serial",
+                                "plans": [
+                                    {"file": "plan_1.md", "name": "implementation"}
+                                ],
+                            }
+                        ],
+                        "review_strategy": {"severity": "medium", "focus": []},
+                        "needs_design": False,
+                        "needs_docs": False,
+                        "doc_files": [],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -499,9 +529,8 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
 
             handler = ProductManagementHandler()
             event = WorkflowEvent(
-                kind="pm_completed",
-                path="01_product_management/done",
-                payload={},
+                kind="pm_done",
+                payload={"payload": {}},
             )
             handler.handle_event(event, load_state(state_path), ctx)
             prompt = build_architect_prompt(ctx.files)
@@ -528,9 +557,8 @@ class PreferenceMemoryWorkflowRequirementsTests(unittest.TestCase):
 
             handler = ProductManagementHandler()
             event = WorkflowEvent(
-                kind="pm_completed",
-                path="01_product_management/done",
-                payload={},
+                kind="pm_done",
+                payload={"payload": {}},
             )
             handler.handle_event(event, load_state(state_path), ctx)
 

--- a/tests/test_product_manager_requirements.py
+++ b/tests/test_product_manager_requirements.py
@@ -187,7 +187,7 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             self.assertIn("01_product_management/done", prompt)
             self.assertNotIn("04_design/design.md", prompt)
             self.assertNotIn("/frontend-design", prompt)
-            self.assertIn("needs_design: true", prompt)
+            self.assertIn("Design handoff needed", prompt)
             self.assertIn("must not create design artifacts", prompt)
 
     def test_product_management_phase_entry_and_completion_transition(self) -> None:

--- a/tests/test_product_manager_requirements.py
+++ b/tests/test_product_manager_requirements.py
@@ -206,14 +206,10 @@ class ProductManagerRequirementsTests(unittest.TestCase):
                 ctx.runtime.calls[-1],
             )
 
-            (feature_dir / PRODUCT_MANAGEMENT_DIR).mkdir(parents=True, exist_ok=True)
-            (feature_dir / PRODUCT_MANAGEMENT_DIR / "done").touch()
-
-            # Create workflow event for done file creation
+            # Create workflow event for PM done tool call
             event = WorkflowEvent(
-                kind="pm_completed",
-                path="01_product_management/done",
-                payload={},
+                kind="pm_done",
+                payload={"payload": {}},
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -234,19 +230,18 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             state["research_tasks"] = {}
             write_state(state_path, state)
 
-            (feature_dir / RESEARCH_DIR / "code-market-fit").mkdir(
-                parents=True, exist_ok=True
-            )
-            (feature_dir / RESEARCH_DIR / "code-market-fit" / "request.md").write_text(
-                "analyze", encoding="utf-8"
-            )
-
             handler = ProductManagementHandler()
-            # Simulate file.created event for research request
+            # Simulate MCP tool call for research dispatch
             event = WorkflowEvent(
-                kind="code_research_requested",
-                path="03_research/code-market-fit/request.md",
-                payload={},
+                kind="research_code_req",
+                payload={
+                    "payload": {
+                        "topic": "market-fit",
+                        "context": "Analyze market fit",
+                        "questions": ["What are the requirements?"],
+                        "scope_hints": [],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -265,12 +260,10 @@ class ProductManagerRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["research_tasks"] = {"market-fit": "dispatched"}
             write_state(state_path, state)
-            (feature_dir / RESEARCH_DIR / "code-market-fit" / "done").touch()
 
             done_event = WorkflowEvent(
-                kind="code_research_done",
-                path="03_research/code-market-fit/done",
-                payload={},
+                kind="research_done",
+                payload={"payload": {"topic": "market-fit", "role_type": "code"}},
             )
             handler.handle_event(done_event, load_state(state_path), ctx)
 

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -360,10 +360,15 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             with self.subTest(template=str(template_path)):
                 template = template_path.read_text(encoding="utf-8")
                 self.assertIn("[[placeholder:project_instructions]]", template)
-                self.assertIn("Constraints:", template)
+                # Agent templates use "## Constraints", commands use "Constraints:"
+                if "## Constraints" in template:
+                    constraints_str = "## Constraints"
+                else:
+                    constraints_str = "Constraints:"
+                self.assertIn(constraints_str, template)
                 self.assertLess(
                     template.index("[[placeholder:project_instructions]]"),
-                    template.index("Constraints:"),
+                    template.index(constraints_str),
                 )
 
     def test_builders_inject_project_prompt_extensions_before_constraints(self) -> None:
@@ -456,8 +461,13 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
                 with self.subTest(marker=marker):
                     prompt = builder(files)
                     self.assertIn(marker, prompt)
-                    self.assertIn("Constraints:", prompt)
-                    self.assertLess(prompt.index(marker), prompt.index("Constraints:"))
+                    # Agent prompts use "## Constraints", commands use "Constraints:"
+                    if "## Constraints" in prompt:
+                        constraints_str = "## Constraints"
+                    else:
+                        constraints_str = "Constraints:"
+                    self.assertIn(constraints_str, prompt)
+                    self.assertLess(prompt.index(marker), prompt.index(constraints_str))
 
     def test_project_prompts_with_curly_braces_do_not_break_template_rendering(
         self,

--- a/tests/test_prompt_tool_name_migration.py
+++ b/tests/test_prompt_tool_name_migration.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+PROMPTS_DIR = Path(__file__).resolve().parents[1] / "src" / "agentmux" / "prompts"
+
+# Tool names that should exist (unprefixed) in prompt files
+VALID_TOOL_NAMES = {
+    "submit_architecture",
+    "submit_execution_plan",
+    "submit_subplan",
+    "submit_review",
+    "research_dispatch_code",
+    "research_dispatch_web",
+    "submit_done",
+    "submit_research_done",
+    "submit_pm_done",
+}
+
+# Old prefixed names that must NOT appear in any prompt file
+DEPRECATED_TOOL_NAMES = {
+    "agentmux_submit_architecture",
+    "agentmux_submit_execution_plan",
+    "agentmux_submit_subplan",
+    "agentmux_submit_review",
+    "agentmux_research_dispatch_code",
+    "agentmux_research_dispatch_web",
+}
+
+
+class PromptToolNameMigrationTests(unittest.TestCase):
+    """Ensure all prompt files use unprefixed MCP tool names."""
+
+    def _prompt_files(self) -> list[Path]:
+        files: list[Path] = []
+        for root in (
+            PROMPTS_DIR / "agents",
+            PROMPTS_DIR / "shared",
+            PROMPTS_DIR / "commands",
+        ):
+            if root.exists():
+                files.extend(root.glob("*.md"))
+        return sorted(files)
+
+    def test_no_deprecated_agentmux_prefix_in_prompt_files(self) -> None:
+        """No prompt file should reference an agentmux_ prefixed tool name."""
+        violations: list[str] = []
+        for path in self._prompt_files():
+            content = path.read_text(encoding="utf-8")
+            for deprecated in DEPRECATED_TOOL_NAMES:
+                if deprecated in content:
+                    violations.append(
+                        f"{path.relative_to(PROMPTS_DIR)}: contains '{deprecated}'"
+                    )
+        self.assertEqual(
+            [],
+            violations,
+            "Deprecated tool names found in prompt files:\n" + "\n".join(violations),
+        )
+
+    def test_handoff_contract_architecture_uses_unprefixed_submit(self) -> None:
+        """handoff-contract-architecture.md should reference submit_architecture."""
+        path = PROMPTS_DIR / "shared" / "handoff-contract-architecture.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("submit_architecture", content)
+        self.assertNotIn("agentmux_submit_architecture", content)
+
+    def test_handoff_contract_plan_uses_unprefixed_submit(self) -> None:
+        """handoff-contract-plan.md should reference unprefixed submit tools."""
+        path = PROMPTS_DIR / "shared" / "handoff-contract-plan.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("submit_subplan", content)
+        self.assertIn("submit_execution_plan", content)
+        self.assertNotIn("agentmux_submit_subplan", content)
+        self.assertNotIn("agentmux_submit_execution_plan", content)
+
+    def test_handoff_contract_review_uses_unprefixed_submit(self) -> None:
+        """handoff-contract-review.md should reference submit_review."""
+        path = PROMPTS_DIR / "shared" / "handoff-contract-review.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("submit_review", content)
+        self.assertNotIn("agentmux_submit_review", content)
+
+    def test_handoff_contracts_mention_event_model(self) -> None:
+        """Each handoff contract should mention the event-based workflow model."""
+        for name in (
+            "handoff-contract-architecture.md",
+            "handoff-contract-plan.md",
+            "handoff-contract-review.md",
+        ):
+            path = PROMPTS_DIR / "shared" / name
+            content = path.read_text(encoding="utf-8")
+            self.assertTrue(
+                "event" in content.lower()
+                or "orchestrator observes" in content.lower(),
+                f"{name} should mention the event-based workflow model",
+            )
+
+    def test_architect_prompt_uses_unprefixed_research_tools(self) -> None:
+        """architect.md should reference unprefixed research dispatch tools."""
+        path = PROMPTS_DIR / "agents" / "architect.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("research_dispatch_code", content)
+        self.assertIn("research_dispatch_web", content)
+        self.assertNotIn("agentmux_research_dispatch_code", content)
+        self.assertNotIn("agentmux_research_dispatch_web", content)
+
+    def test_architect_prompt_mentions_submit_research_done(self) -> None:
+        """architect.md should document submit_research_done."""
+        path = PROMPTS_DIR / "agents" / "architect.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("submit_research_done", content)
+
+    def test_coder_prompt_mentions_submit_done(self) -> None:
+        """coder.md should document submit_done."""
+        path = PROMPTS_DIR / "agents" / "coder.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("submit_done", content)
+
+    def test_product_manager_prompt_uses_unprefixed_research_tools(self) -> None:
+        """product-manager.md should reference unprefixed research dispatch tools."""
+        path = PROMPTS_DIR / "agents" / "product-manager.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("research_dispatch_code", content)
+        self.assertIn("research_dispatch_web", content)
+        self.assertNotIn("agentmux_research_dispatch_code", content)
+        self.assertNotIn("agentmux_research_dispatch_web", content)
+
+    def test_product_manager_prompt_mentions_submit_pm_done(self) -> None:
+        """product-manager.md should document submit_pm_done."""
+        path = PROMPTS_DIR / "agents" / "product-manager.md"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("submit_pm_done", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -111,7 +111,7 @@ class ResumeCliAndSessionTests(unittest.TestCase):
 
 
 class InferResumePhaseTests(unittest.TestCase):
-    def _write_json(self, path: Path, text: str) -> None:
+    def _write_yaml(self, path: Path, text: str) -> None:
         path.write_text(text, encoding="utf-8")
 
     def test_non_failed_phase_returns_as_is(self) -> None:
@@ -146,8 +146,9 @@ class InferResumePhaseTests(unittest.TestCase):
             (feature_dir / PLANNING_DIR / "plan.md").write_text(
                 "# Plan", encoding="utf-8"
             )
-            self._write_json(
-                feature_dir / PLANNING_DIR / "plan_meta.json", '{"needs_design": true}'
+            self._write_yaml(
+                feature_dir / PLANNING_DIR / "execution_plan.yaml",
+                "needs_design: true\n",
             )
             state = {"phase": "failed"}
             self.assertEqual("designing", infer_resume_phase(feature_dir, state))
@@ -241,12 +242,10 @@ class InferResumePhaseTests(unittest.TestCase):
             (feature_dir / PLANNING_DIR / "plan.md").write_text(
                 "# Plan", encoding="utf-8"
             )
-            self._write_json(
-                feature_dir / PLANNING_DIR / "plan_meta.json",
-                (
-                    '{"needs_design": false, "needs_docs": true, '
-                    '"doc_files": ["docs/file-protocol.md"]}'
-                ),
+            self._write_yaml(
+                feature_dir / PLANNING_DIR / "execution_plan.yaml",
+                "needs_design: false\nneeds_docs: true\n"
+                "doc_files:\n- docs/file-protocol.md\n",
             )
             (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text(
                 "", encoding="utf-8"
@@ -271,9 +270,9 @@ class InferResumePhaseTests(unittest.TestCase):
             (feature_dir / PLANNING_DIR / "plan.md").write_text(
                 "# Plan", encoding="utf-8"
             )
-            self._write_json(
-                feature_dir / PLANNING_DIR / "plan_meta.json",
-                '{"needs_design": false, "needs_docs": false, "doc_files": []}',
+            self._write_yaml(
+                feature_dir / PLANNING_DIR / "execution_plan.yaml",
+                "needs_design: false\nneeds_docs: false\ndoc_files: []\n",
             )
             (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text(
                 "", encoding="utf-8"
@@ -323,14 +322,17 @@ class ResumeStartupRoleTests(unittest.TestCase):
             feature_dir = Path(td)
             planning_dir = feature_dir / PLANNING_DIR
             planning_dir.mkdir(parents=True, exist_ok=True)
-            (planning_dir / "plan_meta.json").write_text(
-                json.dumps(
+            import yaml
+
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
                     {
                         "review_strategy": {
                             "severity": "high",
                             "focus": ["security"],
                         }
-                    }
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -283,6 +283,32 @@ class InferResumePhaseTests(unittest.TestCase):
             state = {"phase": "failed", "subplan_count": 1}
             self.assertEqual("completing", infer_resume_phase(feature_dir, state))
 
+    def test_failed_review_yaml_pass_resumes_completing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            (feature_dir / PLANNING_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / IMPLEMENTATION_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / REVIEW_DIR).mkdir(parents=True, exist_ok=True)
+            (feature_dir / PLANNING_DIR / "architecture.md").write_text(
+                "# Architecture", encoding="utf-8"
+            )
+            (feature_dir / PLANNING_DIR / "plan.md").write_text(
+                "# Plan", encoding="utf-8"
+            )
+            self._write_yaml(
+                feature_dir / PLANNING_DIR / "execution_plan.yaml",
+                "needs_design: false\nneeds_docs: false\ndoc_files: []\n",
+            )
+            (feature_dir / IMPLEMENTATION_DIR / "done_1").write_text(
+                "", encoding="utf-8"
+            )
+            (feature_dir / REVIEW_DIR / "review.yaml").write_text(
+                "verdict: pass\nsummary: Looks good\n",
+                encoding="utf-8",
+            )
+            state = {"phase": "failed", "subplan_count": 1}
+            self.assertEqual("completing", infer_resume_phase(feature_dir, state))
+
     def test_removes_dispatched_research_tasks_from_state(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             feature_dir = Path(td)

--- a/tests/test_review_pass_requirements.py
+++ b/tests/test_review_pass_requirements.py
@@ -149,8 +149,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature")
-            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
-            ctx.files.review.write_text("verdict: pass\n", encoding="utf-8")
+            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
@@ -158,9 +157,15 @@ class ReviewPassRequirementsTests(unittest.TestCase):
 
             handler = ReviewingHandler()
             event = WorkflowEvent(
-                kind="review_ready",
-                path="06_review/review.md",
-                payload={},
+                kind="review",
+                payload={
+                    "payload": {
+                        "verdict": "pass",
+                        "summary": "LGTM, all checks pass.",
+                        "findings": [],
+                        "commit_message": "feat: implementation complete",
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -191,8 +196,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
-            ctx.files.review.write_text("verdict: pass\n", encoding="utf-8")
+            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
@@ -200,9 +204,15 @@ class ReviewPassRequirementsTests(unittest.TestCase):
 
             handler = ReviewingHandler()
             event = WorkflowEvent(
-                kind="review_ready",
-                path="06_review/review.md",
-                payload={},
+                kind="review",
+                payload={
+                    "payload": {
+                        "verdict": "pass",
+                        "summary": "LGTM, all checks pass.",
+                        "findings": [],
+                        "commit_message": "feat: implementation complete",
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
@@ -217,8 +227,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature")
-            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
-            ctx.files.review.write_text("verdict: fail\n- finding\n", encoding="utf-8")
+            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
@@ -227,9 +236,21 @@ class ReviewPassRequirementsTests(unittest.TestCase):
 
             handler = ReviewingHandler()
             event = WorkflowEvent(
-                kind="review_ready",
-                path="06_review/review.md",
-                payload={},
+                kind="review",
+                payload={
+                    "payload": {
+                        "verdict": "fail",
+                        "summary": "Issues found.",
+                        "findings": [
+                            {
+                                "location": "src/x.py:1",
+                                "issue": "missing validation",
+                                "severity": "high",
+                                "recommendation": "Add input validation.",
+                            }
+                        ],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx

--- a/tests/test_review_pass_requirements.py
+++ b/tests/test_review_pass_requirements.py
@@ -177,11 +177,17 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature")
+            import yaml
+
             ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.planning_dir / "plan_meta.json").write_text(
-                (
-                    '{"needs_design": false, "needs_docs": true, '
-                    '"doc_files": ["docs/file-protocol.md"]}'
+            (ctx.files.planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "needs_design": False,
+                        "needs_docs": True,
+                        "doc_files": ["docs/file-protocol.md"],
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -159,9 +159,11 @@ class TestReviewRoutingIntegration:
             "needs_docs": False,
             "doc_files": [],
         }
-        import json
+        import yaml
 
-        (planning_dir / "plan_meta.json").write_text(json.dumps(plan_meta))
+        (planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(plan_meta, default_flow_style=False)
+        )
 
         # Verify routing defaults to logic
         from agentmux.workflow.phase_helpers import load_plan_meta, select_reviewer_type
@@ -172,7 +174,7 @@ class TestReviewRoutingIntegration:
 
     def test_planning_to_reviewing_transition_with_various_plan_meta(self, tmp_path):
         """Test transition with various plan_meta configurations."""
-        import json
+        import yaml
 
         from agentmux.workflow.phase_helpers import load_plan_meta, select_reviewer_type
 
@@ -187,7 +189,9 @@ class TestReviewRoutingIntegration:
             planning_dir = tmp_path / f"02_planning_{idx}_{expected_type}"
             planning_dir.mkdir(parents=True)
             plan_meta = {"review_strategy": review_strategy}
-            (planning_dir / "plan_meta.json").write_text(json.dumps(plan_meta))
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(plan_meta, default_flow_style=False)
+            )
 
             loaded_meta = load_plan_meta(planning_dir)
             reviewer_type = select_reviewer_type(loaded_meta)

--- a/tests/test_reviewing_resume.py
+++ b/tests/test_reviewing_resume.py
@@ -210,15 +210,33 @@ class TestResumeGuard(unittest.TestCase):
 
 
 class TestReviewArchive(unittest.TestCase):
+    _FAIL_PAYLOAD: dict = {
+        "verdict": "fail",
+        "summary": "Issues found in implementation.",
+        "findings": [
+            {
+                "location": "src/x.py:1",
+                "issue": "missing validation",
+                "severity": "high",
+                "recommendation": "Add input validation.",
+            }
+        ],
+    }
+    _PASS_PAYLOAD: dict = {
+        "verdict": "pass",
+        "summary": "All checks pass.",
+        "findings": [],
+        "commit_message": "feat: implementation complete",
+    }
+
     def _dispatch_review(
         self,
         ctx: PipelineContext,
         state_path: Path,
-        verdict_text: str,
+        payload: dict,
         iteration: int = 0,
     ) -> tuple[dict, str | None]:
-        ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
-        ctx.files.review.write_text(verdict_text, encoding="utf-8")
+        ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
 
         state = load_state(state_path)
         state["phase"] = "reviewing"
@@ -226,17 +244,13 @@ class TestReviewArchive(unittest.TestCase):
         write_state(state_path, state)
 
         handler = ReviewingHandler()
-        event = WorkflowEvent(
-            kind="review_ready", path="06_review/review.md", payload={}
-        )
+        event = WorkflowEvent(kind="review", payload={"payload": payload})
         return handler.handle_event(event, load_state(state_path), ctx)
 
     def test_verdict_fail_creates_archive_and_keeps_review_md(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(Path(td) / "feature")
-            self._dispatch_review(
-                ctx, state_path, "verdict: fail\n- finding\n", iteration=0
-            )
+            self._dispatch_review(ctx, state_path, self._FAIL_PAYLOAD, iteration=0)
 
             archive = ctx.files.review_dir / "review_0.md"
             self.assertTrue(archive.exists(), "review_0.md archive must be created")
@@ -246,9 +260,7 @@ class TestReviewArchive(unittest.TestCase):
     def test_verdict_fail_second_iteration_archives_correctly(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(Path(td) / "feature")
-            self._dispatch_review(
-                ctx, state_path, "verdict: fail\n- finding 2\n", iteration=1
-            )
+            self._dispatch_review(ctx, state_path, self._FAIL_PAYLOAD, iteration=1)
 
             archive = ctx.files.review_dir / "review_1.md"
             self.assertTrue(archive.exists(), "review_1.md archive must be created")
@@ -256,7 +268,7 @@ class TestReviewArchive(unittest.TestCase):
     def test_verdict_pass_creates_archive_and_keeps_review_md(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(Path(td) / "feature")
-            self._dispatch_review(ctx, state_path, "verdict: pass\n", iteration=0)
+            self._dispatch_review(ctx, state_path, self._PASS_PAYLOAD, iteration=0)
 
             archive = ctx.files.review_dir / "review_0.md"
             self.assertTrue(
@@ -269,11 +281,16 @@ class TestReviewArchive(unittest.TestCase):
     def test_archive_contains_same_content_as_review_md(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(Path(td) / "feature")
-            content = "verdict: fail\n## Finding\nSomething is wrong.\n"
-            self._dispatch_review(ctx, state_path, content, iteration=2)
+            self._dispatch_review(ctx, state_path, self._FAIL_PAYLOAD, iteration=2)
 
             archive = ctx.files.review_dir / "review_2.md"
-            self.assertEqual(content, archive.read_text(encoding="utf-8"))
+            review_md = ctx.files.review_dir / "review.md"
+            self.assertTrue(archive.exists(), "archive must be created")
+            self.assertTrue(review_md.exists(), "review.md must be created")
+            self.assertEqual(
+                review_md.read_text(encoding="utf-8"),
+                archive.read_text(encoding="utf-8"),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_reviewing_resume.py
+++ b/tests/test_reviewing_resume.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 from agentmux.sessions.state_store import create_feature_files, load_state, write_state
 from agentmux.shared.models import SESSION_DIR_NAMES, AgentConfig
 from agentmux.workflow.event_router import WorkflowEvent
@@ -103,6 +105,41 @@ class TestResumeGuard(unittest.TestCase):
             send_calls = [c for c in ctx.runtime.calls if c[0] == "send"]
             self.assertEqual([], send_calls, "no prompt should be sent on resume")
 
+    def test_resume_with_existing_review_yaml_does_not_delete_or_prompt(self) -> None:
+        """On resume, if review.yaml exists, enter() leaves it and sends no prompt."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(Path(td) / "feature")
+            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
+            (ctx.files.review_dir / "review.yaml").write_text(
+                yaml.dump(
+                    {
+                        "verdict": "fail",
+                        "summary": "Needs fixes",
+                        "findings": [
+                            {
+                                "issue": "Missing validation",
+                                "recommendation": "Add the missing check.",
+                            }
+                        ],
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "resumed"
+            write_state(state_path, state)
+
+            handler = ReviewingHandler()
+            result = handler.enter(load_state(state_path), ctx)
+
+            self.assertEqual({}, result)
+            self.assertTrue((ctx.files.review_dir / "review.yaml").exists())
+            send_calls = [c for c in ctx.runtime.calls if c[0] == "send"]
+            self.assertEqual([], send_calls, "no prompt should be sent on resume")
+
     def test_resume_without_review_sends_prompt(self) -> None:
         """On resume, if review.md does not exist, enter() proceeds normally."""
         with tempfile.TemporaryDirectory() as td:
@@ -140,6 +177,35 @@ class TestResumeGuard(unittest.TestCase):
 
             self.assertFalse(
                 ctx.files.review.exists(), "stale review.md must be deleted"
+            )
+
+    def test_fresh_entry_deletes_stale_review_yaml(self) -> None:
+        """On fresh entry, a stale review.yaml is also deleted."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(Path(td) / "feature")
+            ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
+            (ctx.files.review_dir / "review.yaml").write_text(
+                yaml.dump(
+                    {
+                        "verdict": "pass",
+                        "summary": "Looks good",
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "implementation_completed"
+            write_state(state_path, state)
+
+            handler = ReviewingHandler()
+            handler.enter(load_state(state_path), ctx)
+
+            self.assertFalse(
+                (ctx.files.review_dir / "review.yaml").exists(),
+                "stale review.yaml must be deleted",
             )
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -599,10 +599,21 @@ class RuntimeTests(unittest.TestCase):
             (planning_dir / "plan_2.md").write_text(
                 "## Sub-plan 2: UI polish\n", encoding="utf-8"
             )
-            (planning_dir / "execution_plan.json").write_text(
-                (
-                    '{"version": 1, "groups": [{"group_id": "g1", "mode": "parallel", '
-                    '"plans": [{"file": "plan_2.md", "name": "UI polish"}]}]}'
+            import yaml
+
+            (planning_dir / "execution_plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "version": 1,
+                        "groups": [
+                            {
+                                "group_id": "g1",
+                                "mode": "parallel",
+                                "plans": [{"file": "plan_2.md", "name": "UI polish"}],
+                            }
+                        ],
+                    },
+                    default_flow_style=False,
                 ),
                 encoding="utf-8",
             )

--- a/tests/test_split_architecting_planning.py
+++ b/tests/test_split_architecting_planning.py
@@ -171,12 +171,12 @@ class TestPlannerPromptTemplates(unittest.TestCase):
             content = planner_prompt.read_text(encoding="utf-8")
             self.assertIn("[[include:02_planning/architecture.md]]", content)
 
-    def test_planner_agent_includes_execution_plan_json(self) -> None:
-        """Planner agent prompt should mention execution_plan.json creation."""
+    def test_planner_agent_includes_execution_plan_yaml(self) -> None:
+        """Planner agent prompt should mention execution_plan.yaml creation."""
         planner_prompt = self.agents_dir / "planner.md"
         if planner_prompt.exists():
             content = planner_prompt.read_text(encoding="utf-8")
-            self.assertIn("execution_plan.json", content)
+            self.assertIn("execution_plan.yaml", content)
 
     def test_planner_agent_includes_plan_markdown(self) -> None:
         """Planner agent prompt should mention plan.md creation."""

--- a/tests/test_staged_execution_scheduler.py
+++ b/tests/test_staged_execution_scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -123,9 +122,11 @@ def _write_execution_plan(ctx: PipelineContext, groups: list[dict]) -> None:
     planning_dir.mkdir(parents=True, exist_ok=True)
     (planning_dir / "architecture.md").write_text("# Architecture\n", encoding="utf-8")
     (planning_dir / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    import yaml
+
     payload = {"version": 1, "groups": groups}
-    (planning_dir / "execution_plan.json").write_text(
-        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    (planning_dir / "execution_plan.yaml").write_text(
+        yaml.dump(payload, default_flow_style=False), encoding="utf-8"
     )
     for group in groups:
         for plan_file in group["plans"]:

--- a/tests/test_staged_execution_scheduler.py
+++ b/tests/test_staged_execution_scheduler.py
@@ -175,9 +175,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_1")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_1",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 1}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -216,9 +215,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_1")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_1",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 1}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -228,9 +226,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_2")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_2",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 2}},
             )
             updates, next_phase = handler.handle_event(event, state, ctx)
             state.update(updates)
@@ -280,9 +277,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_1")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_1",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 1}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -303,9 +299,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_2")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_2",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 2}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -315,9 +310,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_3")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_3",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 3}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -331,9 +325,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_4")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_4",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 4}},
             )
             updates, next_phase = handler.handle_event(event, state, ctx)
             state.update(updates)
@@ -377,9 +370,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_1")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_1",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 1}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -388,9 +380,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_2")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_2",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 2}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -433,9 +424,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_3")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_3",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 3}},
             )
             state = load_state(state_path)
             updates, next_phase = resumed_handler.handle_event(
@@ -451,9 +441,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             _touch(ctx.files.implementation_dir / "done_4")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_4",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 4}},
             )
             updates, next_phase = resumed_handler.handle_event(
                 event, state, resumed_ctx
@@ -507,9 +496,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
             # Complete first plan
             _touch(ctx.files.implementation_dir / "done_1")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_1",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 1}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)
@@ -533,9 +521,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
             # Complete second plan
             _touch(ctx.files.implementation_dir / "done_2")
             event = WorkflowEvent(
-                kind="done_marker",
-                path="05_implementation/done_2",
-                payload={},
+                kind="done",
+                payload={"payload": {"subplan_index": 2}},
             )
             state = load_state(state_path)
             updates, next_phase = handler.handle_event(event, state, ctx)

--- a/tests/test_staged_planning_docs_requirements.py
+++ b/tests/test_staged_planning_docs_requirements.py
@@ -12,7 +12,7 @@ class StagedPlanningDocsRequirementsTests(unittest.TestCase):
 
     def test_prompts_doc_covers_staged_planning_contract(self) -> None:
         text = self._read_doc("docs/prompts.md")
-        self.assertIn("02_planning/execution_plan.json", text)
+        self.assertIn("02_planning/execution_plan.yaml", text)
         self.assertIn("plan_<N>.md", text)
         self.assertIn("Scope", text)
         self.assertIn("Owned files/modules", text)
@@ -59,7 +59,7 @@ class StagedPlanningDocsRequirementsTests(unittest.TestCase):
         self,
     ) -> None:
         text = self._read_doc("docs/file-protocol.md")
-        self.assertIn("execution_plan.json", text)
+        self.assertIn("execution_plan.yaml", text)
         self.assertIn("execution groups", text.lower())
         self.assertIn("serial", text.lower())
         self.assertIn("parallel", text.lower())

--- a/tests/test_staged_planning_docs_requirements.py
+++ b/tests/test_staged_planning_docs_requirements.py
@@ -64,7 +64,9 @@ class StagedPlanningDocsRequirementsTests(unittest.TestCase):
         self.assertIn("serial", text.lower())
         self.assertIn("parallel", text.lower())
         self.assertIn("strict", text.lower())
-        self.assertIn('{ "file": "plan_<N>.md", "name": "Human title" }', text)
+        self.assertIn("YAML mapping", text)
+        self.assertIn("`- file: plan_1.md`", text)
+        self.assertIn("`name: Core setup`", text)
 
     def test_monitor_doc_covers_staged_execution_progress(self) -> None:
         text = self._read_doc("docs/monitor.md")

--- a/tests/test_tasks_requirements.py
+++ b/tests/test_tasks_requirements.py
@@ -124,7 +124,7 @@ class TasksRequirementsTests(unittest.TestCase):
             )
             self.assertNotIn("also write per-plan task files", architect_prompt)
             self.assertNotIn(
-                "also write `02_planning/execution_plan.json`", architect_prompt
+                "also write `02_planning/execution_plan.yaml`", architect_prompt
             )
             self.assertNotIn("write `02_planning/plan_meta.json`", architect_prompt)
             self.assertNotIn("Phase 1: Foundation & Interfaces", architect_prompt)
@@ -151,8 +151,8 @@ class TasksRequirementsTests(unittest.TestCase):
             self.assertIn("Dependencies", planner_prompt)
             self.assertIn("Isolation", planner_prompt)
             self.assertIn("Final Artifact Generation", planner_prompt)
-            self.assertIn("execution_plan.json", planner_prompt)
-            self.assertIn("plan_meta.json", planner_prompt)
+            self.assertIn("execution_plan.yaml", planner_prompt)
+            self.assertNotIn("plan_meta.json", planner_prompt)
 
             self.assertIn("05_implementation/done_1", coder_prompt)
             self.assertIn("Do not update state.json", coder_prompt)
@@ -232,8 +232,7 @@ class TasksRequirementsTests(unittest.TestCase):
             )
 
             self.assertIn(
-                "Treat planned documentation updates as required implementation "
-                "scope during review; do not defer them to a separate phase or agent.",
+                "Treat planned documentation updates as required implementation scope",
                 reviewer_agent_prompt,
             )
             self.assertIn(
@@ -264,8 +263,8 @@ class TasksRequirementsTests(unittest.TestCase):
             self.assertIn('<file path="02_planning/plan.md">', prompt)
             self.assertIn('<file path="02_planning/tasks.md">', prompt)
             self.assertIn('<file path="08_completion/changes.md">', prompt)
-            self.assertIn("02_planning/execution_plan.json", prompt)
-            self.assertIn("02_planning/plan_meta.json", prompt)
+            self.assertIn("02_planning/execution_plan.yaml", prompt)
+            self.assertNotIn("02_planning/plan_meta.json", prompt)
             self.assertIn(
                 "Documentation updates must be captured as explicit plan "
                 "and task items in `02_planning/plan.md`, "

--- a/tests/test_web_researcher_requirements.py
+++ b/tests/test_web_researcher_requirements.py
@@ -174,7 +174,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
 
             self.assertIn("03_research/web-<topic>/summary.md", prompt)
             self.assertIn("03_research/web-<topic>/detail.md", prompt)
-            self.assertIn("agentmux_research_dispatch_web", prompt)
+            self.assertIn("research_dispatch_web", prompt)
 
     def test_planning_handle_web_task_requested_spawns_researcher_and_updates_state(
         self,
@@ -187,40 +187,30 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             write_state(state_path, state)
 
-            (feature_dir / RESEARCH_DIR / "web-openai-models").mkdir(
-                parents=True, exist_ok=True
-            )
-            (
-                feature_dir / RESEARCH_DIR / "web-openai-models" / "request.md"
-            ).write_text(
-                "investigate models",
-                encoding="utf-8",
-            )
-            stale_done = feature_dir / RESEARCH_DIR / "web-openai-models" / "done"
-            stale_done.touch()
-
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="web_research_requested",
-                path="03_research/web-openai-models/request.md",
-                payload={},
+                kind="research_web_req",
+                payload={
+                    "payload": {
+                        "topic": "openai-models",
+                        "context": "Investigate OpenAI models API",
+                        "questions": ["What models are available?"],
+                        "scope_hints": [],
+                    }
+                },
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx
             )
 
             self.assertIsNone(next_phase)
-            self.assertFalse(stale_done.exists())
-            # spawn_task now receives the research directory
+            # spawn_task receives the research directory
             self.assertEqual(
                 ("spawn_task", "web-researcher", "openai-models", "web-openai-models"),
                 ctx.runtime.calls[-1],
             )
-            self.assertTrue(
-                (
-                    feature_dir / RESEARCH_DIR / "web-openai-models" / "prompt.md"
-                ).exists()
-            )
+            research_dir = feature_dir / RESEARCH_DIR / "web-openai-models"
+            self.assertTrue((research_dir / "request.md").exists())
             self.assertEqual(
                 "dispatched", updates.get("web_research_tasks", {}).get("openai-models")
             )
@@ -236,16 +226,10 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             state["phase"] = "planning"
             state["web_research_tasks"] = {"openai-models": "dispatched"}
             write_state(state_path, state)
-            (feature_dir / RESEARCH_DIR / "web-openai-models").mkdir(
-                parents=True, exist_ok=True
-            )
-            (feature_dir / RESEARCH_DIR / "web-openai-models" / "done").touch()
-
             handler = PlanningHandler()
             event = WorkflowEvent(
-                kind="web_research_done",
-                path="03_research/web-openai-models/done",
-                payload={},
+                kind="research_done",
+                payload={"payload": {"topic": "openai-models", "role_type": "web"}},
             )
             updates, next_phase = handler.handle_event(
                 event, load_state(state_path), ctx

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from agentmux.workflow.event_catalog import (
     EVENT_CHANGES_REQUESTED,
@@ -309,10 +310,10 @@ class TestPlanningHandler:
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
         mock_ctx.files.plan.write_text("plan")
         mock_ctx.files.tasks.write_text("tasks")
-        (mock_ctx.files.planning_dir / "plan_meta.json").write_text(
-            '{"needs_design": false}'
+
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump({"needs_design": False}, default_flow_style=False)
         )
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text("{}")
 
         with (
             patch("agentmux.workflow.handlers.planning.load_execution_plan"),
@@ -340,10 +341,10 @@ class TestPlanningHandler:
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
         mock_ctx.files.plan.write_text("plan")
         mock_ctx.files.tasks.write_text("tasks")
-        (mock_ctx.files.planning_dir / "plan_meta.json").write_text(
-            '{"needs_design": true}'
+
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump({"needs_design": True}, default_flow_style=False)
         )
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text("{}")
 
         # Add designer to agents
         mock_ctx.agents = {"designer": MagicMock()}
@@ -370,8 +371,10 @@ class TestPlanningHandler:
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
         mock_ctx.files.plan.write_text("plan")
         mock_ctx.files.tasks.write_text("tasks")
-        (mock_ctx.files.planning_dir / "plan_meta.json").write_text("{}")
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text("{}")
+
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump({}, default_flow_style=False)
+        )
         mock_ctx.files.changes.write_text("changes")
 
         with (
@@ -448,8 +451,8 @@ class TestImplementingHandler:
 
         # Create execution plan
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text(
-            json.dumps(
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
                 {
                     "version": 1,
                     "groups": [
@@ -459,7 +462,8 @@ class TestImplementingHandler:
                             "plans": [{"file": "plan_1.md", "name": "First Plan"}],
                         }
                     ],
-                }
+                },
+                default_flow_style=False,
             )
         )
         (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
@@ -504,8 +508,8 @@ class TestImplementingHandler:
 
         # Create execution plan
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text(
-            json.dumps(
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
                 {
                     "version": 1,
                     "groups": [
@@ -518,7 +522,8 @@ class TestImplementingHandler:
                             ],
                         }
                     ],
-                }
+                },
+                default_flow_style=False,
             )
         )
         (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
@@ -545,8 +550,8 @@ class TestImplementingHandler:
 
         # Create execution plan and done marker
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text(
-            json.dumps(
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
                 {
                     "version": 1,
                     "groups": [
@@ -556,7 +561,8 @@ class TestImplementingHandler:
                             "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
                         }
                     ],
-                }
+                },
+                default_flow_style=False,
             )
         )
         (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
@@ -591,8 +597,8 @@ class TestImplementingHandler:
 
         # Create execution plan
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text(
-            json.dumps(
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
                 {
                     "version": 1,
                     "groups": [
@@ -602,7 +608,8 @@ class TestImplementingHandler:
                             "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
                         }
                     ],
-                }
+                },
+                default_flow_style=False,
             )
         )
         (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
@@ -649,8 +656,8 @@ class TestImplementingHandler:
 
         # Create execution plan
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.planning_dir / "execution_plan.json").write_text(
-            json.dumps(
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
                 {
                     "version": 1,
                     "groups": [
@@ -660,7 +667,8 @@ class TestImplementingHandler:
                             "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
                         }
                     ],
-                }
+                },
+                default_flow_style=False,
             )
         )
         (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -127,7 +127,7 @@ class TestProductManagementHandler:
     def test_handle_pm_completed(self, mock_ctx: MagicMock, empty_state: dict) -> None:
         """Test handling of pm_done marker."""
         handler = ProductManagementHandler()
-        event = WorkflowEvent(kind="pm_completed", path="01_product_management/done")
+        event = WorkflowEvent(kind="pm_done", payload={"payload": {}})
 
         with patch(
             "agentmux.workflow.handlers.product_management.apply_role_preferences"
@@ -145,13 +145,16 @@ class TestProductManagementHandler:
         """Test dispatching code-researcher task."""
         handler = ProductManagementHandler()
         event = WorkflowEvent(
-            kind="code_research_requested", path="03_research/code-auth/request.md"
+            kind="research_code_req",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "context": "Need to understand auth flow",
+                    "questions": ["How does auth work?"],
+                    "scope_hints": ["src/auth/"],
+                }
+            },
         )
-
-        # Create the request file
-        research_dir = mock_ctx.files.research_dir / "code-auth"
-        research_dir.mkdir(parents=True, exist_ok=True)
-        (research_dir / "request.md").write_text("research auth")
 
         with (
             patch("agentmux.workflow.prompts.write_prompt_file") as mock_write,
@@ -164,6 +167,7 @@ class TestProductManagementHandler:
 
             updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
 
+            research_dir = mock_ctx.files.research_dir / "code-auth"
             mock_ctx.runtime.spawn_task.assert_called_once_with(
                 "code-researcher", "auth", research_dir
             )
@@ -177,13 +181,16 @@ class TestProductManagementHandler:
         """Test dispatching web-researcher task."""
         handler = ProductManagementHandler()
         event = WorkflowEvent(
-            kind="web_research_requested", path="03_research/web-api/request.md"
+            kind="research_web_req",
+            payload={
+                "payload": {
+                    "topic": "api",
+                    "context": "Need to understand API design",
+                    "questions": ["What are best practices?"],
+                    "scope_hints": [],
+                }
+            },
         )
-
-        # Create the request file
-        research_dir = mock_ctx.files.research_dir / "web-api"
-        research_dir.mkdir(parents=True, exist_ok=True)
-        (research_dir / "request.md").write_text("research api")
 
         with (
             patch("agentmux.workflow.prompts.write_prompt_file") as mock_write,
@@ -196,6 +203,7 @@ class TestProductManagementHandler:
 
             updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
 
+            research_dir = mock_ctx.files.research_dir / "web-api"
             mock_ctx.runtime.spawn_task.assert_called_once_with(
                 "web-researcher", "api", research_dir
             )
@@ -208,7 +216,8 @@ class TestProductManagementHandler:
         """Test handling code-research completion."""
         handler = ProductManagementHandler()
         event = WorkflowEvent(
-            kind="code_research_done", path="03_research/code-auth/done"
+            kind="research_done",
+            payload={"payload": {"topic": "auth", "role_type": "code"}},
         )
 
         # Setup state with dispatched task
@@ -226,7 +235,15 @@ class TestProductManagementHandler:
         """Test that already dispatched research is not re-dispatched."""
         handler = ProductManagementHandler()
         event = WorkflowEvent(
-            kind="code_research_requested", path="03_research/code-auth/request.md"
+            kind="research_code_req",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "context": "Need to understand auth",
+                    "questions": ["How does auth work?"],
+                    "scope_hints": [],
+                }
+            },
         )
 
         # Setup state with already dispatched task
@@ -304,7 +321,7 @@ class TestPlanningHandler:
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
         handler = PlanningHandler()
-        event = WorkflowEvent(kind="plan_written", path="02_planning/plan.md")
+        event = WorkflowEvent(kind="execution_plan", payload={"payload": {}})
 
         # Create all required files
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
@@ -335,7 +352,7 @@ class TestPlanningHandler:
     ) -> None:
         """Test transition to designing when needs_design is true."""
         handler = PlanningHandler()
-        event = WorkflowEvent(kind="plan_written", path="02_planning/plan.md")
+        event = WorkflowEvent(kind="execution_plan", payload={"payload": {}})
 
         # Create all required files
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
@@ -363,9 +380,9 @@ class TestPlanningHandler:
     def test_deletes_changes_md_on_transition(
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
-        """Test that changes.md is deleted on plan_written transition."""
+        """Test that changes.md is deleted on execution_plan submission."""
         handler = PlanningHandler()
-        event = WorkflowEvent(kind="plan_written", path="02_planning/plan.md")
+        event = WorkflowEvent(kind="execution_plan", payload={"payload": {}})
 
         # Create all required files including changes.md
         mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
@@ -493,9 +510,9 @@ class TestImplementingHandler:
     def test_handle_subplan_completed_parallel_mode(self, mock_ctx: MagicMock) -> None:
         """Test handling subplan completion in parallel mode."""
         handler = ImplementingHandler()
-        event = WorkflowEvent(kind="done_marker", path="05_implementation/done_1")
+        event = WorkflowEvent(kind="done", payload={"payload": {"subplan_index": 1}})
 
-        # Create the done marker so is_ready predicate passes
+        # Pre-create done_1 so group-completion check sees it as already done
         mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
         (mock_ctx.files.implementation_dir / "done_1").touch()
 
@@ -539,7 +556,7 @@ class TestImplementingHandler:
     def test_handle_implementation_completed(self, mock_ctx: MagicMock) -> None:
         """Test transition when all implementation is complete."""
         handler = ImplementingHandler()
-        event = WorkflowEvent(kind="done_marker", path="05_implementation/done_1")
+        event = WorkflowEvent(kind="done", payload={"payload": {"subplan_index": 1}})
 
         # Setup state with all markers complete
         state = {
@@ -727,11 +744,19 @@ class TestReviewingHandler:
     def test_handle_review_passed(self, mock_ctx: MagicMock, empty_state: dict) -> None:
         """Test that VERDICT:PASS stays in reviewing and requests summary."""
         handler = ReviewingHandler()
-        event = WorkflowEvent(kind="review_ready", path="06_review/review.md")
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "pass",
+                    "summary": "Looks good!",
+                    "findings": [],
+                    "commit_message": "feat: all done",
+                }
+            },
+        )
 
-        # Create review.md with pass verdict
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        mock_ctx.files.review.write_text("verdict: pass\n\nLooks good!")
 
         updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
 
@@ -745,25 +770,28 @@ class TestReviewingHandler:
     def test_handle_review_yaml_pass_materializes_review_md(
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
+        """Review tool event writes both review.yaml and review.md."""
         handler = ReviewingHandler()
-        event = WorkflowEvent(kind="review_ready", path="06_review/review.yaml")
-
-        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
-            yaml.dump(
-                {
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
                     "verdict": "pass",
                     "summary": "Looks good!",
-                },
-                sort_keys=False,
-            ),
-            encoding="utf-8",
+                    "findings": [],
+                    "commit_message": "feat: done",
+                }
+            },
         )
+
+        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
 
         updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
 
         assert next_phase is None
         assert updates.get("awaiting_summary") is True
+        yaml_path = mock_ctx.files.review_dir / "review.yaml"
+        assert yaml_path.exists()
         assert mock_ctx.files.review.exists()
         assert mock_ctx.files.review.read_text(encoding="utf-8").startswith(
             "verdict: pass"
@@ -774,11 +802,26 @@ class TestReviewingHandler:
     ) -> None:
         """Test transition to fixing when under max iterations."""
         handler = ReviewingHandler()
-        event = WorkflowEvent(kind="review_ready", path="06_review/review.md")
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "fail",
+                    "summary": "Needs fixes",
+                    "findings": [
+                        {
+                            "location": "src/example.py:10",
+                            "issue": "Missing validation",
+                            "severity": "high",
+                            "recommendation": "Add check",
+                        }
+                    ],
+                    "commit_message": "",
+                }
+            },
+        )
 
-        # Create review.md with fail verdict
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        mock_ctx.files.review.write_text("verdict: fail\n\nNeeds fixes")
 
         updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
 
@@ -789,13 +832,12 @@ class TestReviewingHandler:
     def test_handle_review_yaml_fail_creates_fix_request(
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
+        """Review tool event with fail verdict creates fix_request.txt."""
         handler = ReviewingHandler()
-        event = WorkflowEvent(kind="review_ready", path="06_review/review.yaml")
-
-        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
-            yaml.dump(
-                {
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
                     "verdict": "fail",
                     "summary": "Needs fixes",
                     "findings": [
@@ -806,11 +848,12 @@ class TestReviewingHandler:
                             "recommendation": "Add the missing check.",
                         }
                     ],
-                },
-                sort_keys=False,
-            ),
-            encoding="utf-8",
+                    "commit_message": "",
+                }
+            },
         )
+
+        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
 
         updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
 
@@ -826,11 +869,26 @@ class TestReviewingHandler:
     ) -> None:
         """Test transition to completing when max iterations reached."""
         handler = ReviewingHandler()
-        event = WorkflowEvent(kind="review_ready", path="06_review/review.md")
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "fail",
+                    "summary": "Still failing",
+                    "findings": [
+                        {
+                            "location": "src/example.py:10",
+                            "issue": "Persistent issue",
+                            "severity": "high",
+                            "recommendation": "Fix it",
+                        }
+                    ],
+                    "commit_message": "",
+                }
+            },
+        )
 
-        # Create review.md with fail verdict
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        mock_ctx.files.review.write_text("verdict: fail\n\nStill failing")
 
         # Set state at max iterations
         state = {"review_iteration": 3}
@@ -1085,13 +1143,16 @@ class TestHandlerEdgeCases:
         """Test that handlers preserve existing state fields."""
         handler = ProductManagementHandler()
         event = WorkflowEvent(
-            kind="code_research_requested", path="03_research/code-auth/request.md"
+            kind="research_code_req",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "context": "Need to understand auth",
+                    "questions": ["How does auth work?"],
+                    "scope_hints": [],
+                }
+            },
         )
-
-        # Create the request file
-        research_dir = mock_ctx.files.research_dir / "code-auth"
-        research_dir.mkdir(parents=True, exist_ok=True)
-        (research_dir / "request.md").write_text("research auth")
 
         # State with existing fields
         state = {

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -742,6 +742,33 @@ class TestReviewingHandler:
         assert updates.get("awaiting_summary") is True
         assert updates.get("last_event") == EVENT_REVIEW_PASSED
 
+    def test_handle_review_yaml_pass_materializes_review_md(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        handler = ReviewingHandler()
+        event = WorkflowEvent(kind="review_ready", path="06_review/review.yaml")
+
+        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
+        (mock_ctx.files.review_dir / "review.yaml").write_text(
+            yaml.dump(
+                {
+                    "verdict": "pass",
+                    "summary": "Looks good!",
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        assert next_phase is None
+        assert updates.get("awaiting_summary") is True
+        assert mock_ctx.files.review.exists()
+        assert mock_ctx.files.review.read_text(encoding="utf-8").startswith(
+            "verdict: pass"
+        )
+
     def test_handle_review_failed_under_max_iterations(
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
@@ -758,6 +785,41 @@ class TestReviewingHandler:
         assert next_phase == "fixing"
         assert updates["review_iteration"] == 1
         assert mock_ctx.files.fix_request.exists()
+
+    def test_handle_review_yaml_fail_creates_fix_request(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        handler = ReviewingHandler()
+        event = WorkflowEvent(kind="review_ready", path="06_review/review.yaml")
+
+        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
+        (mock_ctx.files.review_dir / "review.yaml").write_text(
+            yaml.dump(
+                {
+                    "verdict": "fail",
+                    "summary": "Needs fixes",
+                    "findings": [
+                        {
+                            "location": "src/example.py:10",
+                            "issue": "Missing validation",
+                            "severity": "high",
+                            "recommendation": "Add the missing check.",
+                        }
+                    ],
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        assert next_phase == "fixing"
+        assert updates["review_iteration"] == 1
+        assert mock_ctx.files.fix_request.exists()
+        assert mock_ctx.files.fix_request.read_text(encoding="utf-8").startswith(
+            "verdict: fail"
+        )
 
     def test_handle_review_failed_at_max_iterations(
         self, mock_ctx: MagicMock, empty_state: dict

--- a/tests/workflow/handlers/test_tool_event_migration.py
+++ b/tests/workflow/handlers/test_tool_event_migration.py
@@ -1,0 +1,1023 @@
+"""Tests for tool-event-based phase handler migration (sub-plan 3).
+
+These tests verify that handlers correctly implement get_tool_specs() and
+route MCP tool events via handle_event().
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentmux.workflow.event_catalog import EVENT_PM_COMPLETED
+from agentmux.workflow.event_router import WorkflowEvent
+from agentmux.workflow.handlers import (
+    ArchitectingHandler,
+    ImplementingHandler,
+    PlanningHandler,
+    ProductManagementHandler,
+    ReviewingHandler,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture
+def mock_ctx(tmp_path: Path) -> MagicMock:
+    """Create a mock PipelineContext with realistic file structure."""
+    ctx = MagicMock()
+    ctx.files.feature_dir = tmp_path
+    ctx.files.product_management_dir = tmp_path / "01_product_management"
+    ctx.files.planning_dir = tmp_path / "02_planning"
+    ctx.files.design_dir = tmp_path / "04_design"
+    ctx.files.implementation_dir = tmp_path / "05_implementation"
+    ctx.files.review_dir = tmp_path / "06_review"
+    ctx.files.completion_dir = tmp_path / "08_completion"
+    ctx.files.research_dir = tmp_path / "03_research"
+    ctx.files.changes = tmp_path / "02_planning" / "changes.md"
+    ctx.files.plan = tmp_path / "02_planning" / "plan.md"
+    ctx.files.tasks = tmp_path / "02_planning" / "tasks.md"
+    ctx.files.design = tmp_path / "04_design" / "design.md"
+    ctx.files.review = tmp_path / "06_review" / "review.md"
+    ctx.files.fix_request = tmp_path / "06_review" / "fix_request.txt"
+    ctx.files.requirements = tmp_path / "requirements.md"
+    ctx.files.context = tmp_path / "context.md"
+    ctx.files.architecture = tmp_path / "02_planning" / "architecture.md"
+    ctx.files.pm_preference_proposal = (
+        tmp_path / "01_product_management" / "preference_proposal.json"
+    )
+    ctx.files.architect_preference_proposal = (
+        tmp_path / "02_planning" / "preference_proposal.json"
+    )
+    ctx.files.reviewer_preference_proposal = (
+        tmp_path / "06_review" / "preference_proposal.json"
+    )
+    ctx.files.project_dir = tmp_path.parent
+    ctx.files.relative_path = lambda p: str(p.relative_to(tmp_path))
+    ctx.files.state = tmp_path / "state.json"
+    ctx.agents = {}
+    ctx.max_review_iterations = 3
+    ctx.workflow_settings.completion.skip_final_approval = False
+    ctx.github_config.branch_prefix = "feature/"
+
+    # Create required files for prompts that include them
+    ctx.files.context.write_text("# Context")
+    ctx.files.architecture.parent.mkdir(parents=True, exist_ok=True)
+    ctx.files.architecture.write_text("# Architecture")
+    (tmp_path / "requirements.md").write_text("# Requirements")
+    ctx.files.plan.parent.mkdir(parents=True, exist_ok=True)
+    ctx.files.plan.write_text("# Plan")
+
+    return ctx
+
+
+@pytest.fixture
+def empty_state() -> dict:
+    """Create an empty state dict."""
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# ProductManagementHandler tool-event tests
+# ---------------------------------------------------------------------------
+
+
+class TestProductManagementHandlerToolEvents:
+    """Tests for ProductManagementHandler tool-event migration."""
+
+    def test_get_tool_specs_returns_pm_done(self) -> None:
+        """get_tool_specs() returns pm_done ToolSpec."""
+        handler = ProductManagementHandler()
+        specs = handler.get_tool_specs()
+        spec_names = [s.name for s in specs]
+        assert "pm_done" in spec_names
+        pm_spec = next(s for s in specs if s.name == "pm_done")
+        assert pm_spec.tool_names == ("submit_pm_done",)
+
+    def test_get_tool_specs_returns_research_specs(self) -> None:
+        """get_tool_specs() returns research ToolSpecs."""
+        handler = ProductManagementHandler()
+        specs = handler.get_tool_specs()
+        spec_names = [s.name for s in specs]
+        assert "research_code_req" in spec_names
+        assert "research_web_req" in spec_names
+        assert "research_done" in spec_names
+
+    def test_get_event_specs_is_empty(self) -> None:
+        """get_event_specs() returns empty sequence (all replaced by ToolSpecs)."""
+        handler = ProductManagementHandler()
+        assert len(handler.get_event_specs()) == 0
+
+    def test_handle_pm_done_transitions_to_architecting(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """pm_done event transitions to architecting phase."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="pm_done",
+            payload={"payload": {}},
+        )
+
+        with patch(
+            "agentmux.workflow.handlers.product_management.apply_role_preferences"
+        ) as mock_apply:
+            updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+            mock_ctx.runtime.kill_primary.assert_called_once_with("product-manager")
+            mock_apply.assert_called_once_with(mock_ctx, "product-manager")
+            assert updates == {"last_event": EVENT_PM_COMPLETED}
+            assert next_phase == "architecting"
+
+    def test_handle_research_code_req_writes_request_then_dispatch(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_code_req writes request.md BEFORE dispatching."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_code_req",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "context": "Need to understand auth flow",
+                    "questions": ["How does OAuth work?", "What about JWT?"],
+                    "scope_hints": ["src/auth/", "src/middleware/"],
+                }
+            },
+        )
+
+        with (
+            patch("agentmux.workflow.prompts.write_prompt_file") as mock_write,
+            patch(
+                "agentmux.workflow.prompts.build_code_researcher_prompt"
+            ) as mock_build,
+        ):
+            mock_write.return_value = Path("/mock/prompt.md")
+            mock_build.return_value = "research prompt"
+
+            updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+            # Verify request.md was written
+            req_path = mock_ctx.files.research_dir / "code-auth" / "request.md"
+            assert req_path.exists()
+            content = req_path.read_text(encoding="utf-8")
+            assert "auth" in content
+            assert "OAuth" in content
+            assert "JWT" in content
+            assert "src/auth/" in content
+
+            # Verify dispatch happened after write
+            mock_ctx.runtime.spawn_task.assert_called_once_with(
+                "code-researcher", "auth", mock_ctx.files.research_dir / "code-auth"
+            )
+            assert "research_tasks" in updates
+            assert updates["research_tasks"]["auth"] == "dispatched"
+            assert next_phase is None
+
+    def test_handle_research_code_req_idempotent(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_code_req is idempotent — does not overwrite existing request.md."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_code_req",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "context": "original context",
+                    "questions": ["original question"],
+                }
+            },
+        )
+
+        # Pre-create request.md
+        req_dir = mock_ctx.files.research_dir / "code-auth"
+        req_dir.mkdir(parents=True, exist_ok=True)
+        req_path = req_dir / "request.md"
+        req_path.write_text("original content", encoding="utf-8")
+
+        with (
+            patch("agentmux.workflow.prompts.write_prompt_file"),
+            patch("agentmux.workflow.prompts.build_code_researcher_prompt"),
+        ):
+            handler.handle_event(event, empty_state, mock_ctx)
+
+            # Content should be unchanged
+            assert req_path.read_text(encoding="utf-8") == "original content"
+
+    def test_handle_research_web_req_writes_request_then_dispatch(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_web_req writes request.md BEFORE dispatching."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_web_req",
+            payload={
+                "payload": {
+                    "topic": "api",
+                    "context": "Need to find best API practices",
+                    "questions": ["What is the latest REST API standard?"],
+                }
+            },
+        )
+
+        with (
+            patch("agentmux.workflow.prompts.write_prompt_file"),
+            patch("agentmux.workflow.prompts.build_web_researcher_prompt"),
+        ):
+            updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+            req_path = mock_ctx.files.research_dir / "web-api" / "request.md"
+            assert req_path.exists()
+            content = req_path.read_text(encoding="utf-8")
+            assert "api" in content
+            assert "REST API" in content
+
+            mock_ctx.runtime.spawn_task.assert_called_once_with(
+                "web-researcher", "api", mock_ctx.files.research_dir / "web-api"
+            )
+            assert "web_research_tasks" in updates
+            assert next_phase is None
+
+    def test_handle_research_done_code(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_done for code type notifies product-manager."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_done",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "role_type": "code",
+                }
+            },
+        )
+
+        state = {"research_tasks": {"auth": "dispatched"}}
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
+
+        mock_ctx.runtime.finish_task.assert_called_once_with("code-researcher", "auth")
+        mock_ctx.runtime.notify.assert_called_once()
+        assert updates["research_tasks"]["auth"] == "done"
+        assert next_phase is None
+
+    def test_handle_research_done_web(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_done for web type notifies product-manager."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_done",
+            payload={
+                "payload": {
+                    "topic": "api",
+                    "role_type": "web",
+                }
+            },
+        )
+
+        state = {"web_research_tasks": {"api": "dispatched"}}
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
+
+        mock_ctx.runtime.finish_task.assert_called_once_with("web-researcher", "api")
+        mock_ctx.runtime.notify.assert_called_once()
+        assert updates["web_research_tasks"]["api"] == "done"
+        assert next_phase is None
+
+    def test_handle_research_done_missing_fields(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_done with missing topic/role_type returns empty."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_done",
+            payload={"payload": {"topic": ""}},
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        assert updates == {}
+        assert next_phase is None
+
+    def test_handle_research_code_req_missing_topic(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_code_req with missing topic returns empty."""
+        handler = ProductManagementHandler()
+        event = WorkflowEvent(
+            kind="research_code_req",
+            payload={"payload": {"context": "no topic"}},
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        assert updates == {}
+        assert next_phase is None
+
+
+# ---------------------------------------------------------------------------
+# ArchitectingHandler tool-event tests
+# ---------------------------------------------------------------------------
+
+
+class TestArchitectingHandlerToolEvents:
+    """Tests for ArchitectingHandler tool-event migration."""
+
+    def test_get_tool_specs_returns_correct_specs(self) -> None:
+        """get_tool_specs() returns architecture, research, and done specs."""
+        handler = ArchitectingHandler()
+        specs = handler.get_tool_specs()
+        spec_names = [s.name for s in specs]
+        assert "architecture" in spec_names
+        assert "research_code_req" in spec_names
+        assert "research_web_req" in spec_names
+        assert "research_done" in spec_names
+
+        arch_spec = next(s for s in specs if s.name == "architecture")
+        assert arch_spec.tool_names == ("submit_architecture",)
+
+    def test_get_event_specs_is_empty(self) -> None:
+        """get_event_specs() returns empty sequence."""
+        handler = ArchitectingHandler()
+        assert len(handler.get_event_specs()) == 0
+
+    def test_handle_architecture_writes_artifacts(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """architecture event writes architecture.yaml and architecture.md."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="architecture",
+            payload={
+                "payload": {
+                    "solution_overview": "A microservices architecture",
+                    "components": [
+                        {
+                            "name": "API Gateway",
+                            "responsibility": "Route requests",
+                            "interfaces": ["REST"],
+                        }
+                    ],
+                    "interfaces_and_contracts": "REST APIs between services",
+                    "data_models": "User, Session, Token",
+                    "cross_cutting_concerns": "Logging, monitoring",
+                    "technology_choices": "Python, FastAPI, PostgreSQL",
+                    "risks_and_mitigations": "Rate limiting needed",
+                }
+            },
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        # Verify artifacts were written
+        yaml_path = mock_ctx.files.planning_dir / "architecture.yaml"
+        md_path = mock_ctx.files.planning_dir / "architecture.md"
+        assert yaml_path.exists()
+        assert md_path.exists()
+
+        # Verify state transition
+        assert next_phase == "planning"
+        assert "last_event" in updates
+
+    def test_handle_architecture_idempotent(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """architecture event is idempotent — doesn't overwrite existing files."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="architecture",
+            payload={
+                "payload": {
+                    "solution_overview": "A microservices architecture",
+                    "components": [
+                        {
+                            "name": "API Gateway",
+                            "responsibility": "Route requests",
+                            "interfaces": ["REST"],
+                        }
+                    ],
+                    "interfaces_and_contracts": "REST APIs between services",
+                    "data_models": "User, Session, Token",
+                    "cross_cutting_concerns": "Logging, monitoring",
+                    "technology_choices": "Python, FastAPI, PostgreSQL",
+                    "risks_and_mitigations": "Rate limiting needed",
+                }
+            },
+        )
+
+        # Pre-create architecture files
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = mock_ctx.files.planning_dir / "architecture.yaml"
+        yaml_path.write_text("original: content", encoding="utf-8")
+
+        # Should not raise
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        # Content should be unchanged
+        assert yaml_path.read_text(encoding="utf-8") == "original: content"
+
+    def test_handle_architecture_applies_preferences_and_kills_architect(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """architecture event applies preferences and kills architect."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="architecture",
+            payload={
+                "payload": {
+                    "solution_overview": "A simple architecture",
+                    "components": [
+                        {"name": "App", "responsibility": "Main app", "interfaces": []}
+                    ],
+                    "interfaces_and_contracts": "None",
+                    "data_models": "None",
+                    "cross_cutting_concerns": "None",
+                    "technology_choices": "Python",
+                    "risks_and_mitigations": "None",
+                }
+            },
+        )
+
+        with patch(
+            "agentmux.workflow.handlers.architecting.apply_role_preferences"
+        ) as mock_apply:
+            handler.handle_event(event, empty_state, mock_ctx)
+
+            mock_apply.assert_called_once_with(mock_ctx, "architect")
+            mock_ctx.runtime.deactivate.assert_called_once_with("architect")
+            mock_ctx.runtime.kill_primary.assert_called_once_with("architect")
+
+    def test_handle_architecture_deletes_changes_md(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """architecture event deletes changes.md if it exists."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="architecture",
+            payload={
+                "payload": {
+                    "solution_overview": "A simple architecture",
+                    "components": [
+                        {"name": "App", "responsibility": "Main app", "interfaces": []}
+                    ],
+                    "interfaces_and_contracts": "None",
+                    "data_models": "None",
+                    "cross_cutting_concerns": "None",
+                    "technology_choices": "Python",
+                    "risks_and_mitigations": "None",
+                }
+            },
+        )
+
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        mock_ctx.files.changes.write_text("changes", encoding="utf-8")
+
+        handler.handle_event(event, empty_state, mock_ctx)
+
+        assert not mock_ctx.files.changes.exists()
+
+    def test_handle_research_code_req_writes_request_then_dispatch(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_code_req writes request.md BEFORE dispatching."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="research_code_req",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "context": "Auth context",
+                    "questions": ["How does OAuth work?"],
+                }
+            },
+        )
+
+        with (
+            patch("agentmux.workflow.prompts.write_prompt_file"),
+            patch("agentmux.workflow.prompts.build_code_researcher_prompt"),
+        ):
+            updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+            req_path = mock_ctx.files.research_dir / "code-auth" / "request.md"
+            assert req_path.exists()
+            mock_ctx.runtime.spawn_task.assert_called_once_with(
+                "code-researcher", "auth", mock_ctx.files.research_dir / "code-auth"
+            )
+            assert "research_tasks" in updates
+            assert next_phase is None
+
+    def test_handle_research_web_req_writes_request_then_dispatch(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_web_req writes request.md BEFORE dispatching."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="research_web_req",
+            payload={
+                "payload": {
+                    "topic": "api",
+                    "context": "API context",
+                    "questions": ["What is REST?"],
+                }
+            },
+        )
+
+        with (
+            patch("agentmux.workflow.prompts.write_prompt_file"),
+            patch("agentmux.workflow.prompts.build_web_researcher_prompt"),
+        ):
+            updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+            req_path = mock_ctx.files.research_dir / "web-api" / "request.md"
+            assert req_path.exists()
+            mock_ctx.runtime.spawn_task.assert_called_once_with(
+                "web-researcher", "api", mock_ctx.files.research_dir / "web-api"
+            )
+            assert "web_research_tasks" in updates
+            assert next_phase is None
+
+    def test_handle_research_done_code(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_done for code type notifies architect."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="research_done",
+            payload={
+                "payload": {
+                    "topic": "auth",
+                    "role_type": "code",
+                }
+            },
+        )
+
+        state = {"research_tasks": {"auth": "dispatched"}}
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
+
+        mock_ctx.runtime.finish_task.assert_called_once_with("code-researcher", "auth")
+        mock_ctx.runtime.notify.assert_called_once()
+        assert updates["research_tasks"]["auth"] == "done"
+        assert next_phase is None
+
+    def test_handle_research_done_web(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """research_done for web type notifies architect."""
+        handler = ArchitectingHandler()
+        event = WorkflowEvent(
+            kind="research_done",
+            payload={
+                "payload": {
+                    "topic": "api",
+                    "role_type": "web",
+                }
+            },
+        )
+
+        state = {"web_research_tasks": {"api": "dispatched"}}
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
+
+        mock_ctx.runtime.finish_task.assert_called_once_with("web-researcher", "api")
+        mock_ctx.runtime.notify.assert_called_once()
+        assert updates["web_research_tasks"]["api"] == "done"
+        assert next_phase is None
+
+
+# ---------------------------------------------------------------------------
+# PlanningHandler tool-event tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningHandlerToolEvents:
+    """Tests for PlanningHandler tool-event migration."""
+
+    def test_get_tool_specs_returns_correct_specs(self) -> None:
+        """get_tool_specs() returns execution_plan and subplan specs."""
+        handler = PlanningHandler()
+        specs = handler.get_tool_specs()
+        spec_names = [s.name for s in specs]
+        assert "execution_plan" in spec_names
+        assert "subplan" in spec_names
+
+        ep_spec = next(s for s in specs if s.name == "execution_plan")
+        assert ep_spec.tool_names == ("submit_execution_plan",)
+
+        sp_spec = next(s for s in specs if s.name == "subplan")
+        assert sp_spec.tool_names == ("submit_subplan",)
+
+    def test_get_event_specs_is_empty(self) -> None:
+        """get_event_specs() returns empty sequence."""
+        handler = PlanningHandler()
+        assert len(handler.get_event_specs()) == 0
+
+    def test_handle_execution_plan_writes_artifacts(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """execution_plan event writes execution_plan.yaml and plan.md."""
+        handler = PlanningHandler()
+        event = WorkflowEvent(
+            kind="execution_plan",
+            payload={
+                "payload": {
+                    "plan_overview": "Build in 3 phases",
+                    "groups": [
+                        {
+                            "group_id": "g1",
+                            "mode": "serial",
+                            "plans": [
+                                {
+                                    "file": "plan_1.md",
+                                    "name": "Setup",
+                                }
+                            ],
+                        }
+                    ],
+                    "review_strategy": {"severity": "medium", "focus": []},
+                    "needs_design": False,
+                    "needs_docs": False,
+                    "doc_files": [],
+                }
+            },
+        )
+
+        # load_execution_plan requires referenced plan files to exist
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        yaml_path = mock_ctx.files.planning_dir / "execution_plan.yaml"
+        md_path = mock_ctx.files.planning_dir / "plan.md"
+        assert yaml_path.exists()
+        assert md_path.exists()
+
+    def test_handle_execution_plan_idempotent(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """execution_plan event is idempotent."""
+        handler = PlanningHandler()
+        event = WorkflowEvent(
+            kind="execution_plan",
+            payload={
+                "payload": {
+                    "plan_overview": "Build in 3 phases",
+                    "groups": [
+                        {
+                            "group_id": "g1",
+                            "mode": "serial",
+                            "plans": [{"file": "plan_1.md", "name": "Setup"}],
+                        }
+                    ],
+                    "review_strategy": {"severity": "medium", "focus": []},
+                    "needs_design": False,
+                    "needs_docs": False,
+                    "doc_files": [],
+                }
+            },
+        )
+
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = mock_ctx.files.planning_dir / "execution_plan.yaml"
+        yaml_path.write_text("original: content", encoding="utf-8")
+
+        handler.handle_event(event, empty_state, mock_ctx)
+        assert yaml_path.read_text(encoding="utf-8") == "original: content"
+
+    def test_handle_subplan_writes_artifacts(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """subplan event writes plan_N.yaml, plan_N.md, tasks_N.md."""
+        handler = PlanningHandler()
+        event = WorkflowEvent(
+            kind="subplan",
+            payload={
+                "payload": {
+                    "index": 1,
+                    "title": "Setup Infrastructure",
+                    "scope": "Set up CI/CD and infra",
+                    "owned_files": ["src/infra/main.tf"],
+                    "dependencies": "None",
+                    "implementation_approach": "Use Terraform",
+                    "acceptance_criteria": "Infra is provisioned",
+                    "tasks": ["Write terraform config", "Apply changes"],
+                    "isolation_rationale": "",
+                }
+            },
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        yaml_path = mock_ctx.files.planning_dir / "plan_1.yaml"
+        md_path = mock_ctx.files.planning_dir / "plan_1.md"
+        tasks_path = mock_ctx.files.planning_dir / "tasks_1.md"
+        assert yaml_path.exists()
+        assert md_path.exists()
+        assert tasks_path.exists()
+
+    def test_handle_subplan_idempotent(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """subplan event is idempotent."""
+        handler = PlanningHandler()
+        event = WorkflowEvent(
+            kind="subplan",
+            payload={
+                "payload": {
+                    "index": 1,
+                    "title": "Setup",
+                    "scope": "Setup scope",
+                    "owned_files": [],
+                    "dependencies": "None",
+                    "implementation_approach": "Approach",
+                    "acceptance_criteria": "Criteria",
+                    "tasks": ["Task 1"],
+                    "isolation_rationale": "",
+                }
+            },
+        )
+
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = mock_ctx.files.planning_dir / "plan_1.yaml"
+        yaml_path.write_text("original: content", encoding="utf-8")
+
+        handler.handle_event(event, empty_state, mock_ctx)
+        assert yaml_path.read_text(encoding="utf-8") == "original: content"
+
+
+# ---------------------------------------------------------------------------
+# ImplementingHandler tool-event tests
+# ---------------------------------------------------------------------------
+
+
+class TestImplementingHandlerToolEvents:
+    """Tests for ImplementingHandler tool-event migration."""
+
+    def test_get_tool_specs_returns_done_spec(self) -> None:
+        """get_tool_specs() returns done ToolSpec."""
+        handler = ImplementingHandler()
+        specs = handler.get_tool_specs()
+        spec_names = [s.name for s in specs]
+        assert "done" in spec_names
+
+        done_spec = next(s for s in specs if s.name == "done")
+        assert done_spec.tool_names == ("submit_done",)
+
+    def test_get_event_specs_is_empty(self) -> None:
+        """get_event_specs() returns empty sequence."""
+        handler = ImplementingHandler()
+        assert len(handler.get_event_specs()) == 0
+
+    def test_handle_done_writes_done_marker_and_transitions(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """done event writes done_N marker and transitions correctly."""
+        handler = ImplementingHandler()
+        event = WorkflowEvent(
+            kind="done",
+            payload={
+                "payload": {
+                    "subplan_index": 1,
+                }
+            },
+        )
+
+        # Setup state for single subplan
+        state = {
+            "implementation_group_index": 1,
+            "implementation_group_mode": "serial",
+            "implementation_active_plan_ids": ["plan_1"],
+        }
+
+        # Create execution plan
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        import yaml
+
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
+                {
+                    "version": 1,
+                    "groups": [
+                        {
+                            "group_id": "group1",
+                            "mode": "serial",
+                            "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                        }
+                    ],
+                },
+                default_flow_style=False,
+            )
+        )
+        (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
+
+        # Verify done_N marker was written
+        done_n_path = mock_ctx.files.implementation_dir / "done_1"
+        assert done_n_path.exists()
+
+        mock_ctx.runtime.hide_task.assert_called_once_with("coder", 1)
+        mock_ctx.runtime.finish_many.assert_called_once_with("coder")
+        mock_ctx.runtime.deactivate.assert_called_once_with("coder")
+        assert next_phase == "reviewing"
+
+    def test_handle_done_idempotent(self, mock_ctx: MagicMock) -> None:
+        """done event is idempotent — doesn't overwrite existing done_N marker."""
+        handler = ImplementingHandler()
+        event = WorkflowEvent(
+            kind="done",
+            payload={
+                "payload": {
+                    "subplan_index": 1,
+                }
+            },
+        )
+
+        state = {
+            "implementation_group_index": 1,
+            "implementation_group_mode": "serial",
+            "implementation_active_plan_ids": ["plan_1"],
+        }
+
+        import yaml
+
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(
+                {
+                    "version": 1,
+                    "groups": [
+                        {
+                            "group_id": "group1",
+                            "mode": "serial",
+                            "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                        }
+                    ],
+                },
+                default_flow_style=False,
+            )
+        )
+        (mock_ctx.files.planning_dir / "plan_1.md").write_text("plan 1")
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pre-create done_1 marker
+        done_path = mock_ctx.files.implementation_dir / "done_1"
+        done_path.touch()
+
+        handler.handle_event(event, state, mock_ctx)
+        assert done_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# ReviewingHandler tool-event tests
+# ---------------------------------------------------------------------------
+
+
+class TestReviewingHandlerToolEvents:
+    """Tests for ReviewingHandler tool-event migration."""
+
+    def test_get_tool_specs_returns_review_spec(self) -> None:
+        """get_tool_specs() returns review ToolSpec."""
+        handler = ReviewingHandler()
+        specs = handler.get_tool_specs()
+        spec_names = [s.name for s in specs]
+        assert "review" in spec_names
+
+        review_spec = next(s for s in specs if s.name == "review")
+        assert review_spec.tool_names == ("submit_review",)
+
+    def test_get_event_specs_keeps_summary_ready(self) -> None:
+        """get_event_specs() keeps summary_ready EventSpec."""
+        handler = ReviewingHandler()
+        specs = handler.get_event_specs()
+        spec_names = [s.name for s in specs]
+        assert "summary_ready" in spec_names
+        # review_ready should be removed (replaced by ToolSpec)
+        assert "review_ready" not in spec_names
+
+    def test_handle_review_verdict_pass(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """review event with verdict:pass writes review.yaml and requests summary."""
+        from agentmux.workflow.event_catalog import EVENT_REVIEW_PASSED
+
+        handler = ReviewingHandler()
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "pass",
+                    "summary": "Looks good!",
+                    "findings": [],
+                    "commit_message": "feat: implement feature",
+                }
+            },
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        yaml_path = mock_ctx.files.review_dir / "review.yaml"
+        md_path = mock_ctx.files.review_dir / "review.md"
+        assert yaml_path.exists()
+        assert md_path.exists()
+
+        mock_ctx.runtime.finish_many.assert_called_once_with("coder")
+        mock_ctx.runtime.kill_primary.assert_called_once_with("coder")
+        assert updates.get("awaiting_summary") is True
+        assert updates.get("last_event") == EVENT_REVIEW_PASSED
+        assert next_phase is None
+
+    def test_handle_review_verdict_fail_under_max(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """review event with verdict:fail transitions to fixing."""
+        from agentmux.workflow.event_catalog import EVENT_REVIEW_FAILED
+
+        handler = ReviewingHandler()
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "fail",
+                    "summary": "Needs fixes",
+                    "findings": [
+                        {
+                            "location": "src/example.py:10",
+                            "issue": "Missing validation",
+                            "severity": "high",
+                            "recommendation": "Add check",
+                        }
+                    ],
+                    "commit_message": "",
+                }
+            },
+        )
+
+        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+
+        yaml_path = mock_ctx.files.review_dir / "review.yaml"
+        md_path = mock_ctx.files.review_dir / "review.md"
+        assert yaml_path.exists()
+        assert md_path.exists()
+        assert mock_ctx.files.fix_request.exists()
+
+        assert updates["review_iteration"] == 1
+        assert updates["last_event"] == EVENT_REVIEW_FAILED
+        assert next_phase == "fixing"
+
+    def test_handle_review_verdict_fail_at_max(self, mock_ctx: MagicMock) -> None:
+        """verdict:fail at max iterations transitions to completing."""
+        from agentmux.workflow.event_catalog import EVENT_REVIEW_FAILED
+
+        handler = ReviewingHandler()
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "fail",
+                    "summary": "Still failing",
+                    "findings": [
+                        {
+                            "location": "src/example.py:10",
+                            "issue": "Persistent issue",
+                            "severity": "high",
+                            "recommendation": "Fix it",
+                        }
+                    ],
+                    "commit_message": "",
+                }
+            },
+        )
+
+        state = {"review_iteration": 3}
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
+
+        assert next_phase == "completing"
+        assert updates["last_event"] == EVENT_REVIEW_FAILED
+
+    def test_handle_review_idempotent(
+        self, mock_ctx: MagicMock, empty_state: dict
+    ) -> None:
+        """review event is idempotent."""
+        handler = ReviewingHandler()
+        event = WorkflowEvent(
+            kind="review",
+            payload={
+                "payload": {
+                    "verdict": "pass",
+                    "summary": "Looks good!",
+                    "findings": [],
+                    "commit_message": "",
+                }
+            },
+        )
+
+        mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = mock_ctx.files.review_dir / "review.yaml"
+        yaml_path.write_text("original: content", encoding="utf-8")
+        md_path = mock_ctx.files.review_dir / "review.md"
+        md_path.write_text("# Review\n\nLooks good!", encoding="utf-8")
+
+        handler.handle_event(event, empty_state, mock_ctx)
+        assert yaml_path.read_text(encoding="utf-8") == "original: content"

--- a/tests/workflow/test_event_router.py
+++ b/tests/workflow/test_event_router.py
@@ -89,6 +89,10 @@ class MockHandler:
         """Return empty specs — use legacy raw-event path for these tests."""
         return ()
 
+    def get_tool_specs(self):
+        """Return empty tool specs — tool events return empty for these tests."""
+        return ()
+
     def handle_event(
         self, event: WorkflowEvent, state: dict, ctx: PipelineContext
     ) -> tuple[dict, str | None]:
@@ -790,3 +794,221 @@ class TestEventSpecRouting:
 
         assert len(received) == 1
         assert received[0].kind == "done_marker"
+
+
+class TestToolSpecRouting:
+    """Test ToolSpec-based tool.* event routing in the router."""
+
+    def _make_ctx(self, tmp_path):
+        """Build a minimal mock context with a real feature_dir."""
+        files = MagicMock(spec=RuntimeFiles)
+        files.feature_dir = tmp_path
+        files.state = tmp_path / "state.json"
+        runtime = MagicMock()
+        agents = {"coder": MagicMock(spec=AgentConfig)}
+        return PipelineContext(
+            files=files,
+            runtime=runtime,
+            agents=agents,
+            max_review_iterations=3,
+            prompts={},
+            github_config=GitHubConfig(),
+            workflow_settings=WorkflowSettings(),
+        )
+
+    def test_tool_event_matching_spec_dispatches_logical_event(self, tmp_path):
+        """tool.* event matching a ToolSpec dispatches WorkflowEvent(kind=spec.name)."""
+        from agentmux.workflow.event_router import ToolSpec
+
+        received = []
+
+        class ToolSpecHandler:
+            def enter(self, state, ctx):
+                return {}
+
+            def get_event_specs(self):
+                return ()
+
+            def get_tool_specs(self):
+                return (
+                    ToolSpec(
+                        name="architecture_submitted",
+                        tool_names=("submit_architecture",),
+                    ),
+                )
+
+            def handle_event(self, event, state, ctx):
+                received.append(event)
+                return {}, None
+
+        router = WorkflowEventRouter({"architecting": ToolSpecHandler()})
+        ctx = self._make_ctx(tmp_path)
+        state = {"phase": "architecting"}
+
+        event = WorkflowEvent(
+            kind="tool.submit_architecture",
+            payload={"status": "ok"},
+        )
+        with patch("agentmux.sessions.state_store.write_state"):
+            router.handle(event, state, ctx)
+
+        assert len(received) == 1
+        assert received[0].kind == "architecture_submitted"
+        assert received[0].payload == {"status": "ok"}
+
+    def test_tool_event_non_matching_returns_empty(self, tmp_path):
+        """Non-matching tool name returns ({}, None)."""
+        from agentmux.workflow.event_router import ToolSpec
+
+        received = []
+
+        class ToolSpecHandler:
+            def enter(self, state, ctx):
+                return {}
+
+            def get_event_specs(self):
+                return ()
+
+            def get_tool_specs(self):
+                return (
+                    ToolSpec(
+                        name="plan_submitted",
+                        tool_names=("submit_plan",),
+                    ),
+                )
+
+            def handle_event(self, event, state, ctx):
+                received.append(event)
+                return {}, None
+
+        router = WorkflowEventRouter({"planning": ToolSpecHandler()})
+        ctx = self._make_ctx(tmp_path)
+        state = {"phase": "planning"}
+
+        event = WorkflowEvent(
+            kind="tool.submit_architecture",
+            payload={"status": "ok"},
+        )
+        with patch("agentmux.sessions.state_store.write_state"):
+            updates, next_phase = router.handle(event, state, ctx)
+
+        assert updates == {}
+        assert next_phase is None
+        assert received == []
+
+    def test_backward_compat_file_events_still_route_via_eventspec(self, tmp_path):
+        """file.created events still route via EventSpec when handler has both specs."""
+        from agentmux.workflow.event_router import EventSpec, ToolSpec
+
+        file_received = []
+        tool_received = []
+
+        class DualSpecHandler:
+            def enter(self, state, ctx):
+                return {}
+
+            def get_event_specs(self):
+                return (
+                    EventSpec(
+                        name="plan_written",
+                        watch_paths=("02_planning/plan.md",),
+                        is_ready=lambda p, c, s: True,
+                    ),
+                )
+
+            def get_tool_specs(self):
+                return (
+                    ToolSpec(
+                        name="plan_submitted",
+                        tool_names=("submit_plan",),
+                    ),
+                )
+
+            def handle_event(self, event, state, ctx):
+                if event.kind.startswith("tool."):
+                    tool_received.append(event)
+                else:
+                    file_received.append(event)
+                return {}, None
+
+        router = WorkflowEventRouter({"planning": DualSpecHandler()})
+        ctx = self._make_ctx(tmp_path)
+        state = {"phase": "planning"}
+
+        # File event should still route via EventSpec
+        file_event = WorkflowEvent(kind="file.created", path="02_planning/plan.md")
+        with patch("agentmux.sessions.state_store.write_state"):
+            router.handle(file_event, state, ctx)
+
+        assert len(file_received) == 1
+        assert file_received[0].kind == "plan_written"
+        assert file_received[0].path == "02_planning/plan.md"
+        assert tool_received == []
+
+    def test_tool_event_with_multiple_tool_names_in_spec(self, tmp_path):
+        """A single ToolSpec can match multiple bare tool names."""
+        from agentmux.workflow.event_router import ToolSpec
+
+        received = []
+
+        class ToolSpecHandler:
+            def enter(self, state, ctx):
+                return {}
+
+            def get_event_specs(self):
+                return ()
+
+            def get_tool_specs(self):
+                return (
+                    ToolSpec(
+                        name="any_submission",
+                        tool_names=(
+                            "submit_architecture",
+                            "submit_plan",
+                            "submit_review",
+                        ),
+                    ),
+                )
+
+            def handle_event(self, event, state, ctx):
+                received.append(event)
+                return {}, None
+
+        router = WorkflowEventRouter({"architecting": ToolSpecHandler()})
+        ctx = self._make_ctx(tmp_path)
+        state = {"phase": "architecting"}
+
+        for tool_name in ("submit_architecture", "submit_plan", "submit_review"):
+            event = WorkflowEvent(kind=f"tool.{tool_name}", payload={"tool": tool_name})
+            with patch("agentmux.sessions.state_store.write_state"):
+                router.handle(event, state, ctx)
+
+        assert len(received) == 3
+        assert all(r.kind == "any_submission" for r in received)
+
+    def test_handler_without_get_tool_specs_ignores_tool_events(self, tmp_path):
+        """Handler without get_tool_specs returns empty for tool.* events."""
+        received = []
+
+        class NoToolSpecHandler:
+            def enter(self, state, ctx):
+                return {}
+
+            def get_event_specs(self):
+                return ()
+
+            def handle_event(self, event, state, ctx):
+                received.append(event)
+                return {}, None
+
+        router = WorkflowEventRouter({"architecting": NoToolSpecHandler()})
+        ctx = self._make_ctx(tmp_path)
+        state = {"phase": "architecting"}
+
+        event = WorkflowEvent(kind="tool.submit_architecture", payload={})
+        with patch("agentmux.sessions.state_store.write_state"):
+            updates, next_phase = router.handle(event, state, ctx)
+
+        assert updates == {}
+        assert next_phase is None
+        assert received == []


### PR DESCRIPTION
## Initial Request

# Refactoring - Should be

Diese Aspekte sollten von der Implementierung umgesetzt worden sein

- Toolcall als eigenes event (statt file events), auf das der Orchestrator hört
- Orchestrator schreibt md Dateien (wie vorher) in das session verzeichnis
- Die Dateien die vom entsprechenden Agent zwingend benötigt werden, werden (wie vorher) direkt in das Prompt eingebettet
- MCP Tools haben eine saubere Abstraktion (MCP Tool), die von konkretem provider implementiert wird (copilot mcp aktivierung sieht anders aus als bei gemini zb)
- Wir müssen eine hybride Lösung wählen: Agents schreiben die Dateien, Tool Call gibt signal dass der agent fertig ist und welche Dateien er geschrieben hat + Metadaten (z.b. ausführungsplan)
- wenn wir schon einen agentmux namespace für die tools haben brauchen wir keinen 'agentmux_'
- Alle "done-signale" müssen über ein entsprechendes Tool laufen

Outlined Plan: 

│ Refactoring Plan: Handoff Contracts — Should-Be Architecture                                                                        │
│                                                                                                                                     │
│ Approach: Implement the hybrid model where agents write files themselves AND call MCP tools to signal completion. Tool calls become │
│ first-class tool.* events — not file events.                                                                                        │
│                                                                                                                                     │
│ 4 Steps (largely sequential, Step 4 independent):                                                                                   │
│                                                                                                                                     │
│ Step 1 — Tool Call Event Channel (infrastructure only)                                                                              │
│                                                                                                                                     │
│  - Add tool_events.jsonl append-only log to session dir                                                                             │
│  - New ToolCallEventSource (watchdog-backed) emitting tool.<name> events                                                            │
│  - Wire into EventBus + WorkflowEventRouter                                                                                         │
│  - MCP tools append to this log instead of relying on file detection                                                                │
│                                                                                                                                     │
│ Step 2 — Migrate Handlers to Tool Events + Move File Writing                                                                        │
│                                                                                                                                     │
│  - ArchitectingHandler, PlanningHandler, ReviewingHandler: replace file EventSpecs with tool call events (tool.submit_architecture  │
│ etc.)                                                                                                                               │
│  - Move file-writing (architecture.md, plan.md, review.md) from MCP tools → orchestrator handlers                                   │
│  - MCP tools become pure: validate → append to event log → return confirmation                                                      │
│                                                                                                                                     │
│ Step 3 — Coder/Researcher Done Tools + Rename                                                                                       │
│                                                                                                                                     │
│  - New submit_done(subplan_index) tool for coders                                                                                   │
│  - New submit_research_done(topic, type) tool for researchers                                                                       │
│  - Add coder/researcher roles to MCP access (DEFAULT_RESEARCH_ROLES)                                                                │
│  - Remove redundant agentmux_ prefix from all tool names                                                                            │
│  - Update all prompt templates                                                                                                      │
│                                                                                                                                     │
│ Step 4 — Copilot MCP Configurator (independent, can run parallel with 2-3)                                                          │
│                                                                                                                                     │
│  - Add CopilotConfigurator to integrations/mcp/configurators.py                                                                     │
│  - Wire into CONFIGURATORS dict so init + ensure_mcp_config auto-covers Copilot

## Plan Summary

Overview

Replace all file-system completion signals with MCP tool-call events. Agents call
MCP tools that append JSON entries to a new `tool_events.jsonl` log; a new
`ToolCallEventSource` tails the log and emits `tool.*` events into the `EventBus`.
Phase handlers declare `ToolSpec`s (parallel to `EventSpec`s) to respond to these
events, writing YAML/marker artifacts as orchestrator side-effects rather than as
preconditions for detecting them.

All MCP tools become pure: validate → append to log → return confirmation. The
dispatch tools (`research_dispatch_code`, `research_dispatch_web`) also become pure;
the orchestrator handler writes `request.md` and spawns the researcher as a
side-effect of the dispatch tool event.

## Review Verdict

verdict: pass
