### PR TITLE
feat(resume): persist single_coder mode for interrupted implementations

### DIFF
--- a/docs/session-resumption.md
+++ b/docs/session-resumption.md
@@ -30,5 +30,6 @@ agentmux resume <feature-dir-or-name>  # Resume specific session by name or path
 12. The background orchestrator explicitly re-enters the current phase before starting file/interruption sources, so resume prompt dispatch is deterministic and no longer depends on the first seeded file event
 13. `runtime_state.json` is treated as advisory recovery data for panes/PIDs, while `tool_event_state.json` persists the last applied `tool_events.jsonl` cursor so resume replays only unapplied tool signals
 14. `implementing` and `fixing` explicitly clear the primary `coder` pane before dispatch so resume never reuses an old shell after the prior coder CLI has exited
-15. After the resumed phase is entered and unapplied tool events are replayed, any still-dispatched research subtasks are restarted from their persisted `03_research/<type>-<topic>/prompt.md` directories
-16. If the prior run failed because a registered tmux agent pane disappeared, the interruption metadata in `state.json` is cleared on resume and a fresh pane is created only when the resumed phase next needs that role
+15. `implementation_single_coder` is persisted on entering the implementing phase; on resume, the handler restores this setting so the same dispatch mode (whole-plan vs per-group) is used regardless of current agent configuration
+16. After the resumed phase is entered and unapplied tool events are replayed, any still-dispatched research subtasks are restarted from their persisted `03_research/<type>-<topic>/prompt.md` directories
+17. If the prior run failed because a registered tmux agent pane disappeared, the interruption metadata in `state.json` is cleared on resume and a fresh pane is created only when the resumed phase next needs that role

--- a/src/agentmux/sessions/state_store.py
+++ b/src/agentmux/sessions/state_store.py
@@ -187,6 +187,7 @@ def create_feature_files(
         "implementation_group_total": 0,
         "implementation_group_index": 0,
         "implementation_group_mode": None,
+        "implementation_single_coder": False,
         "implementation_active_plan_ids": [],
         "implementation_completed_group_ids": [],
         "updated_at": now_iso(),

--- a/src/agentmux/workflow/handlers/implementing.py
+++ b/src/agentmux/workflow/handlers/implementing.py
@@ -115,6 +115,8 @@ def _set_implementation_progress(
     state: dict,
     schedule: list[dict[str, object]],
     active_group_index: int | None,
+    *,
+    single_coder: bool,
 ) -> None:
     """Set implementation progress in state."""
     group_total = len(schedule)
@@ -136,6 +138,7 @@ def _set_implementation_progress(
         ]
         return
 
+    state["implementation_single_coder"] = single_coder
     state["implementation_group_index"] = active_group_index + 1
     state["implementation_group_mode"] = str(schedule[active_group_index]["mode"])
     state["implementation_active_plan_ids"] = list(
@@ -163,26 +166,62 @@ class ImplementingHandler(BaseToolHandler):
 
         Resets markers and dispatches first group (or whole plan in single-coder mode).
         """
-        if state.get("last_event") in {
+        is_fresh_start = state.get("last_event") in {
             EVENT_PLAN_WRITTEN,
             EVENT_DESIGN_WRITTEN,
             EVENT_CHANGES_REQUESTED,
-        }:
+        }
+        if is_fresh_start:
             reset_markers(ctx.files.implementation_dir, "done_*")
         ctx.runtime.kill_primary("coder")
 
-        schedule = _build_implementation_schedule(planning_dir=ctx.files.planning_dir)
-        updates: dict[str, object] = {}
-        updates["subplan_count"] = self._total_marker_count(schedule)
-        updates["completed_subplans"] = []
+        coder = ctx.agents.get("coder")
+        if is_fresh_start or "implementation_single_coder" not in state:
+            effective_single_coder = coder is not None and coder.single_coder
+        else:
+            effective_single_coder = bool(state["implementation_single_coder"])
 
+        schedule = _build_implementation_schedule(planning_dir=ctx.files.planning_dir)
         active_group_index = _first_incomplete_group_index(
             ctx.files.implementation_dir, schedule
         )
-        _set_implementation_progress(updates, schedule, active_group_index)
+        active_group_mode = (
+            str(schedule[active_group_index]["mode"])
+            if active_group_index is not None
+            else "none"
+        )
+
+        if is_fresh_start:
+            print(
+                "Starting implementing phase "
+                "(fresh start, "
+                f"group_mode={active_group_mode}, "
+                f"single_coder={effective_single_coder})."
+            )
+        else:
+            mode_source = (
+                "saved state"
+                if "implementation_single_coder" in state
+                else "agent config"
+            )
+            print(
+                "Resuming implementing phase "
+                f"(group_mode={active_group_mode}, "
+                f"single_coder={effective_single_coder}, source={mode_source})."
+            )
+
+        updates: dict[str, object] = {}
+        updates["subplan_count"] = self._total_marker_count(schedule)
+        updates["completed_subplans"] = []
+        _set_implementation_progress(
+            updates,
+            schedule,
+            active_group_index,
+            single_coder=effective_single_coder,
+        )
 
         if active_group_index is not None:
-            if self._is_single_coder(ctx):
+            if effective_single_coder:
                 self._dispatch_whole_plan(ctx, schedule)
             else:
                 self._dispatch_active_group(ctx, schedule, active_group_index)
@@ -225,7 +264,7 @@ class ImplementingHandler(BaseToolHandler):
         updates: dict[str, object] = {"completed_subplans": sorted(completed)}
 
         # Single-coder mode: one pane handles everything — just watch for all markers
-        if self._is_single_coder(ctx):
+        if self._is_single_coder(ctx, state):
             all_marker_indexes = [
                 int(idx) for group in schedule for idx in group["marker_indexes"]
             ]
@@ -257,8 +296,13 @@ class ImplementingHandler(BaseToolHandler):
         if not _all_markers_complete(ctx.files.implementation_dir, active_group):
             # Group not complete - check if there are more pending plans to dispatch
             # This handles serial groups with multiple plans
-            if str(active_group["mode"]) == "serial":
-                self._dispatch_active_group(ctx, schedule, group_index - 1)
+            group_mode = (
+                str(state["implementation_group_mode"])
+                if "implementation_group_mode" in state
+                else str(active_group["mode"])
+            )
+            if group_mode == "serial":
+                self._dispatch_active_group(ctx, schedule, group_index - 1, state=state)
             return updates, None
 
         # Group complete - move to next group or finish
@@ -278,7 +322,12 @@ class ImplementingHandler(BaseToolHandler):
 
         if next_group_index is None:
             # All groups complete
-            _set_implementation_progress(state, schedule, active_group_index=None)
+            _set_implementation_progress(
+                state,
+                schedule,
+                active_group_index=None,
+                single_coder=self._is_single_coder(ctx, state),
+            )
             updates = {
                 "completed_subplans": [],
                 "implementation_group_index": state.get("implementation_group_index"),
@@ -296,7 +345,10 @@ class ImplementingHandler(BaseToolHandler):
 
         # Move to next group
         _set_implementation_progress(
-            state, schedule, active_group_index=next_group_index
+            state,
+            schedule,
+            active_group_index=next_group_index,
+            single_coder=self._is_single_coder(ctx, state),
         )
         updates = {
             "completed_subplans": [],
@@ -309,7 +361,7 @@ class ImplementingHandler(BaseToolHandler):
                 "implementation_completed_group_ids"
             ),
         }
-        self._dispatch_active_group(ctx, schedule, next_group_index)
+        self._dispatch_active_group(ctx, schedule, next_group_index, state=state)
         return updates, None
 
     def _dispatch_active_group(
@@ -317,6 +369,7 @@ class ImplementingHandler(BaseToolHandler):
         ctx: PipelineContext,
         schedule: list[dict[str, object]],
         active_group_index: int,
+        state: dict | None = None,
     ) -> None:
         """Dispatch prompts for the active group."""
         group = schedule[active_group_index]
@@ -365,7 +418,12 @@ class ImplementingHandler(BaseToolHandler):
                 )
             )
 
-        if str(group["mode"]) == "parallel" and len(prompt_specs) > 1:
+        group_mode = (
+            str(state["implementation_group_mode"])
+            if state is not None and "implementation_group_mode" in state
+            else str(group["mode"])
+        )
+        if group_mode == "parallel" and len(prompt_specs) > 1:
             ctx.runtime.send_many("coder", prompt_specs)
         else:
             send_to_role(
@@ -395,8 +453,10 @@ class ImplementingHandler(BaseToolHandler):
         return completed
 
     @staticmethod
-    def _is_single_coder(ctx: PipelineContext) -> bool:
+    def _is_single_coder(ctx: PipelineContext, state: dict | None = None) -> bool:
         """Return True if the coder agent uses single-coder mode (e.g. copilot)."""
+        if state is not None and "implementation_single_coder" in state:
+            return bool(state["implementation_single_coder"])
         coder = ctx.agents.get("coder")
         return coder is not None and coder.single_coder
 

--- a/tests/test_initial_phase_state.py
+++ b/tests/test_initial_phase_state.py
@@ -101,6 +101,28 @@ class TestInitialPhaseState(unittest.TestCase):
             self.assertIn("product_manager", state)
             self.assertFalse(state["product_manager"])
 
+    def test_initial_state_has_implementation_single_coder_false(self) -> None:
+        """Initial state should include implementation_single_coder=False."""
+        with tempfile.TemporaryDirectory() as td:
+            project_dir = Path(td) / "project"
+            feature_dir = Path(td) / "feature"
+            project_dir.mkdir()
+
+            files = create_feature_files(
+                project_dir=project_dir,
+                feature_dir=feature_dir,
+                prompt="Test feature request",
+                session_name="test-session",
+                product_manager=False,
+            )
+
+            import json
+
+            state = json.loads(files.state.read_text(encoding="utf-8"))
+
+            self.assertIn("implementation_single_coder", state)
+            self.assertFalse(state["implementation_single_coder"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -517,6 +517,25 @@ class TestDesigningHandler:
 class TestImplementingHandler:
     """Tests for ImplementingHandler."""
 
+    @staticmethod
+    def _write_execution_plan(
+        mock_ctx: MagicMock, groups: list[dict[str, object]]
+    ) -> None:
+        """Create an execution plan and matching plan files for tests."""
+        mock_ctx.files.planning_dir.mkdir(parents=True, exist_ok=True)
+        (mock_ctx.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump({"groups": groups}, default_flow_style=False)
+        )
+
+        plan_files = {
+            plan["file"]
+            for group in groups
+            for plan in group["plans"]
+            if isinstance(plan, dict) and "file" in plan
+        }
+        for plan_file in plan_files:
+            (mock_ctx.files.planning_dir / str(plan_file)).write_text(str(plan_file))
+
     def test_enter_resets_markers_and_dispatches(self, mock_ctx: MagicMock) -> None:
         """Test that enter() resets markers and dispatches first group."""
         handler = ImplementingHandler()
@@ -760,6 +779,295 @@ class TestImplementingHandler:
             mock_send.assert_called_once()
             call_kwargs = mock_send.call_args[1]
             assert call_kwargs.get("prefix_command") is None
+
+    def test_enter_resume_uses_state_single_coder_true(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Resume should dispatch the whole plan when persisted single-coder is true."""
+        handler = ImplementingHandler()
+        state = {
+            "last_event": "implementation_resumed",
+            "implementation_single_coder": True,
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with (
+            patch.object(handler, "_dispatch_whole_plan") as mock_whole,
+            patch.object(handler, "_dispatch_active_group") as mock_group,
+        ):
+            handler.enter(state, mock_ctx)
+
+        mock_whole.assert_called_once()
+        mock_group.assert_not_called()
+
+    def test_enter_fresh_start_logs_group_and_single_coder_mode(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Fresh starts should log the authoritative group and single-coder modes."""
+        from agentmux.shared.models import AgentConfig
+
+        handler = ImplementingHandler()
+        state = {"last_event": EVENT_PLAN_WRITTEN}
+        mock_ctx.agents = {
+            "coder": AgentConfig(
+                role="coder",
+                cli="some-cli",
+                model="some-model",
+                provider="some-provider",
+                single_coder=False,
+            )
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with (
+            patch("builtins.print") as mock_print,
+            patch.object(handler, "_dispatch_active_group"),
+        ):
+            handler.enter(state, mock_ctx)
+
+        mock_print.assert_called_once_with(
+            "Starting implementing phase "
+            "(fresh start, group_mode=serial, single_coder=False)."
+        )
+
+    def test_enter_resume_logs_authoritative_group_and_single_coder_mode(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Resume should log the active group mode alongside single-coder mode."""
+        handler = ImplementingHandler()
+        state = {
+            "last_event": "implementation_resumed",
+            "implementation_single_coder": True,
+            "implementation_group_mode": "parallel",
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with (
+            patch("builtins.print") as mock_print,
+            patch.object(handler, "_dispatch_whole_plan"),
+        ):
+            handler.enter(state, mock_ctx)
+
+        mock_print.assert_called_once_with(
+            "Resuming implementing phase "
+            "(group_mode=serial, single_coder=True, source=saved state)."
+        )
+
+    def test_enter_resume_logs_none_group_mode_when_no_active_group(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Resume should log group_mode=none when all implementation groups are done."""
+        handler = ImplementingHandler()
+        state = {
+            "last_event": "implementation_resumed",
+            "implementation_single_coder": False,
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        (mock_ctx.files.implementation_dir / "done_1").write_text("")
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with patch("builtins.print") as mock_print:
+            handler.enter(state, mock_ctx)
+
+        mock_print.assert_called_once_with(
+            "Resuming implementing phase "
+            "(group_mode=none, single_coder=False, source=saved state)."
+        )
+
+    def test_enter_resume_uses_state_single_coder_false(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Resume should dispatch the active group when persisted mode is false."""
+        from agentmux.shared.models import AgentConfig
+
+        handler = ImplementingHandler()
+        state = {
+            "last_event": "implementation_resumed",
+            "implementation_single_coder": False,
+        }
+        mock_ctx.agents = {
+            "coder": AgentConfig(
+                role="coder",
+                cli="copilot",
+                model="claude-sonnet-4.6",
+                provider="copilot",
+                single_coder=True,
+            )
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with (
+            patch.object(handler, "_dispatch_whole_plan") as mock_whole,
+            patch.object(handler, "_dispatch_active_group") as mock_group,
+        ):
+            handler.enter(state, mock_ctx)
+
+        mock_whole.assert_not_called()
+        mock_group.assert_called_once()
+
+    def test_enter_resume_missing_single_coder_uses_agent_config(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Resume should fall back to the current coder config when state is missing."""
+        from agentmux.shared.models import AgentConfig
+
+        handler = ImplementingHandler()
+        state = {"last_event": "implementation_resumed"}
+        mock_ctx.agents = {
+            "coder": AgentConfig(
+                role="coder",
+                cli="copilot",
+                model="claude-sonnet-4.6",
+                provider="copilot",
+                single_coder=True,
+            )
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with (
+            patch.object(handler, "_dispatch_whole_plan") as mock_whole,
+            patch.object(handler, "_dispatch_active_group") as mock_group,
+        ):
+            handler.enter(state, mock_ctx)
+
+        mock_whole.assert_called_once()
+        mock_group.assert_not_called()
+
+    def test_dispatch_active_group_prefers_persisted_parallel_mode(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Dispatch should use persisted group mode over the schedule when resuming."""
+        handler = ImplementingHandler()
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        schedule = [
+            {
+                "group_id": "group1",
+                "mode": "serial",
+                "plan_paths": [
+                    mock_ctx.files.planning_dir / "plan_1.md",
+                    mock_ctx.files.planning_dir / "plan_2.md",
+                ],
+                "plan_ids": ["plan_1", "plan_2"],
+                "plan_names": ["Plan 1", "Plan 2"],
+                "marker_indexes": [1, 2],
+            }
+        ]
+        state = {"implementation_group_mode": "parallel"}
+
+        with (
+            patch(
+                "agentmux.workflow.handlers.implementing.write_prompt_file"
+            ) as mock_write,
+            patch(
+                "agentmux.workflow.handlers.implementing.build_coder_subplan_prompt"
+            ) as mock_build,
+            patch("agentmux.workflow.handlers.implementing.send_to_role") as mock_send,
+        ):
+            mock_write.side_effect = [
+                Path("/mock/prompt-1.md"),
+                Path("/mock/prompt-2.md"),
+            ]
+            mock_build.return_value = "coder prompt"
+
+            handler._dispatch_active_group(
+                mock_ctx, schedule, active_group_index=0, state=state
+            )
+
+        mock_ctx.runtime.send_many.assert_called_once()
+        mock_send.assert_not_called()
+
+    def test_enter_fresh_start_persists_agent_single_coder(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Fresh starts should persist the current coder single-coder setting."""
+        from agentmux.shared.models import AgentConfig
+
+        handler = ImplementingHandler()
+        state = {"last_event": EVENT_PLAN_WRITTEN}
+        mock_ctx.agents = {
+            "coder": AgentConfig(
+                role="coder",
+                cli="some-cli",
+                model="some-model",
+                provider="some-provider",
+                single_coder=False,
+            )
+        }
+        mock_ctx.files.implementation_dir.mkdir(parents=True, exist_ok=True)
+        self._write_execution_plan(
+            mock_ctx,
+            [
+                {
+                    "group_id": "group1",
+                    "mode": "serial",
+                    "plans": [{"file": "plan_1.md", "name": "Plan 1"}],
+                }
+            ],
+        )
+
+        with patch.object(handler, "_dispatch_active_group"):
+            updates = handler.enter(state, mock_ctx)
+
+        assert updates["implementation_single_coder"] is False
 
 
 class TestReviewingHandler:


### PR DESCRIPTION
## Summary
- Persist `implementation_single_coder` in state.json when entering the implementing phase
- On resume, restore the saved setting instead of re-reading current agent config
- Ensures copilot-style whole-plan dispatch vs per-group dispatch is consistent across restarts

Closes #105

## Test plan
- [x] `pytest tests/test_initial_phase_state.py tests/workflow/handlers/test_handlers.py` (51 tests pass)
- [x] Fresh start persists agent config's single_coder value
- [x] Resume uses saved state, ignoring current config
- [x] Fallback to agent config when state key is missing (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)