### PR TITLE
feat: parallel reviewer support, remove feature_dir from submit tools, and refactor review pipeline

### DIFF
--- a/.cursor/commands
+++ b/.cursor/commands
@@ -1,0 +1,1 @@
+../.agents/commands

--- a/docs/artifacts/plan-yaml.md
+++ b/docs/artifacts/plan-yaml.md
@@ -12,19 +12,13 @@
 |-------|------|----------|-------------|
 | `version` | int | yes | Must be `2`. |
 | `plan_overview` | string | yes | Human-readable summary of the plan. Becomes the content of `plan.md`. |
-| `review_strategy` | dict | yes | Review configuration. See [review_strategy fields](#review_strategy-fields). |
 | `needs_design` | bool | yes | Whether a design phase is required before implementation. Controls `planning → designing` vs `planning → implementing` transition. |
 | `needs_docs` | bool | yes | Whether documentation updates are in scope. Informational only — does not affect transitions. |
 | `doc_files` | string[] | yes | Planned documentation files to create or update. May be empty (`[]`). |
 | `groups` | list[dict] | yes | Execution groups defining the scheduling order. See [groups fields](#groups-fields). Must have at least one group. |
 | `subplans` | list[dict] | yes | Sub-plans for the coder agents. See [subplans fields](#subplans-fields). Must have at least one sub-plan. |
 
-## `review_strategy` fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `severity` | string | yes | Risk level: `"low"`, `"medium"`, or `"high"`. Controls reviewer type selection. |
-| `focus` | string[] | no | Specific review focus areas. Valid values: `"security"`, `"performance"`, `"testing"`, `"error-handling"`, `"accessibility"`, `"documentation"`, `"maintainability"`. When `severity` is `medium` or `high` and `focus` contains `"security"` or `"performance"`, the expert reviewer is selected. |
+> **Note:** The `review_strategy` field has been removed. The architect nominates reviewers through `submit_architecture(reviewers=[...])` during the architecting phase.
 
 ## `groups` fields
 
@@ -68,9 +62,6 @@ version: 2
 plan_overview: |
   Add JWT authentication to the API. Covers token generation, validation
   middleware, and protected route guards.
-review_strategy:
-  severity: medium
-  focus: [security]
 needs_design: false
 needs_docs: true
 doc_files: [docs/auth.md]

--- a/docs/phases/07_review.md
+++ b/docs/phases/07_review.md
@@ -3,7 +3,7 @@
 > Related source files: `src/agentmux/workflow/handlers/reviewing.py`, `src/agentmux/workflow/phase_registry.py`, `src/agentmux/workflow/prompts.py`, `src/agentmux/integrations/mcp_server.py`
 > Directory: `07_review/` | Optional: no
 
-The reviewer evaluates the implementation against the plan, producing a structured verdict. AgentMux routes to a specialized reviewer type based on the plan's `review_strategy`.
+The reviewer evaluates the implementation against the plan, producing a structured verdict. The architect nominates which reviewer roles should run via `submit_architecture(reviewers=[...])`.
 
 ## Conditions
 
@@ -11,14 +11,15 @@ Entered after `implementing` or `fixing` completes (`implementation_completed` e
 
 ## Role
 
-One of four reviewer agents is selected based on `review_strategy.severity` and `review_strategy.focus` from `plan.yaml`:
+The architect nominates the reviewer set via `submit_architecture(reviewers=[...])` during the architecting phase. Valid values:
 
-| Condition | Agent used |
-|-----------|------------|
-| No `review_strategy` in plan | **reviewer_logic** (backward-compatible default) |
-| `severity: low` | **reviewer_quality** |
-| `severity: medium/high`, no security/performance focus | **reviewer_logic** |
-| `severity: medium/high` with `security` or `performance` in focus | **reviewer_expert** |
+| Role | Purpose |
+|------|---------|
+| `reviewer_logic` | Checks alignment to plan and functional correctness |
+| `reviewer_quality` | Checks code quality, style, and maintainability |
+| `reviewer_expert` | Checks security, performance, and edge cases |
+
+When `reviewers` is omitted or empty, only `reviewer_logic` runs by default.
 
 ## Artifacts
 
@@ -35,7 +36,7 @@ One of four reviewer agents is selected based on `review_strategy.severity` and 
 
 ## Reviewer selection
 
-See the **Role** section above for the routing table.
+The architect nominates the reviewer set via `submit_architecture(reviewers=[...])` during the architecting phase. The nominations are stored in `state["reviewer_nominations"]` and read by `select_reviewer_roles(state)` to determine which reviewer panes to dispatch.
 
 ## `review.yaml` schema
 

--- a/src/agentmux/integrations/mcp_server.py
+++ b/src/agentmux/integrations/mcp_server.py
@@ -197,7 +197,6 @@ def _read_yaml_for_signal(yaml_path: Path, contract_name: str) -> dict[str, Any]
 
 @_tool("submit_architecture")
 def submit_architecture(
-    feature_dir: str | None = None,
     preferences: list[dict[str, str]] | None = None,
 ) -> str:
     """Signal architecture completion.
@@ -209,7 +208,7 @@ def submit_architecture(
     Optional: pass preferences=[{target_role, bullet}, ...] to persist approved
     style/quality preferences directly to .agentmux/prompts/agents/<role>.md.
     """
-    feature = _feature_dir(feature_dir)
+    feature = _feature_dir()
     md_path = feature / SESSION_DIR_NAMES["architecting"] / "architecture.md"
     if not md_path.exists():
         raise ValueError(
@@ -219,13 +218,12 @@ def submit_architecture(
         raise ValueError("architecture.md is empty.")
     if preferences:
         apply_preference_entries(_project_dir(), preferences)
-    append_tool_event(_log_path(feature_dir), "submit_architecture", {})
+    append_tool_event(_log_path(), "submit_architecture", {})
     return "Architecture submitted."
 
 
 @_tool("submit_plan")
 def submit_plan(
-    feature_dir: str | None = None,
     preferences: list[dict[str, str]] | None = None,
 ) -> str:
     """Signal execution plan completion.
@@ -237,36 +235,42 @@ def submit_plan(
     Optional: pass preferences=[{target_role, bullet}, ...] to persist approved
     style/quality preferences directly to .agentmux/prompts/agents/<role>.md.
     """
-    feature = _feature_dir(feature_dir)
+    feature = _feature_dir()
     yaml_path = feature / SESSION_DIR_NAMES["planning"] / "plan.yaml"
     _read_yaml_for_signal(yaml_path, "plan")
     if preferences:
         apply_preference_entries(_project_dir(), preferences)
-    append_tool_event(_log_path(feature_dir), "submit_plan", {})
+    append_tool_event(_log_path(), "submit_plan", {})
     return "Plan submitted."
 
 
 @_tool("submit_review")
 def submit_review(
-    feature_dir: str | None = None,
     preferences: list[dict[str, str]] | None = None,
+    role: str | None = None,
 ) -> str:
     """Signal review completion.
 
-    Reads and validates the agent-written 07_review/review.yaml,
-    then appends a completion signal to tool_events.jsonl.
-    Write the YAML file before calling this tool.
+    Reads and validates the agent-written review YAML, then appends a
+    completion signal to tool_events.jsonl.  Write the YAML file before
+    calling this tool.
+
+    When called by a parallel reviewer, pass role=<your_role> (e.g.
+    role="reviewer_logic") so the tool reads the role-specific file
+    review_{role}.yaml.  Without a role the legacy review.yaml is used.
 
     Optional: pass preferences=[{target_role, bullet}, ...] to persist approved
     style/quality preferences directly to .agentmux/prompts/agents/<role>.md.
     """
-    feature = _feature_dir(feature_dir)
-    yaml_path = feature / SESSION_DIR_NAMES["review"] / "review.yaml"
+    feature = _feature_dir()
+    review_dir = feature / SESSION_DIR_NAMES["review"]
+    filename = f"review_{role}.yaml" if role else "review.yaml"
+    yaml_path = review_dir / filename
     data = _read_yaml_for_signal(yaml_path, "review")
     verdict = data.get("verdict", "unknown")
     if preferences:
         apply_preference_entries(_project_dir(), preferences)
-    append_tool_event(_log_path(feature_dir), "submit_review", {})
+    append_tool_event(_log_path(), "submit_review", {})
     return f"Review submitted (verdict: {verdict})."
 
 
@@ -278,14 +282,11 @@ def submit_review(
 @_tool("submit_done")
 def submit_done(
     subplan_index: int,
-    feature_dir: str | None = None,
 ) -> str:
     """Mark a sub-plan as done."""
     if not isinstance(subplan_index, int) or subplan_index < 1:
         raise ValueError("subplan_index must be an integer >= 1.")
-    append_tool_event(
-        _log_path(feature_dir), "submit_done", {"subplan_index": subplan_index}
-    )
+    append_tool_event(_log_path(), "submit_done", {"subplan_index": subplan_index})
     return f"Sub-plan {subplan_index} marked done."
 
 
@@ -293,14 +294,13 @@ def submit_done(
 def submit_research_done(
     topic: str,
     type: str,
-    feature_dir: str | None = None,
 ) -> str:
     """Mark a research task as done."""
     normalized = _validate_topic(topic)
     if type not in ("code", "web"):
         raise ValueError("type must be 'code' or 'web'.")
     append_tool_event(
-        _log_path(feature_dir),
+        _log_path(),
         "submit_research_done",
         {"topic": normalized, "type": type, "role_type": type},
     )
@@ -309,7 +309,6 @@ def submit_research_done(
 
 @_tool("submit_pm_done")
 def submit_pm_done(
-    feature_dir: str | None = None,
     preferences: list[dict[str, str]] | None = None,
 ) -> str:
     """Mark the product management phase as done.
@@ -319,7 +318,7 @@ def submit_pm_done(
     """
     if preferences:
         apply_preference_entries(_project_dir(), preferences)
-    append_tool_event(_log_path(feature_dir), "submit_pm_done", {})
+    append_tool_event(_log_path(), "submit_pm_done", {})
     return "Product management phase done."
 
 

--- a/src/agentmux/integrations/mcp_server.py
+++ b/src/agentmux/integrations/mcp_server.py
@@ -195,9 +195,19 @@ def _read_yaml_for_signal(yaml_path: Path, contract_name: str) -> dict[str, Any]
     return data
 
 
+_ALLOWED_REVIEWER_ROLES = frozenset(
+    {
+        "reviewer_logic",
+        "reviewer_quality",
+        "reviewer_expert",
+    }
+)
+
+
 @_tool("submit_architecture")
 def submit_architecture(
     preferences: list[dict[str, str]] | None = None,
+    reviewers: list[str] | None = None,
 ) -> str:
     """Signal architecture completion.
 
@@ -207,6 +217,10 @@ def submit_architecture(
 
     Optional: pass preferences=[{target_role, bullet}, ...] to persist approved
     style/quality preferences directly to .agentmux/prompts/agents/<role>.md.
+
+    Optional: pass reviewers=[...] to nominate which reviewer roles should run.
+    Valid values: reviewer_logic, reviewer_quality, reviewer_expert.
+    Default (None or empty): reviewer_logic.
     """
     feature = _feature_dir()
     md_path = feature / SESSION_DIR_NAMES["architecting"] / "architecture.md"
@@ -218,7 +232,20 @@ def submit_architecture(
         raise ValueError("architecture.md is empty.")
     if preferences:
         apply_preference_entries(_project_dir(), preferences)
-    append_tool_event(_log_path(), "submit_architecture", {})
+
+    # Validate and normalise reviewers
+    if reviewers is not None:
+        for r in reviewers:
+            if r not in _ALLOWED_REVIEWER_ROLES:
+                raise ValueError(
+                    f"Unknown reviewer role {r!r}. "
+                    f"Allowed: {sorted(_ALLOWED_REVIEWER_ROLES)}"
+                )
+        reviewer_payload = {"reviewers": list(reviewers)}
+    else:
+        reviewer_payload = {}
+
+    append_tool_event(_log_path(), "submit_architecture", reviewer_payload)
     return "Architecture submitted."
 
 

--- a/src/agentmux/prompts/agents/code-researcher.md
+++ b/src/agentmux/prompts/agents/code-researcher.md
@@ -35,8 +35,4 @@ Your job:
 
 [[placeholder:project_instructions]]
 
-Constraints:
-- Communicate only through files in the session directory.
-- Do not invent facts.
-- Do not ask questions. If the scope is unclear, use your best judgment and document your interpretation.
-- Only write files in the session directory. Do not create or modify any files in the project directory.
+[[shared:research-constraints]]

--- a/src/agentmux/prompts/agents/reviewer_expert.md
+++ b/src/agentmux/prompts/agents/reviewer_expert.md
@@ -32,7 +32,7 @@ You focus **exclusively** on security vulnerabilities, performance issues, edge 
 
 ## Output & Artifacts
 
-- `07_review/review.md` — verdict (pass/fail) with security/performance findings and guidance for the coder if fail.
+- `07_review/review_reviewer_expert.yaml` — verdict (pass/fail) with security/performance findings and guidance for the coder if fail.
 - `08_completion/confirmation_prompt.md` — confirmation prompt for the user (confirmation step only).
 
 ## Preference Memory
@@ -46,3 +46,5 @@ You focus **exclusively** on security vulnerabilities, performance issues, edge 
 - Do not mix implementation verdicting with preference-capture decisions.
 - Do not implement fixes or modify any project files.
 - When verdict is fail, the orchestrator routes to the coder agent for fixes — your job ends at writing the review.
+
+[[shared:handoff-contract-review]]

--- a/src/agentmux/prompts/agents/reviewer_logic.md
+++ b/src/agentmux/prompts/agents/reviewer_logic.md
@@ -32,7 +32,7 @@ You focus **exclusively** on whether the technical implementation aligns with th
 
 ## Output & Artifacts
 
-- `07_review/review.md` — verdict (pass/fail) with findings, logic gaps, and guidance for the coder if fail.
+- `07_review/review_reviewer_logic.yaml` — verdict (pass/fail) with findings, logic gaps, and guidance for the coder if fail.
 - `08_completion/confirmation_prompt.md` — confirmation prompt for the user (confirmation step only).
 
 ## Preference Memory
@@ -46,3 +46,5 @@ You focus **exclusively** on whether the technical implementation aligns with th
 - Do not mix implementation verdicting with preference-capture decisions.
 - Do not implement fixes or modify any project files.
 - When verdict is fail, the orchestrator routes to the coder agent for fixes — your job ends at writing the review.
+
+[[shared:handoff-contract-review]]

--- a/src/agentmux/prompts/agents/reviewer_quality.md
+++ b/src/agentmux/prompts/agents/reviewer_quality.md
@@ -32,7 +32,7 @@ You focus **exclusively** on Clean Code principles, naming conventions, and proj
 
 ## Output & Artifacts
 
-- `07_review/review.md` — verdict (pass/fail) with findings on code quality, naming, and style.
+- `07_review/review_reviewer_quality.yaml` — verdict (pass/fail) with findings on code quality, naming, and style.
 - `08_completion/confirmation_prompt.md` — confirmation prompt for the user (confirmation step only).
 
 ## Preference Memory
@@ -46,3 +46,5 @@ You focus **exclusively** on Clean Code principles, naming conventions, and proj
 - Do not mix implementation verdicting with preference-capture decisions.
 - Do not implement fixes or modify any project files.
 - When verdict is fail, the orchestrator routes to the coder agent for fixes — your job ends at writing the review.
+
+[[shared:handoff-contract-review]]

--- a/src/agentmux/prompts/agents/web-researcher.md
+++ b/src/agentmux/prompts/agents/web-researcher.md
@@ -19,7 +19,7 @@ Your job:
 4. If you cannot verify something, say explicitly that you could not find reliable information.
 5. Write `03_research/web-[[placeholder:topic]]/summary.md` for the architect (see format below).
 6. Write `03_research/web-[[placeholder:topic]]/detail.md` for coder/designer agents (see format below).
-7. FINAL STEP ONLY — call `mcp__agentmux__submit_research_done(topic="[[placeholder:topic]]", type="web")` to signal completion to the orchestrator and materialize `03_research/web-[[placeholder:topic]]/done`.
+7. FINAL STEP ONLY — call `mcp__agentmux__submit_research_done(topic="[[placeholder:topic]]", type="web")` to signal completion to the orchestrator.
 
 ## Output format
 
@@ -36,8 +36,4 @@ Your job:
 
 [[placeholder:project_instructions]]
 
-Constraints:
-- Communicate only through files in the session directory.
-- Do not invent facts.
-- Do not ask questions. If the scope is unclear, use your best judgment and document your interpretation.
-- Only write files in the session directory. Do not create or modify any files in the project directory.
+[[shared:research-constraints]]

--- a/src/agentmux/prompts/shared/handoff-contract-architecture.md
+++ b/src/agentmux/prompts/shared/handoff-contract-architecture.md
@@ -4,4 +4,19 @@ Write `02_architecting/architecture.md` as a Markdown document describing your t
 
 The document is free-form Markdown — include whatever sections are appropriate (Solution Overview, Components, Interfaces, Data Models, Technology Choices, Risks, etc.).
 
-After writing the file, call `mcp__agentmux__submit_architecture()` (no arguments needed).
+After writing the file, call `mcp__agentmux__submit_architecture()` to signal completion.
+
+### Reviewer Nomination
+
+Optionally, you can nominate which reviewer roles should evaluate the implementation.
+Pass the `reviewers` argument with a list of one or more of these values:
+
+| Role | Purpose |
+|---|---|
+| `reviewer_logic` | Checks alignment to plan and functional correctness |
+| `reviewer_quality` | Checks code quality, style, and maintainability |
+| `reviewer_expert` | Checks security, performance, and edge cases |
+
+Example: `mcp__agentmux__submit_architecture(reviewers=["reviewer_logic", "reviewer_expert"])`
+
+If you omit `reviewers` or pass an empty list, only `reviewer_logic` will run by default.

--- a/src/agentmux/prompts/shared/handoff-contract-plan.md
+++ b/src/agentmux/prompts/shared/handoff-contract-plan.md
@@ -8,10 +8,6 @@ plan_overview: |
   # Implementation Plan
 
   Overview of all planned work.
-review_strategy:
-  severity: medium   # low | medium | high
-  focus:
-    - security       # optional focus areas
 needs_design: false
 needs_docs: true
 doc_files:
@@ -44,3 +40,5 @@ subplans:
 After writing the file, call `mcp__agentmux__submit_plan()` (no arguments needed).
 
 Each sub-plan in `subplans` must be referenced exactly once in `groups[].plans[]` via its `index`. Indices must start at 1 and be contiguous (1, 2, 3, …).
+
+> **Note:** Reviewer selection is no longer configured via `review_strategy`. The architect nominates reviewers through `submit_architecture(reviewers=[...])` during the architecting phase.

--- a/src/agentmux/prompts/shared/handoff-contract-review.md
+++ b/src/agentmux/prompts/shared/handoff-contract-review.md
@@ -1,6 +1,6 @@
 ## Submitting Your Review
 
-Write `07_review/review.yaml` with the fields below, then call `mcp__agentmux__submit_review()` to validate your file and signal completion.
+Write `07_review/review_[[placeholder:review_role]].yaml` with the fields below, then call `mcp__agentmux__submit_review(role="[[placeholder:review_role]]")` to validate your file and signal completion.
 
 On pass:
 ```yaml
@@ -22,4 +22,4 @@ findings:
     recommendation: Add email format check before database lookup.
 ```
 
-After writing the file, call `mcp__agentmux__submit_review()` (no arguments needed).
+After writing the file, call `mcp__agentmux__submit_review(role="[[placeholder:review_role]]")`.

--- a/src/agentmux/prompts/shared/research-constraints.md
+++ b/src/agentmux/prompts/shared/research-constraints.md
@@ -1,0 +1,6 @@
+Constraints:
+- Communicate only through files in the session directory. This means research outputs — do not message other agents or modify the project directory.
+- The `submit_research_done` MCP call is the **only** valid completion signal. The orchestrator does NOT detect your output files automatically — it will wait indefinitely until you make this call.
+- Do not invent facts.
+- Do not ask questions. If the scope is unclear, use your best judgment and document your interpretation.
+- Only write files in the session directory. Do not create or modify any files in the project directory.

--- a/src/agentmux/runtime/__init__.py
+++ b/src/agentmux/runtime/__init__.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Literal, NamedTuple, Protocol
 
 from ..agent_labels import role_display_label
 from ..shared.models import BATCH_AGENT_ROLES, AgentConfig
@@ -28,6 +28,14 @@ from .tmux_core import tmux_pane_exists
 SNAPSHOT_VERSION = 2
 
 
+class ReviewerSpec(NamedTuple):
+    """Specification for a reviewer pane in send_reviewers_many()."""
+
+    role: str
+    prompt_file: Path
+    display_label: str | None = None
+
+
 class AgentRuntime(Protocol):
     def send(
         self,
@@ -40,6 +48,10 @@ class AgentRuntime(Protocol):
     def send_many(
         self, role: str, prompt_specs: list[ParallelPromptSpec | Path]
     ) -> None: ...
+
+    def send_reviewers_many(
+        self, reviewer_specs: list[ReviewerSpec]
+    ) -> dict[str, str]: ...
 
     def deactivate(self, role: str) -> None: ...
 
@@ -491,6 +503,60 @@ class TmuxAgentRuntime:
 
         self.parallel_panes[role] = workers
         self._persist_snapshot()
+
+    def send_reviewers_many(self, reviewer_specs: list[ReviewerSpec]) -> dict[str, str]:
+        """Create parallel panes for heterogeneous reviewer roles.
+
+        Unlike send_many() which creates multiple panes for the same role,
+        this creates one pane per distinct reviewer role. Each pane gets its
+        own prompt file. All panes are shown in parallel via content_zone.
+
+        Args:
+            reviewer_specs: List of ReviewerSpec, one per reviewer role.
+
+        Returns:
+            Dict mapping role -> pane_id for all created panes.
+        """
+        if not reviewer_specs:
+            return {}
+
+        role_to_pane: dict[str, str] = {}
+        pane_ids: list[str] = []
+
+        for spec in reviewer_specs:
+            if spec.role not in self.agents:
+                logging.getLogger(__name__).warning(
+                    "Unknown reviewer role %r — skipping", spec.role
+                )
+                continue
+            display_label = spec.display_label or self._display_label_for_task(
+                spec.role, None
+            )
+            pane_id, pid = create_agent_pane(
+                self.session_name,
+                spec.role,
+                self.agents,
+                self.project_dir,
+                self.agents[spec.role].trust_snippet,
+                display_label=display_label,
+            )
+            self._track_process_pid(pane_id, pid)
+            set_pane_identity(pane_id, role=spec.role, display_label=display_label)
+            role_to_pane[spec.role] = pane_id
+            pane_ids.append(pane_id)
+
+        self._zone.show_parallel(pane_ids)
+
+        for spec in reviewer_specs:
+            if spec.role in role_to_pane:
+                send_prompt(role_to_pane[spec.role], spec.prompt_file)
+
+        # Track in parallel_panes under each role
+        for role, pane_id in role_to_pane.items():
+            self.parallel_panes.setdefault(role, {})[0] = pane_id
+
+        self._persist_snapshot()
+        return role_to_pane
 
     def deactivate(self, role: str) -> None:
         workers = self.parallel_panes.get(role, {})

--- a/src/agentmux/workflow/event_router.py
+++ b/src/agentmux/workflow/event_router.py
@@ -12,21 +12,10 @@ import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, NamedTuple, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
+from .phase_result import PhaseResult
 from .transitions import PipelineContext
-
-
-class PhaseResult(NamedTuple):
-    """Uniform return type for handler enter() methods.
-
-    Attributes:
-        updates: Dict of state updates to apply.
-        next_phase: Optional phase name to transition to immediately.
-    """
-
-    updates: dict
-    next_phase: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/agentmux/workflow/event_router.py
+++ b/src/agentmux/workflow/event_router.py
@@ -12,9 +12,21 @@ import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 from .transitions import PipelineContext
+
+
+class PhaseResult(NamedTuple):
+    """Uniform return type for handler enter() methods.
+
+    Attributes:
+        updates: Dict of state updates to apply.
+        next_phase: Optional phase name to transition to immediately.
+    """
+
+    updates: dict
+    next_phase: str | None = None
 
 
 @dataclass(frozen=True)
@@ -96,7 +108,7 @@ class PhaseHandler(Protocol):
     ``EventSpec(name=..., watch_paths=('*',), ...)``.
     """
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called once when entering the phase.
 
         Responsibilities:
@@ -109,7 +121,7 @@ class PhaseHandler(Protocol):
             ctx: Pipeline context with files, runtime, agents
 
         Returns:
-            Dict of state updates to apply (e.g., {"subplan_count": 3})
+            PhaseResult with updates dict and optional next_phase
         """
         ...
 
@@ -233,21 +245,44 @@ class WorkflowEventRouter:
 
         return False
 
-    def enter_current_phase(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter_current_phase(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         phase_name = state.get("phase", "")
         handler = self._phases.get(phase_name)
         if handler is None or phase_name in self._entered:
-            return {}
+            return PhaseResult({})
 
         self._entered.add(phase_name)
 
-        enter_updates = handler.enter(state, ctx)
-        state.update(enter_updates)
+        result = handler.enter(state, ctx)
+        state.update(result.updates)
 
         from ..sessions.state_store import write_state
 
         write_state(ctx.files.state, state)
-        return enter_updates
+
+        # If enter() requests an immediate transition, do it
+        if result.next_phase is not None:
+            return self._transition(state, ctx, phase_name, result.next_phase)
+
+        return result
+
+    def _transition(
+        self,
+        state: dict,
+        ctx: PipelineContext,
+        current_phase: str,
+        next_phase: str,
+    ) -> PhaseResult:
+        """Perform a phase transition: update state, write, enter new phase."""
+        self._entered.discard(current_phase)
+        state["phase"] = next_phase
+        state["updated_at"] = self._now_iso()
+        state["updated_by"] = "pipeline"
+        from ..sessions.state_store import write_state
+
+        write_state(ctx.files.state, state)
+        self.enter_current_phase(state, ctx)
+        return PhaseResult({})
 
     def handle(
         self, event: WorkflowEvent, state: dict, ctx: PipelineContext
@@ -292,16 +327,9 @@ class WorkflowEventRouter:
         # Apply updates
         state.update(updates)
 
-        # Phase transition: enter new phase explicitly (no recursive handle call)
+        # Phase transition: enter new phase explicitly
         if next_phase is not None:
-            self._entered.discard(phase_name)
-            state["phase"] = next_phase
-            state["updated_at"] = self._now_iso()
-            state["updated_by"] = "pipeline"
-            from ..sessions.state_store import write_state
-
-            write_state(ctx.files.state, state)
-            self.enter_current_phase(state, ctx)
+            self._transition(state, ctx, phase_name, next_phase)
             return {}, None
 
         # Write state if there were updates

--- a/src/agentmux/workflow/handlers/architecting.py
+++ b/src/agentmux/workflow/handlers/architecting.py
@@ -12,16 +12,13 @@ from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_ARCHITECTURE_WRITTEN
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import (
-    BaseToolHandler,
-    PhaseResult,
-    ToolHandlerEntry,
-)
+from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
 from agentmux.workflow.phase_helpers import (
     handle_research_done,
     handle_research_request,
     send_to_role,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.prompts import (
     build_architect_prompt,
     write_prompt_file,

--- a/src/agentmux/workflow/handlers/architecting.py
+++ b/src/agentmux/workflow/handlers/architecting.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_ARCHITECTURE_WRITTEN
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
+from agentmux.workflow.handlers.base import (
+    BaseToolHandler,
+    PhaseResult,
+    ToolHandlerEntry,
+)
 from agentmux.workflow.phase_helpers import (
     handle_research_done,
     handle_research_request,
@@ -66,7 +70,7 @@ class ArchitectingHandler(BaseToolHandler):
     def get_event_specs(self) -> Sequence[EventSpec]:
         return ()
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering architecting phase."""
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
@@ -74,7 +78,7 @@ class ArchitectingHandler(BaseToolHandler):
             build_architect_prompt(ctx.files, ctx.agents.get("architect")),
         )
         send_to_role(ctx, "architect", prompt_file)
-        return {}
+        return PhaseResult({})
 
     def _handle_architecture(
         self,
@@ -94,6 +98,13 @@ class ArchitectingHandler(BaseToolHandler):
         ctx.runtime.deactivate("architect")
         ctx.runtime.kill_primary("architect")
 
+        # Extract reviewer nominations from the tool event payload
+        payload = event.payload.get("payload", {})
+        reviewers = payload.get("reviewers")
+        updates: dict[str, object] = {"last_event": EVENT_ARCHITECTURE_WRITTEN}
+        if isinstance(reviewers, list) and reviewers:
+            updates["reviewer_nominations"] = reviewers
+
         _ = md_path  # used by the orchestrator directly; no transformation needed
         # Transition to planning phase (planner takes over)
-        return {"last_event": EVENT_ARCHITECTURE_WRITTEN}, "planning"
+        return updates, "planning"

--- a/src/agentmux/workflow/handlers/base.py
+++ b/src/agentmux/workflow/handlers/base.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_router import ToolSpec, WorkflowEvent
+from agentmux.workflow.phase_result import PhaseResult
 
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext

--- a/src/agentmux/workflow/handlers/base.py
+++ b/src/agentmux/workflow/handlers/base.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_router import ToolSpec, WorkflowEvent
-from agentmux.workflow.phase_result import PhaseResult
 
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext

--- a/src/agentmux/workflow/handlers/completing.py
+++ b/src/agentmux/workflow/handlers/completing.py
@@ -12,6 +12,7 @@ from agentmux.sessions.state_store import feature_slug_from_dir, read_json_resil
 from agentmux.shared.models import ProjectPaths
 from agentmux.workflow.event_catalog import EVENT_CHANGES_REQUESTED
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
+from agentmux.workflow.handlers.base import PhaseResult
 
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext
@@ -80,7 +81,7 @@ def _parse_changed_paths(status_output: str) -> list[str]:
 class CompletingHandler:
     """Event-driven handler for completing phase."""
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering completing phase.
 
         Launches native TUI or auto-approves if configured.
@@ -95,10 +96,10 @@ class CompletingHandler:
                 json.dumps({"action": "approve", "exclude_files": []}, indent=2) + "\n",
                 encoding="utf-8",
             )
-            return {}
+            return PhaseResult({})
 
         ctx.runtime.show_completion_ui(ctx.files.feature_dir)
-        return {}
+        return PhaseResult({})
 
     def get_event_specs(self) -> tuple[EventSpec, ...]:
         return _SPECS

--- a/src/agentmux/workflow/handlers/completing.py
+++ b/src/agentmux/workflow/handlers/completing.py
@@ -12,7 +12,7 @@ from agentmux.sessions.state_store import feature_slug_from_dir, read_json_resil
 from agentmux.shared.models import ProjectPaths
 from agentmux.workflow.event_catalog import EVENT_CHANGES_REQUESTED
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import PhaseResult
+from agentmux.workflow.phase_result import PhaseResult
 
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext

--- a/src/agentmux/workflow/handlers/designing.py
+++ b/src/agentmux/workflow/handlers/designing.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from agentmux.agent_labels import role_display_label
 from agentmux.workflow.event_catalog import EVENT_DESIGN_WRITTEN
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import PhaseResult
 from agentmux.workflow.phase_helpers import send_to_role
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.prompts import build_designer_prompt, write_prompt_file
 
 if TYPE_CHECKING:

--- a/src/agentmux/workflow/handlers/designing.py
+++ b/src/agentmux/workflow/handlers/designing.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from agentmux.agent_labels import role_display_label
 from agentmux.workflow.event_catalog import EVENT_DESIGN_WRITTEN
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
+from agentmux.workflow.handlers.base import PhaseResult
 from agentmux.workflow.phase_helpers import send_to_role
 from agentmux.workflow.prompts import build_designer_prompt, write_prompt_file
 
@@ -33,7 +34,7 @@ class DesigningHandler:
     def get_event_specs(self) -> tuple[EventSpec, ...]:
         return _SPECS
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering designing phase.
 
         Sends designer prompt.
@@ -51,7 +52,7 @@ class DesigningHandler:
                 ctx.files.feature_dir, "designer", state=state
             ),
         )
-        return {}
+        return PhaseResult({})
 
     def handle_event(
         self,

--- a/src/agentmux/workflow/handlers/failed.py
+++ b/src/agentmux/workflow/handlers/failed.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import PhaseResult
+from agentmux.workflow.phase_result import PhaseResult
 
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext

--- a/src/agentmux/workflow/handlers/failed.py
+++ b/src/agentmux/workflow/handlers/failed.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
+from agentmux.workflow.handlers.base import PhaseResult
 
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext
@@ -26,12 +27,12 @@ class FailedHandler:
             ),
         )
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering failed phase.
 
         Does nothing - failure is handled by handle_event.
         """
-        return {}
+        return PhaseResult({})
 
     def handle_event(
         self,

--- a/src/agentmux/workflow/handlers/fixing.py
+++ b/src/agentmux/workflow/handlers/fixing.py
@@ -14,15 +14,12 @@ from agentmux.workflow.event_router import (
     WorkflowEvent,
     extract_subplan_index,
 )
-from agentmux.workflow.handlers.base import (
-    BaseToolHandler,
-    PhaseResult,
-    ToolHandlerEntry,
-)
+from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
 from agentmux.workflow.phase_helpers import (
     reset_markers,
     send_to_role,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.prompts import build_fix_prompt, write_prompt_file
 
 if TYPE_CHECKING:

--- a/src/agentmux/workflow/handlers/fixing.py
+++ b/src/agentmux/workflow/handlers/fixing.py
@@ -14,7 +14,11 @@ from agentmux.workflow.event_router import (
     WorkflowEvent,
     extract_subplan_index,
 )
-from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
+from agentmux.workflow.handlers.base import (
+    BaseToolHandler,
+    PhaseResult,
+    ToolHandlerEntry,
+)
 from agentmux.workflow.phase_helpers import (
     reset_markers,
     send_to_role,
@@ -37,7 +41,7 @@ class FixingHandler(BaseToolHandler):
             ),
         )
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering fixing phase.
 
         Sends fix prompt to coder.
@@ -59,9 +63,11 @@ class FixingHandler(BaseToolHandler):
                 ctx.files.feature_dir, "coder", state=state
             ),
         )
-        return {
-            "completed_subplans": [],
-        }
+        return PhaseResult(
+            {
+                "completed_subplans": [],
+            }
+        )
 
     def get_event_specs(self) -> tuple[EventSpec, ...]:
         return ()

--- a/src/agentmux/workflow/handlers/implementing.py
+++ b/src/agentmux/workflow/handlers/implementing.py
@@ -17,7 +17,11 @@ from agentmux.workflow.event_catalog import (
 )
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
 from agentmux.workflow.execution_plan import load_execution_plan
-from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
+from agentmux.workflow.handlers.base import (
+    BaseToolHandler,
+    PhaseResult,
+    ToolHandlerEntry,
+)
 from agentmux.workflow.phase_helpers import (
     reset_markers,
     send_to_role,
@@ -161,7 +165,7 @@ class ImplementingHandler(BaseToolHandler):
             ),
         )
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering implementing phase.
 
         Resets markers and dispatches first group (or whole plan in single-coder mode).
@@ -226,7 +230,7 @@ class ImplementingHandler(BaseToolHandler):
             else:
                 self._dispatch_active_group(ctx, schedule, active_group_index)
 
-        return updates
+        return PhaseResult(updates)
 
     def get_event_specs(self) -> Sequence[EventSpec]:
         return ()

--- a/src/agentmux/workflow/handlers/implementing.py
+++ b/src/agentmux/workflow/handlers/implementing.py
@@ -17,15 +17,12 @@ from agentmux.workflow.event_catalog import (
 )
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
 from agentmux.workflow.execution_plan import load_execution_plan
-from agentmux.workflow.handlers.base import (
-    BaseToolHandler,
-    PhaseResult,
-    ToolHandlerEntry,
-)
+from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
 from agentmux.workflow.phase_helpers import (
     reset_markers,
     send_to_role,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.plan_parser import coder_label_for_subplan
 from agentmux.workflow.prompts import (
     build_coder_subplan_prompt,

--- a/src/agentmux/workflow/handlers/planning.py
+++ b/src/agentmux/workflow/handlers/planning.py
@@ -14,11 +14,7 @@ import yaml
 from agentmux.workflow.event_catalog import EVENT_CHANGES_REQUESTED, EVENT_PLAN_WRITTEN
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
 from agentmux.workflow.execution_plan import load_execution_plan
-from agentmux.workflow.handlers.base import (
-    BaseToolHandler,
-    PhaseResult,
-    ToolHandlerEntry,
-)
+from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
 from agentmux.workflow.handoff_artifacts import (
     _write_yaml,
     generate_execution_plan_yaml,
@@ -32,6 +28,7 @@ from agentmux.workflow.phase_helpers import (
     load_plan_meta,
     send_to_role,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.prompts import (
     build_change_prompt,
     build_planner_prompt,

--- a/src/agentmux/workflow/handlers/planning.py
+++ b/src/agentmux/workflow/handlers/planning.py
@@ -14,7 +14,11 @@ import yaml
 from agentmux.workflow.event_catalog import EVENT_CHANGES_REQUESTED, EVENT_PLAN_WRITTEN
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
 from agentmux.workflow.execution_plan import load_execution_plan
-from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
+from agentmux.workflow.handlers.base import (
+    BaseToolHandler,
+    PhaseResult,
+    ToolHandlerEntry,
+)
 from agentmux.workflow.handoff_artifacts import (
     _write_yaml,
     generate_execution_plan_yaml,
@@ -75,7 +79,7 @@ class PlanningHandler(BaseToolHandler):
     def get_event_specs(self) -> Sequence[EventSpec]:
         return ()
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering planning phase.
 
         Sends planner prompt (initial or changes).
@@ -95,7 +99,7 @@ class PlanningHandler(BaseToolHandler):
             else build_planner_prompt(ctx.files, ctx.agents.get("planner")),
         )
         send_to_role(ctx, "planner", prompt_file)
-        return {}
+        return PhaseResult({})
 
     def _handle_plan(
         self,

--- a/src/agentmux/workflow/handlers/product_management.py
+++ b/src/agentmux/workflow/handlers/product_management.py
@@ -7,16 +7,13 @@ from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_PM_COMPLETED
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import (
-    BaseToolHandler,
-    PhaseResult,
-    ToolHandlerEntry,
-)
+from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
 from agentmux.workflow.phase_helpers import (
     handle_research_done,
     handle_research_request,
     send_to_role,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.prompts import (
     build_product_manager_prompt,
     write_prompt_file,

--- a/src/agentmux/workflow/handlers/product_management.py
+++ b/src/agentmux/workflow/handlers/product_management.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 
 from agentmux.workflow.event_catalog import EVENT_PM_COMPLETED
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
+from agentmux.workflow.handlers.base import (
+    BaseToolHandler,
+    PhaseResult,
+    ToolHandlerEntry,
+)
 from agentmux.workflow.phase_helpers import (
     handle_research_done,
     handle_research_request,
@@ -58,7 +62,7 @@ class ProductManagementHandler(BaseToolHandler):
     def get_event_specs(self) -> Sequence[EventSpec]:
         return ()
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering product_management phase.
 
         Sends product-manager prompt.
@@ -71,7 +75,7 @@ class ProductManagementHandler(BaseToolHandler):
             build_product_manager_prompt(ctx.files, ctx.agents.get("product-manager")),
         )
         send_to_role(ctx, "product-manager", prompt_file)
-        return {}  # No state updates
+        return PhaseResult({})  # No state updates
 
     def _handle_pm_done(
         self,

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -15,16 +15,13 @@ from agentmux.workflow.event_catalog import (
     EVENT_REVIEW_PASSED,
 )
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import (
-    BaseToolHandler,
-    PhaseResult,
-    ToolHandlerEntry,
-)
+from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
 from agentmux.workflow.handoff_artifacts import generate_review_md
 from agentmux.workflow.phase_helpers import (
     select_reviewer_roles,
     send_to_role,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.prompts import (
     build_reviewer_expert_prompt,
     build_reviewer_logic_prompt,

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -48,6 +48,12 @@ _REVIEWER_PROMPT_BUILDERS = {
 }
 
 
+def _all_done(active_reviews: dict) -> bool:
+    return bool(active_reviews) and all(
+        s == "completed" for s in active_reviews.values()
+    )
+
+
 def _summary_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
     return bool(state.get("awaiting_summary")) and ctx.files.summary.exists()
 
@@ -207,21 +213,21 @@ class ReviewingHandler(BaseToolHandler):
     ) -> tuple[dict, str | None]:
         """Handle review submission via tool event.
 
-        Scans all role-specific review_*.yaml files, aggregates verdicts,
-        and either triggers fixing (first fail) or summary (all pass).
+        Scans every role-specific review_*.yaml file available at event time,
+        aggregates verdicts, and only after the full scan decides the verdict.
+        This avoids dropping feedback when two reviewers fail concurrently or
+        when a fail would short-circuit a sibling's still-unread file.
         """
         review_results = dict(state.get("review_results", {}))
         active_reviews = dict(state.get("active_reviews", {}))
         review_iteration = int(state.get("review_iteration", 0))
 
-        # Scan all review_<role>.yaml files
         review_dir = ctx.files.review_dir
         for review_file in sorted(review_dir.glob("review_reviewer_*.yaml")):
-            # Extract role from filename: review_<role>.yaml
             role_name = review_file.stem[len("review_") :]
 
             if role_name in review_results:
-                continue  # Already processed
+                continue
 
             try:
                 data = yaml.safe_load(review_file.read_text(encoding="utf-8"))
@@ -233,13 +239,11 @@ class ReviewingHandler(BaseToolHandler):
             if verdict not in ("pass", "fail"):
                 continue
 
-            # Load review text and archive it
             review_text = self._generate_review_text(data)
             archive_path = review_dir / f"review_{review_iteration}_{role_name}.md"
             if review_text is not None:
                 archive_path.write_text(review_text, encoding="utf-8")
 
-            # Store result
             review_results[role_name] = {
                 "verdict": verdict,
                 "review_text": review_text or "",
@@ -247,24 +251,34 @@ class ReviewingHandler(BaseToolHandler):
             if role_name in active_reviews:
                 active_reviews[role_name] = "completed"
 
-            # Handle verdict
-            if verdict == "fail":
-                return self._handle_fail(
-                    state, ctx, review_results, active_reviews, review_iteration
-                )
+        any_failed = any(r.get("verdict") == "fail" for r in review_results.values())
+        if any_failed:
+            self._kill_pending_reviewers(ctx, active_reviews)
+            return self._handle_fail(
+                state, ctx, review_results, active_reviews, review_iteration
+            )
 
-        # Check if all reviewers are done
-        all_completed = all(s == "completed" for s in active_reviews.values())
-        if all_completed and active_reviews:
-            all_pass = all(r.get("verdict") == "pass" for r in review_results.values())
-            if all_pass:
-                return self._request_summary(state, ctx)
+        if _all_done(active_reviews):
+            return self._request_summary(state, ctx)
 
-        # Update state, no transition yet
         return {
             "review_results": review_results,
             "active_reviews": active_reviews,
         }, None
+
+    def _kill_pending_reviewers(
+        self, ctx: PipelineContext, active_reviews: dict
+    ) -> None:
+        """Tear down reviewer panes that are still marked 'pending'.
+
+        Called whenever we abandon the reviewing phase before every reviewer
+        has submitted — prevents leaked reviewer panes running against stale
+        code once fixing has started.
+        """
+        for role, status in list(active_reviews.items()):
+            if status == "pending":
+                ctx.runtime.kill_primary(role)
+                active_reviews[role] = "killed"
 
     def _generate_review_text(self, data: dict) -> str | None:
         """Generate review markdown from an already-parsed review data dict."""
@@ -355,6 +369,12 @@ class ReviewingHandler(BaseToolHandler):
         # Use the first role as coordinator (typically "logic")
         first = reviewer_roles[0] if reviewer_roles else "logic"
         coordinator_role = _REVIEWER_ROLE_MAP.get(first, "reviewer_logic")
+
+        # All reviewers have passed — the coder panes are no longer needed.
+        # Tear them down before dispatching the summary so we don't leak
+        # implementation panes across the summary/completing transition.
+        ctx.runtime.finish_many("coder")
+        ctx.runtime.kill_primary("coder")
 
         # Clear any stale summary from a previous run
         if ctx.files.summary.exists():

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -15,10 +15,13 @@ from agentmux.workflow.event_catalog import (
     EVENT_REVIEW_PASSED,
 )
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
-from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
+from agentmux.workflow.handlers.base import (
+    BaseToolHandler,
+    PhaseResult,
+    ToolHandlerEntry,
+)
 from agentmux.workflow.handoff_artifacts import generate_review_md
 from agentmux.workflow.phase_helpers import (
-    load_plan_meta,
     select_reviewer_roles,
     send_to_role,
 )
@@ -34,17 +37,19 @@ from agentmux.workflow.prompts import (
 if TYPE_CHECKING:
     from agentmux.workflow.transitions import PipelineContext
 
-_REVIEWER_ROLE_MAP = {
-    "logic": "reviewer_logic",
-    "quality": "reviewer_quality",
-    "expert": "reviewer_expert",
-}
+_ALLOWED_REVIEWER_ROLES = frozenset(
+    {
+        "reviewer_logic",
+        "reviewer_quality",
+        "reviewer_expert",
+    }
+)
 
-# Review prompt builders keyed by role suffix
-_REVIEWER_PROMPT_BUILDERS = {
-    "logic": build_reviewer_logic_prompt,
-    "quality": build_reviewer_quality_prompt,
-    "expert": build_reviewer_expert_prompt,
+# Review prompt builders keyed by full pane role name
+_REVIEWER_PROMPT_BUILDERS_BY_ROLE = {
+    "reviewer_logic": build_reviewer_logic_prompt,
+    "reviewer_quality": build_reviewer_quality_prompt,
+    "reviewer_expert": build_reviewer_expert_prompt,
 }
 
 
@@ -86,24 +91,33 @@ class ReviewingHandler(BaseToolHandler):
     # enter() — parallel reviewer dispatch
     # -------------------------------------------------------------------------
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Called when entering reviewing phase.
 
         Dispatches reviewer roles in parallel via send_reviewers_many().
         On resume, skips reviewers that already have results in review_results.
         """
-        plan_meta = load_plan_meta(ctx.files.planning_dir)
-        reviewer_roles = select_reviewer_roles(plan_meta)
+        reviewer_roles = select_reviewer_roles(state)
 
         # Determine which roles still need reviewing (resume support)
         review_results = dict(state.get("review_results", {}))
-        active_reviews = {
-            _REVIEWER_ROLE_MAP[role]: "pending" for role in reviewer_roles
-        }
+        active_reviews = {role: "pending" for role in reviewer_roles}
 
-        # On resume: skip completed reviewers
+        # On resume: ingest pre-existing YAML verdicts before deleting anything
         is_resume = state.get("last_event") == EVENT_RESUMED
         if is_resume:
+            review_iteration = int(state.get("review_iteration", 0))
+            for role in list(active_reviews.keys()):
+                if role not in review_results:
+                    self._ingest_review_yaml(
+                        ctx.files.review_dir,
+                        role,
+                        review_results,
+                        active_reviews,
+                        review_iteration,
+                    )
+
+            # Mark completed from review_results
             for role in list(active_reviews.keys()):
                 if role in review_results:
                     active_reviews[role] = "completed"
@@ -111,21 +125,25 @@ class ReviewingHandler(BaseToolHandler):
             # If all are already completed, transition to summary or fixing
             all_completed = all(s == "completed" for s in active_reviews.values())
             if all_completed and active_reviews:
-                # Check if any review was a fail
                 any_failed = any(
-                    review_results.get(_REVIEWER_ROLE_MAP.get(r, r), {}).get("verdict")
-                    == "fail"
-                    for r in reviewer_roles
+                    review_results.get(r, {}).get("verdict") == "fail"
+                    for r in active_reviews
                 )
                 if any_failed:
-                    return self._trigger_fixing(state, ctx, review_results)
-                return self._request_summary(state, ctx)
+                    updates, next_phase = self._trigger_fixing(
+                        state, ctx, review_results
+                    )
+                else:
+                    updates, next_phase = self._request_summary(state, ctx)
+                # Ensure ingested results are carried forward
+                updates["review_results"] = review_results
+                updates["active_reviews"] = active_reviews
+                return PhaseResult(updates, next_phase)
 
         # Clear stale review outputs for roles we're about to re-dispatch
-        for role_suffix in reviewer_roles:
-            pane_role = _REVIEWER_ROLE_MAP[role_suffix]
-            if active_reviews.get(pane_role) == "pending":
-                review_file = ctx.files.review_dir / f"review_{pane_role}.yaml"
+        for role in reviewer_roles:
+            if active_reviews.get(role) == "pending":
+                review_file = ctx.files.review_dir / f"review_{role}.yaml"
                 if review_file.exists():
                     review_file.unlink()
 
@@ -138,10 +156,12 @@ class ReviewingHandler(BaseToolHandler):
             ctx.runtime.send_reviewers_many(reviewer_specs)
 
         # Initialize state
-        return {
-            "active_reviews": active_reviews,
-            "review_results": review_results,
-        }
+        return PhaseResult(
+            {
+                "active_reviews": active_reviews,
+                "review_results": review_results,
+            }
+        )
 
     def _build_reviewer_specs(
         self,
@@ -152,12 +172,11 @@ class ReviewingHandler(BaseToolHandler):
     ) -> list[ReviewerSpec]:
         """Build ReviewerSpec list for roles that still need reviewing."""
         specs: list[ReviewerSpec] = []
-        for role_suffix in reviewer_roles:
-            pane_role = _REVIEWER_ROLE_MAP[role_suffix]
+        for pane_role in reviewer_roles:
             if active_reviews.get(pane_role) != "pending":
                 continue
 
-            prompt_builder = _REVIEWER_PROMPT_BUILDERS.get(role_suffix)
+            prompt_builder = _REVIEWER_PROMPT_BUILDERS_BY_ROLE.get(pane_role)
             if prompt_builder is None:
                 # Fallback: generic reviewer
                 agent_prompt = build_reviewer_prompt(
@@ -169,7 +188,7 @@ class ReviewingHandler(BaseToolHandler):
                 full_prompt = prompt_builder(ctx.files, ctx.agents.get(pane_role))
 
             # Write the prompt to a role-specific file
-            prompt_filename = f"review_{role_suffix}_prompt.md"
+            prompt_filename = f"review_{pane_role}_prompt.md"
             prompt_path = ctx.files.review_dir / prompt_filename
             prompt_path.parent.mkdir(parents=True, exist_ok=True)
             prompt_path.write_text(full_prompt, encoding="utf-8")
@@ -185,6 +204,47 @@ class ReviewingHandler(BaseToolHandler):
                 )
             )
         return specs
+
+    # -------------------------------------------------------------------------
+    # _ingest_review_yaml — shared YAML parsing for resume and _handle_review
+    # -------------------------------------------------------------------------
+
+    def _ingest_review_yaml(
+        self,
+        review_dir,
+        role: str,
+        review_results: dict,
+        active_reviews: dict,
+        review_iteration: int,
+    ) -> None:
+        """Parse a role-specific review YAML and seed review_results if valid."""
+        review_file = review_dir / f"review_{role}.yaml"
+        if not review_file.exists():
+            return
+        if role in review_results:
+            return
+
+        try:
+            data = yaml.safe_load(review_file.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError):
+            return
+        if not isinstance(data, dict):
+            return
+        verdict = data.get("verdict", "").lower()
+        if verdict not in ("pass", "fail"):
+            return
+
+        review_text = self._generate_review_text(data)
+        archive_path = review_dir / f"review_{review_iteration}_{role}.md"
+        if review_text is not None:
+            archive_path.write_text(review_text, encoding="utf-8")
+
+        review_results[role] = {
+            "verdict": verdict,
+            "review_text": review_text or "",
+        }
+        if role in active_reviews:
+            active_reviews[role] = "completed"
 
     # -------------------------------------------------------------------------
     # handle_event — dispatch to file or tool event handlers
@@ -225,31 +285,13 @@ class ReviewingHandler(BaseToolHandler):
         review_dir = ctx.files.review_dir
         for review_file in sorted(review_dir.glob("review_reviewer_*.yaml")):
             role_name = review_file.stem[len("review_") :]
-
-            if role_name in review_results:
-                continue
-
-            try:
-                data = yaml.safe_load(review_file.read_text(encoding="utf-8"))
-            except (yaml.YAMLError, OSError):
-                continue
-            if not isinstance(data, dict):
-                continue
-            verdict = data.get("verdict", "").lower()
-            if verdict not in ("pass", "fail"):
-                continue
-
-            review_text = self._generate_review_text(data)
-            archive_path = review_dir / f"review_{review_iteration}_{role_name}.md"
-            if review_text is not None:
-                archive_path.write_text(review_text, encoding="utf-8")
-
-            review_results[role_name] = {
-                "verdict": verdict,
-                "review_text": review_text or "",
-            }
-            if role_name in active_reviews:
-                active_reviews[role_name] = "completed"
+            self._ingest_review_yaml(
+                review_dir,
+                role_name,
+                review_results,
+                active_reviews,
+                review_iteration,
+            )
 
         any_failed = any(r.get("verdict") == "fail" for r in review_results.values())
         if any_failed:
@@ -362,13 +404,16 @@ class ReviewingHandler(BaseToolHandler):
         """Send summary prompt to reviewer and wait for summary.md.
 
         Only called when ALL active reviewers have passed.
-        Sends to reviewer_logic as the coordinator role.
+        Sends to the first nominated role as coordinator.
         """
-        plan_meta = load_plan_meta(ctx.files.planning_dir)
-        reviewer_roles = select_reviewer_roles(plan_meta)
-        # Use the first role as coordinator (typically "logic")
-        first = reviewer_roles[0] if reviewer_roles else "logic"
-        coordinator_role = _REVIEWER_ROLE_MAP.get(first, "reviewer_logic")
+        nominated = state.get("reviewer_nominations") or []
+        coordinator_role = (
+            nominated[0]
+            if isinstance(nominated, list)
+            and nominated
+            and nominated[0] in _ALLOWED_REVIEWER_ROLES
+            else "reviewer_logic"
+        )
 
         # All reviewers have passed — the coder panes are no longer needed.
         # Tear them down before dispatching the summary so we don't leak
@@ -406,12 +451,8 @@ class ReviewingHandler(BaseToolHandler):
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Summary is ready — kill all reviewer panes and move to completing."""
-        plan_meta = load_plan_meta(ctx.files.planning_dir)
-        reviewer_roles = select_reviewer_roles(plan_meta)
-
-        # Kill all reviewer panes
-        for role_suffix in reviewer_roles:
-            pane_role = _REVIEWER_ROLE_MAP[role_suffix]
+        # Kill every known reviewer pane — safer than guessing which ones ran.
+        for pane_role in _ALLOWED_REVIEWER_ROLES:
             ctx.runtime.kill_primary(pane_role)
 
         return {"awaiting_summary": False}, "completing"

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from agentmux.agent_labels import role_display_label
+from agentmux.runtime import ReviewerSpec
 from agentmux.workflow.event_catalog import (
     EVENT_RESUMED,
     EVENT_REVIEW_FAILED,
@@ -15,13 +16,10 @@ from agentmux.workflow.event_catalog import (
 )
 from agentmux.workflow.event_router import EventSpec, WorkflowEvent
 from agentmux.workflow.handlers.base import BaseToolHandler, ToolHandlerEntry
-from agentmux.workflow.handoff_artifacts import (
-    load_review_text,
-    review_yaml_has_verdict,
-)
+from agentmux.workflow.handoff_artifacts import generate_review_md
 from agentmux.workflow.phase_helpers import (
     load_plan_meta,
-    select_reviewer_type,
+    select_reviewer_roles,
     send_to_role,
 )
 from agentmux.workflow.prompts import (
@@ -42,6 +40,13 @@ _REVIEWER_ROLE_MAP = {
     "expert": "reviewer_expert",
 }
 
+# Review prompt builders keyed by role suffix
+_REVIEWER_PROMPT_BUILDERS = {
+    "logic": build_reviewer_logic_prompt,
+    "quality": build_reviewer_quality_prompt,
+    "expert": build_reviewer_expert_prompt,
+}
+
 
 def _summary_ready(path: str, ctx: PipelineContext, state: dict) -> bool:
     return bool(state.get("awaiting_summary")) and ctx.files.summary.exists()
@@ -57,7 +62,7 @@ _SPECS = (
 
 
 class ReviewingHandler(BaseToolHandler):
-    """Event-driven handler for reviewing phase."""
+    """Event-driven handler for reviewing phase with parallel reviewer support."""
 
     def _get_tool_handlers(self) -> tuple[ToolHandlerEntry, ...]:
         return (
@@ -71,87 +76,113 @@ class ReviewingHandler(BaseToolHandler):
     def get_event_specs(self) -> Sequence[EventSpec]:
         return _SPECS
 
+    # -------------------------------------------------------------------------
+    # enter() — parallel reviewer dispatch
+    # -------------------------------------------------------------------------
+
     def enter(self, state: dict, ctx: PipelineContext) -> dict:
         """Called when entering reviewing phase.
 
-        Sends reviewer prompt based on review_strategy routing.
+        Dispatches reviewer roles in parallel via send_reviewers_many().
+        On resume, skips reviewers that already have results in review_results.
         """
-        # On resume, if the reviewer already wrote review output leave it in
-        # place. seed_existing_files() will publish file events and handle_event()
-        # will process the verdict correctly.
-        if state.get("last_event") == EVENT_RESUMED and (
-            ctx.files.review.exists() or review_yaml_has_verdict(ctx.files.review_dir)
-        ):
-            return {}
-
-        if ctx.files.review.exists():
-            ctx.files.review.unlink()
-        review_yaml = ctx.files.review_dir / "review.yaml"
-        if review_yaml.exists():
-            review_yaml.unlink()
-
-        # Load plan_meta and determine reviewer type
         plan_meta = load_plan_meta(ctx.files.planning_dir)
-        reviewer_type = select_reviewer_type(plan_meta)
+        reviewer_roles = select_reviewer_roles(plan_meta)
 
-        # Map reviewer types to their configuration
-        reviewer_config = {
-            "logic": {
-                "role": "reviewer_logic",
-                "prompt_builder": build_reviewer_logic_prompt,
-                "prompt_path": ctx.files.review_logic_prompt,
-            },
-            "quality": {
-                "role": "reviewer_quality",
-                "prompt_builder": build_reviewer_quality_prompt,
-                "prompt_path": ctx.files.review_quality_prompt,
-            },
-            "expert": {
-                "role": "reviewer_expert",
-                "prompt_builder": build_reviewer_expert_prompt,
-                "prompt_path": ctx.files.review_expert_prompt,
-            },
+        # Determine which roles still need reviewing (resume support)
+        review_results = dict(state.get("review_results", {}))
+        active_reviews = {
+            _REVIEWER_ROLE_MAP[role]: "pending" for role in reviewer_roles
         }
 
-        config = reviewer_config[reviewer_type]
+        # On resume: skip completed reviewers
+        is_resume = state.get("last_event") == EVENT_RESUMED
+        if is_resume:
+            for role in list(active_reviews.keys()):
+                if role in review_results:
+                    active_reviews[role] = "completed"
 
-        # Build the prompt: specialized agent prompts are self-contained,
-        # the generic reviewer combines agent prompt + command prompt.
-        reviewer_role = config["role"]
-        if reviewer_type == "logic":
-            full_prompt = build_reviewer_logic_prompt(
-                ctx.files, ctx.agents.get(reviewer_role)
-            )
-        elif reviewer_type == "quality":
-            full_prompt = build_reviewer_quality_prompt(
-                ctx.files, ctx.agents.get(reviewer_role)
-            )
-        elif reviewer_type == "expert":
-            full_prompt = build_reviewer_expert_prompt(
-                ctx.files, ctx.agents.get(reviewer_role)
-            )
-        else:
-            # Fallback: generic reviewer combines agent + command prompt
-            agent_prompt = build_reviewer_prompt(
-                ctx.files, agent=ctx.agents.get(reviewer_role)
-            )
-            command_prompt = build_reviewer_prompt(ctx.files, is_review=True)
-            full_prompt = f"{agent_prompt}\n\n{command_prompt}"
+            # If all are already completed, transition to summary or fixing
+            all_completed = all(s == "completed" for s in active_reviews.values())
+            if all_completed and active_reviews:
+                # Check if any review was a fail
+                any_failed = any(
+                    review_results.get(_REVIEWER_ROLE_MAP.get(r, r), {}).get("verdict")
+                    == "fail"
+                    for r in reviewer_roles
+                )
+                if any_failed:
+                    return self._trigger_fixing(state, ctx, review_results)
+                return self._request_summary(state, ctx)
 
-        prompt_file = write_prompt_file(
-            ctx.files.feature_dir,
-            ctx.files.relative_path(config["prompt_path"]),
-            full_prompt,
+        # Clear stale review outputs for roles we're about to re-dispatch
+        for role_suffix in reviewer_roles:
+            pane_role = _REVIEWER_ROLE_MAP[role_suffix]
+            if active_reviews.get(pane_role) == "pending":
+                review_file = ctx.files.review_dir / f"review_{pane_role}.yaml"
+                if review_file.exists():
+                    review_file.unlink()
+
+        # Build ReviewerSpec list for pending roles only
+        reviewer_specs = self._build_reviewer_specs(
+            reviewer_roles, active_reviews, ctx, state
         )
-        send_to_role(
-            ctx,
-            config["role"],
-            prompt_file,
-            display_label=role_display_label(
-                ctx.files.feature_dir, config["role"], state=state
-            ),
-        )
-        return {}
+
+        if reviewer_specs:
+            ctx.runtime.send_reviewers_many(reviewer_specs)
+
+        # Initialize state
+        return {
+            "active_reviews": active_reviews,
+            "review_results": review_results,
+        }
+
+    def _build_reviewer_specs(
+        self,
+        reviewer_roles: list[str],
+        active_reviews: dict[str, str],
+        ctx: PipelineContext,
+        state: dict,
+    ) -> list[ReviewerSpec]:
+        """Build ReviewerSpec list for roles that still need reviewing."""
+        specs: list[ReviewerSpec] = []
+        for role_suffix in reviewer_roles:
+            pane_role = _REVIEWER_ROLE_MAP[role_suffix]
+            if active_reviews.get(pane_role) != "pending":
+                continue
+
+            prompt_builder = _REVIEWER_PROMPT_BUILDERS.get(role_suffix)
+            if prompt_builder is None:
+                # Fallback: generic reviewer
+                agent_prompt = build_reviewer_prompt(
+                    ctx.files, agent=ctx.agents.get(pane_role)
+                )
+                command_prompt = build_reviewer_prompt(ctx.files, is_review=True)
+                full_prompt = f"{agent_prompt}\n\n{command_prompt}"
+            else:
+                full_prompt = prompt_builder(ctx.files, ctx.agents.get(pane_role))
+
+            # Write the prompt to a role-specific file
+            prompt_filename = f"review_{role_suffix}_prompt.md"
+            prompt_path = ctx.files.review_dir / prompt_filename
+            prompt_path.parent.mkdir(parents=True, exist_ok=True)
+            prompt_path.write_text(full_prompt, encoding="utf-8")
+            prompt_file = ctx.files.relative_path(prompt_path)
+
+            specs.append(
+                ReviewerSpec(
+                    role=pane_role,
+                    prompt_file=prompt_file,
+                    display_label=role_display_label(
+                        ctx.files.feature_dir, pane_role, state=state
+                    ),
+                )
+            )
+        return specs
+
+    # -------------------------------------------------------------------------
+    # handle_event — dispatch to file or tool event handlers
+    # -------------------------------------------------------------------------
 
     def handle_event(
         self,
@@ -160,11 +191,13 @@ class ReviewingHandler(BaseToolHandler):
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
         """Handle events: Tool-Events via base, File-Events via EventSpec."""
-        # File events from EventSpec
         if event.kind == "summary_ready":
             return self._handle_summary_written(ctx)
-        # Tool events from BaseToolHandler
         return super().handle_event(event, state, ctx)
+
+    # -------------------------------------------------------------------------
+    # _handle_review — verdict aggregation
+    # -------------------------------------------------------------------------
 
     def _handle_review(
         self,
@@ -172,49 +205,156 @@ class ReviewingHandler(BaseToolHandler):
         state: dict,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Handle review submission via tool event."""
-        # YAML is agent-written and already validated by the MCP signal tool.
-        yaml_path = ctx.files.review_dir / "review.yaml"
-        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-        verdict = data.get("verdict", "").lower()
+        """Handle review submission via tool event.
 
+        Scans all role-specific review_*.yaml files, aggregates verdicts,
+        and either triggers fixing (first fail) or summary (all pass).
+        """
+        review_results = dict(state.get("review_results", {}))
+        active_reviews = dict(state.get("active_reviews", {}))
         review_iteration = int(state.get("review_iteration", 0))
 
-        # Archive this review for history (review_0.md, review_1.md, …).
-        archive_path = ctx.files.review_dir / f"review_{review_iteration}.md"
-        review_text = load_review_text(
-            ctx.files.review_dir,
-            materialize_markdown=True,
-        )
-        if review_text is not None:
-            archive_path.write_text(review_text, encoding="utf-8")
+        # Scan all review_<role>.yaml files
+        review_dir = ctx.files.review_dir
+        for review_file in sorted(review_dir.glob("review_reviewer_*.yaml")):
+            # Extract role from filename: review_<role>.yaml
+            role_name = review_file.stem[len("review_") :]
 
-        if verdict == "pass":
-            ctx.runtime.finish_many("coder")
-            ctx.runtime.kill_primary("coder")
-            return self._request_summary(state, ctx)
+            if role_name in review_results:
+                continue  # Already processed
 
-        if verdict == "fail":
-            if review_iteration >= ctx.max_review_iterations:
-                return {"last_event": EVENT_REVIEW_FAILED}, "completing"
+            try:
+                data = yaml.safe_load(review_file.read_text(encoding="utf-8"))
+            except (yaml.YAMLError, OSError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            verdict = data.get("verdict", "").lower()
+            if verdict not in ("pass", "fail"):
+                continue
 
-            ctx.files.fix_request.write_text(review_text or "", encoding="utf-8")
+            # Load review text and archive it
+            review_text = self._generate_review_text(data)
+            archive_path = review_dir / f"review_{review_iteration}_{role_name}.md"
+            if review_text is not None:
+                archive_path.write_text(review_text, encoding="utf-8")
+
+            # Store result
+            review_results[role_name] = {
+                "verdict": verdict,
+                "review_text": review_text or "",
+            }
+            if role_name in active_reviews:
+                active_reviews[role_name] = "completed"
+
+            # Handle verdict
+            if verdict == "fail":
+                return self._handle_fail(
+                    state, ctx, review_results, active_reviews, review_iteration
+                )
+
+        # Check if all reviewers are done
+        all_completed = all(s == "completed" for s in active_reviews.values())
+        if all_completed and active_reviews:
+            all_pass = all(r.get("verdict") == "pass" for r in review_results.values())
+            if all_pass:
+                return self._request_summary(state, ctx)
+
+        # Update state, no transition yet
+        return {
+            "review_results": review_results,
+            "active_reviews": active_reviews,
+        }, None
+
+    def _generate_review_text(self, data: dict) -> str | None:
+        """Generate review markdown from an already-parsed review data dict."""
+        if not isinstance(data, dict):
+            return None
+        return generate_review_md(data)
+
+    def _handle_fail(
+        self,
+        state: dict,
+        ctx: PipelineContext,
+        review_results: dict,
+        active_reviews: dict,
+        review_iteration: int,
+    ) -> tuple[dict, str | None]:
+        """Handle a fail verdict — aggregate feedback and trigger fixing."""
+        if review_iteration >= ctx.max_review_iterations:
             return {
                 "last_event": EVENT_REVIEW_FAILED,
-                "review_iteration": review_iteration + 1,
-            }, "fixing"
+                "review_results": review_results,
+                "active_reviews": active_reviews,
+            }, "completing"
 
-        return {}, None
+        # Aggregate feedback from ALL completed reviews
+        aggregated = self._aggregate_fix_feedback(review_results)
+        ctx.files.fix_request.write_text(aggregated, encoding="utf-8")
+
+        return {
+            "last_event": EVENT_REVIEW_FAILED,
+            "review_iteration": review_iteration + 1,
+            "review_results": review_results,
+            "active_reviews": active_reviews,
+        }, "fixing"
+
+    def _aggregate_fix_feedback(self, review_results: dict) -> str:
+        """Combine feedback from all completed reviews into fix_request.md."""
+        sections: list[str] = []
+        for role_name, result in sorted(review_results.items()):
+            review_text = result.get("review_text", "")
+            verdict = result.get("verdict", "unknown")
+            if not review_text:
+                continue
+            sections.append(f"## Review: {role_name} (verdict: {verdict})")
+            sections.append("")
+            sections.append(review_text)
+            sections.append("")
+        return "\n".join(sections)
+
+    def _trigger_fixing(
+        self,
+        state: dict,
+        ctx: PipelineContext,
+        review_results: dict,
+    ) -> tuple[dict, str | None]:
+        """Trigger fixing from resume when all reviews are already done."""
+        review_iteration = int(state.get("review_iteration", 0))
+        if review_iteration >= ctx.max_review_iterations:
+            return {
+                "last_event": EVENT_REVIEW_FAILED,
+                "review_results": review_results,
+            }, "completing"
+
+        aggregated = self._aggregate_fix_feedback(review_results)
+        ctx.files.fix_request.write_text(aggregated, encoding="utf-8")
+
+        return {
+            "last_event": EVENT_REVIEW_FAILED,
+            "review_iteration": review_iteration + 1,
+            "review_results": review_results,
+        }, "fixing"
+
+    # -------------------------------------------------------------------------
+    # _request_summary — only after ALL reviews pass
+    # -------------------------------------------------------------------------
 
     def _request_summary(
         self,
         state: dict,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Send summary prompt to reviewer and wait for summary.md."""
+        """Send summary prompt to reviewer and wait for summary.md.
+
+        Only called when ALL active reviewers have passed.
+        Sends to reviewer_logic as the coordinator role.
+        """
         plan_meta = load_plan_meta(ctx.files.planning_dir)
-        reviewer_type = select_reviewer_type(plan_meta)
-        reviewer_role = _REVIEWER_ROLE_MAP[reviewer_type]
+        reviewer_roles = select_reviewer_roles(plan_meta)
+        # Use the first role as coordinator (typically "logic")
+        first = reviewer_roles[0] if reviewer_roles else "logic"
+        coordinator_role = _REVIEWER_ROLE_MAP.get(first, "reviewer_logic")
 
         # Clear any stale summary from a previous run
         if ctx.files.summary.exists():
@@ -225,25 +365,33 @@ class ReviewingHandler(BaseToolHandler):
         prompt_file = write_prompt_file(
             ctx.files.feature_dir,
             ctx.files.relative_path(summary_prompt_path),
-            build_reviewer_summary_prompt(ctx.files, ctx.agents.get(reviewer_role)),
+            build_reviewer_summary_prompt(ctx.files, ctx.agents.get(coordinator_role)),
         )
         send_to_role(
             ctx,
-            reviewer_role,
+            coordinator_role,
             prompt_file,
             display_label=role_display_label(
-                ctx.files.feature_dir, reviewer_role, state=state
+                ctx.files.feature_dir, coordinator_role, state=state
             ),
         )
         return {"last_event": EVENT_REVIEW_PASSED, "awaiting_summary": True}, None
+
+    # -------------------------------------------------------------------------
+    # _handle_summary_written — kill all reviewer panes
+    # -------------------------------------------------------------------------
 
     def _handle_summary_written(
         self,
         ctx: PipelineContext,
     ) -> tuple[dict, str | None]:
-        """Summary is ready — kill reviewer and move to completing."""
+        """Summary is ready — kill all reviewer panes and move to completing."""
         plan_meta = load_plan_meta(ctx.files.planning_dir)
-        reviewer_type = select_reviewer_type(plan_meta)
-        reviewer_role = _REVIEWER_ROLE_MAP[reviewer_type]
-        ctx.runtime.kill_primary(reviewer_role)
+        reviewer_roles = select_reviewer_roles(plan_meta)
+
+        # Kill all reviewer panes
+        for role_suffix in reviewer_roles:
+            pane_role = _REVIEWER_ROLE_MAP[role_suffix]
+            ctx.runtime.kill_primary(pane_role)
+
         return {"awaiting_summary": False}, "completing"

--- a/src/agentmux/workflow/handoff_artifacts.py
+++ b/src/agentmux/workflow/handoff_artifacts.py
@@ -96,7 +96,6 @@ def generate_execution_plan_yaml(data: dict[str, Any]) -> dict[str, Any]:
         )
     return {
         "groups": converted_groups,
-        "review_strategy": data.get("review_strategy", {}),
         "needs_design": data.get("needs_design", False),
         "needs_docs": data.get("needs_docs", False),
         "doc_files": data.get("doc_files", []),

--- a/src/agentmux/workflow/handoff_artifacts.py
+++ b/src/agentmux/workflow/handoff_artifacts.py
@@ -145,8 +145,21 @@ def _load_review_yaml_data(review_dir: Path) -> dict[str, Any] | None:
 
 
 def review_yaml_has_verdict(review_dir: Path) -> bool:
-    """Return True when review.yaml contains a valid review submission."""
-    return _load_review_yaml_data(review_dir) is not None
+    """Return True when any review YAML in review_dir contains a valid submission.
+
+    Checks the legacy review.yaml path first, then role-specific
+    review_reviewer_*.yaml files written by parallel reviewers.
+    """
+    if _load_review_yaml_data(review_dir) is not None:
+        return True
+    for review_file in review_dir.glob("review_reviewer_*.yaml"):
+        try:
+            data = yaml.safe_load(review_file.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if isinstance(data, dict) and data.get("verdict") in _VALID_REVIEW_VERDICTS:
+            return True
+    return False
 
 
 def load_review_text(

--- a/src/agentmux/workflow/handoff_contracts.py
+++ b/src/agentmux/workflow/handoff_contracts.py
@@ -83,8 +83,10 @@ PLAN_CONTRACT = HandoffContract(
         FieldSpec(
             name="review_strategy",
             type="dict",
+            required=False,
             description=(
-                "Review configuration: {severity: low|medium|high, focus: [...]}."
+                "Deprecated — reviewer selection is now via "
+                "submit_architecture(reviewers=[...])."
             ),
             example={"severity": "medium", "focus": ["security", "testing"]},
         ),
@@ -401,6 +403,7 @@ def _validate_plan(data: dict[str, Any], errors: list[str]) -> None:
                 f" missing: {missing_csv}."
             )
 
+    # Deprecated: kept for backward compat but not required.
     strategy = data.get("review_strategy")
     if isinstance(strategy, dict):
         sev = strategy.get("severity")

--- a/src/agentmux/workflow/phase_helpers.py
+++ b/src/agentmux/workflow/phase_helpers.py
@@ -74,7 +74,7 @@ def load_plan_meta(planning_dir: Path) -> dict[str, object]:
         return {}
     if not isinstance(data, dict):
         return {}
-    meta_keys = {"needs_design", "needs_docs", "doc_files", "review_strategy"}
+    meta_keys = {"needs_design", "needs_docs", "doc_files"}
     return {k: v for k, v in data.items() if k in meta_keys}
 
 
@@ -276,51 +276,29 @@ def research_role_from_payload(payload: dict) -> str | None:
     return None
 
 
-def select_reviewer_roles(plan_meta: dict) -> list[str]:
-    """Select reviewer roles based on plan_meta review_strategy.
+_ALLOWED_REVIEWER_ROLES = frozenset(
+    {
+        "reviewer_logic",
+        "reviewer_quality",
+        "reviewer_expert",
+    }
+)
 
-    Replaces select_reviewer_type() — returns a list of role suffixes
-    instead of a single reviewer type string.
+
+def select_reviewer_roles(state: dict) -> list[str]:
+    """Select reviewer roles from the architect's nominations in state.
+
+    Replaces the old severity/focus matrix — the architect now explicitly
+    nominates which reviewers should run via submit_architecture(reviewers= [...]).
 
     Args:
-        plan_meta: The plan_meta dictionary from 02_planning/execution_plan.yaml
+        state: The current state dict (may be empty for fallback calls).
 
     Returns:
-        List of role suffixes: ["quality"], ["logic"], or ["expert"]
-
-    Rules:
-        - Missing review_strategy -> ["logic"] (default)
-        - low severity -> ["quality"]
-        - medium severity + no security/performance in focus -> ["logic"]
-        - medium severity + security OR performance in focus -> ["expert"]
-        - high severity + no security/performance in focus -> ["logic"]
-        - high severity + security OR performance in focus -> ["expert"]
+        List of full pane role names, e.g. ["reviewer_logic", "reviewer_quality"].
+        Defaults to ["reviewer_logic"] when no valid nominations exist.
     """
-    review_strategy = plan_meta.get("review_strategy")
-    if not review_strategy:
-        return ["logic"]
-
-    severity = review_strategy.get("severity", "").lower()
-    focus = review_strategy.get("focus", [])
-
-    # Normalize focus to lowercase strings for comparison
-    focus_lower = set()
-    for item in focus:
-        if isinstance(item, str):
-            focus_lower.add(item.lower())
-
-    has_security_focus = "security" in focus_lower
-    has_performance_focus = "performance" in focus_lower
-    needs_expert = has_security_focus or has_performance_focus
-
-    if severity == "low":
-        return ["quality"]
-
-    if severity == "medium":
-        return ["expert"] if needs_expert else ["logic"]
-
-    if severity == "high":
-        return ["expert"] if needs_expert else ["logic"]
-
-    # Default fallback for unknown severity
-    return ["logic"]
+    nominated = state.get("reviewer_nominations") or []
+    if not isinstance(nominated, list) or not nominated:
+        return ["reviewer_logic"]
+    return [r for r in nominated if r in _ALLOWED_REVIEWER_ROLES] or ["reviewer_logic"]

--- a/src/agentmux/workflow/phase_helpers.py
+++ b/src/agentmux/workflow/phase_helpers.py
@@ -276,26 +276,29 @@ def research_role_from_payload(payload: dict) -> str | None:
     return None
 
 
-def select_reviewer_type(plan_meta: dict) -> str:
-    """Select the appropriate reviewer type based on plan_meta review_strategy.
+def select_reviewer_roles(plan_meta: dict) -> list[str]:
+    """Select reviewer roles based on plan_meta review_strategy.
+
+    Replaces select_reviewer_type() — returns a list of role suffixes
+    instead of a single reviewer type string.
 
     Args:
         plan_meta: The plan_meta dictionary from 02_planning/execution_plan.yaml
 
     Returns:
-        One of "logic" | "quality" | "expert"
+        List of role suffixes: ["quality"], ["logic"], or ["expert"]
 
     Rules:
-        - Missing review_strategy -> "logic" (default)
-        - low severity -> "quality"
-        - medium severity + no security/performance in focus -> "logic"
-        - medium severity + security OR performance in focus -> "expert"
-        - high severity + no security/performance in focus -> "logic"
-        - high severity + security OR performance in focus -> "expert"
+        - Missing review_strategy -> ["logic"] (default)
+        - low severity -> ["quality"]
+        - medium severity + no security/performance in focus -> ["logic"]
+        - medium severity + security OR performance in focus -> ["expert"]
+        - high severity + no security/performance in focus -> ["logic"]
+        - high severity + security OR performance in focus -> ["expert"]
     """
     review_strategy = plan_meta.get("review_strategy")
     if not review_strategy:
-        return "logic"
+        return ["logic"]
 
     severity = review_strategy.get("severity", "").lower()
     focus = review_strategy.get("focus", [])
@@ -311,13 +314,13 @@ def select_reviewer_type(plan_meta: dict) -> str:
     needs_expert = has_security_focus or has_performance_focus
 
     if severity == "low":
-        return "quality"
+        return ["quality"]
 
     if severity == "medium":
-        return "expert" if needs_expert else "logic"
+        return ["expert"] if needs_expert else ["logic"]
 
     if severity == "high":
-        return "expert" if needs_expert else "logic"
+        return ["expert"] if needs_expert else ["logic"]
 
     # Default fallback for unknown severity
-    return "logic"
+    return ["logic"]

--- a/src/agentmux/workflow/phase_registry.py
+++ b/src/agentmux/workflow/phase_registry.py
@@ -37,7 +37,7 @@ from .handlers.planning import PlanningHandler
 from .handlers.product_management import ProductManagementHandler
 from .handlers.reviewing import ReviewingHandler
 from .handoff_artifacts import review_yaml_has_verdict
-from .phase_helpers import select_reviewer_type
+from .phase_helpers import select_reviewer_roles
 
 # ---------------------------------------------------------------------------
 # Resume-check helpers (extracted from sessions/state_store.infer_resume_phase)
@@ -158,7 +158,8 @@ def _reviewing_startup_role(
         if isinstance(loaded, dict):
             plan_meta = loaded
 
-    reviewer_type = select_reviewer_type(plan_meta)
+    reviewer_roles = select_reviewer_roles(plan_meta)
+    reviewer_type = reviewer_roles[0] if reviewer_roles else "logic"
     reviewer_role = {
         "logic": "reviewer_logic",
         "quality": "reviewer_quality",

--- a/src/agentmux/workflow/phase_registry.py
+++ b/src/agentmux/workflow/phase_registry.py
@@ -145,26 +145,9 @@ def _designing_needed_and_done(feature_dir: Path, state: dict[str, Any]) -> bool
 def _reviewing_startup_role(
     feature_dir: Path, state: dict[str, Any], agents: dict[str, Any]
 ) -> str | None:
-    import yaml
-
-    _ = state
-    ep_path = feature_dir / "04_planning" / "execution_plan.yaml"
-    plan_meta: dict[str, Any] = {}
-    if ep_path.exists():
-        try:
-            loaded = yaml.safe_load(ep_path.read_text(encoding="utf-8"))
-        except (yaml.YAMLError, OSError):
-            loaded = {}
-        if isinstance(loaded, dict):
-            plan_meta = loaded
-
-    reviewer_roles = select_reviewer_roles(plan_meta)
-    reviewer_type = reviewer_roles[0] if reviewer_roles else "logic"
-    reviewer_role = {
-        "logic": "reviewer_logic",
-        "quality": "reviewer_quality",
-        "expert": "reviewer_expert",
-    }[reviewer_type]
+    _ = feature_dir
+    reviewer_roles = select_reviewer_roles(state)
+    reviewer_role = reviewer_roles[0] if reviewer_roles else "reviewer_logic"
     if reviewer_role in agents:
         return reviewer_role
     return None

--- a/src/agentmux/workflow/phase_result.py
+++ b/src/agentmux/workflow/phase_result.py
@@ -1,0 +1,21 @@
+"""Phase result types for workflow handlers.
+
+This module defines the PhaseResult NamedTuple used by all phase handlers
+for their enter() method return type.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class PhaseResult(NamedTuple):
+    """Uniform return type for handler enter() methods.
+
+    Attributes:
+        updates: Dict of state updates to apply.
+        next_phase: Optional phase name to transition to immediately.
+    """
+
+    updates: dict
+    next_phase: str | None = None

--- a/src/agentmux/workflow/prompts.py
+++ b/src/agentmux/workflow/prompts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -119,17 +120,48 @@ def write_prompt_file(feature_dir: Path, name: str, content: str) -> Path:
 
 
 def _build_research_handoff(files: RuntimeFiles) -> str:
+    """Build a research handoff section from completed research tasks.
+
+    Uses state.json as the source of truth for completion status (the
+    submit_research_done MCP tool writes events there rather than creating
+    physical 'done' marker files).
+    """
     research_dir = files.research_dir
     if not research_dir.is_dir():
         return ""
 
+    # Read completed tasks from state.json
+    state_file = files.feature_dir / "state.json"
+    if not state_file.exists():
+        return ""
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    done_code_tasks = {
+        k for k, v in state.get("research_tasks", {}).items() if v == "done"
+    }
+    done_web_tasks = {
+        k for k, v in state.get("web_research_tasks", {}).items() if v == "done"
+    }
+
     references: list[str] = []
     for topic_dir in sorted(path for path in research_dir.iterdir() if path.is_dir()):
-        done_path = topic_dir / "done"
         summary_path = topic_dir / "summary.md"
         detail_path = topic_dir / "detail.md"
-        if not done_path.is_file() or not summary_path.is_file():
+
+        # Determine completion from state based on topic prefix
+        topic = topic_dir.name
+        is_done = False
+        if (
+            topic.startswith("code-")
+            and topic[5:] in done_code_tasks
+            or topic.startswith("web-")
+            and topic[4:] in done_web_tasks
+        ):
+            is_done = True
+
+        if not is_done or not summary_path.is_file():
             continue
+
         references.append(f"- `{files.relative_path(summary_path)}` (primary)")
         if detail_path.is_file():
             references.append(
@@ -226,6 +258,7 @@ def build_reviewer_logic_prompt(
             "feature_dir": files.feature_dir,
             "project_dir": files.project_dir,
             "user_ask_tool": _user_ask_tool_for(agent),
+            "review_role": "reviewer_logic",
         },
     )
     return _expand_session_includes(rendered, files.feature_dir)
@@ -245,6 +278,7 @@ def build_reviewer_quality_prompt(
             "feature_dir": files.feature_dir,
             "project_dir": files.project_dir,
             "user_ask_tool": _user_ask_tool_for(agent),
+            "review_role": "reviewer_quality",
         },
     )
     return _expand_session_includes(rendered, files.feature_dir)
@@ -264,6 +298,7 @@ def build_reviewer_expert_prompt(
             "feature_dir": files.feature_dir,
             "project_dir": files.project_dir,
             "user_ask_tool": _user_ask_tool_for(agent),
+            "review_role": "reviewer_expert",
         },
     )
     return _expand_session_includes(rendered, files.feature_dir)

--- a/tests/integration/test_event_driven_workflow.py
+++ b/tests/integration/test_event_driven_workflow.py
@@ -37,6 +37,12 @@ class FakeRuntime:
             ("send", role, prompt_file.name, display_label, prefix_command)
         )
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
+
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(("send_many", role, len(prompt_specs)))
 
@@ -222,9 +228,9 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
             self.assertEqual("reviewing", state["phase"])
             self.assertEqual("implementation_completed", state["last_event"])
 
-            # 5. Reviewer writes review.yaml then submits via MCP tool
+            # 5. Reviewer writes review_reviewer_logic.yaml then submits via MCP tool
             ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
-            (ctx.files.review_dir / "review.yaml").write_text(
+            (ctx.files.review_dir / "review_reviewer_logic.yaml").write_text(
                 _yaml.safe_dump(
                     {
                         "verdict": "pass",
@@ -235,12 +241,28 @@ class TestEventDrivenWorkflowIntegration(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            # Create review.md for summary prompt include expansion
+            (ctx.files.review_dir / "review.md").write_text(
+                "verdict: pass\n\n## Summary\n\nAll checks pass.",
+                encoding="utf-8",
+            )
 
             event = WorkflowEvent(
                 kind="tool.submit_review",
                 payload={"payload": {}},
             )
-            updates, _ = router.handle(event, load_state(state_path), ctx)
+            with (
+                patch(
+                    "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                    return_value="summary prompt",
+                ),
+                patch(
+                    "agentmux.workflow.handlers.reviewing.write_prompt_file",
+                    return_value=Path("/tmp/prompt.md"),
+                ),
+                patch("agentmux.workflow.handlers.reviewing.send_to_role"),
+            ):
+                updates, _ = router.handle(event, load_state(state_path), ctx)
 
             # Still in reviewing, awaiting summary from reviewer
             state = load_state(state_path)

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -144,6 +144,12 @@ class SyncFakeRuntime:
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self._record("send_many", role, prompt_specs)
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self._record("send_reviewers_many", roles)
+        return {role: f"%pane_{role}" for role in roles}
+
     def spawn_task(self, role: str, task_id: str, research_dir: Path) -> None:
         self._record("spawn_task", role, task_id, research_dir)
 
@@ -399,7 +405,14 @@ def _write_review_pass(feature_dir: Path) -> None:
         "findings": [],
         "commit_message": "feat: implement feature",
     }
-    (d / "review.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+    (d / "review_reviewer_logic.yaml").write_text(
+        yaml.safe_dump(data), encoding="utf-8"
+    )
+    # Create review.md for summary prompt include expansion
+    (d / "review.md").write_text(
+        "verdict: pass\n\n## Summary\n\nAll checks pass, implementation is solid.",
+        encoding="utf-8",
+    )
 
 
 def _write_summary(
@@ -547,37 +560,15 @@ def test_happy_path_parallel_coders():
                 orchestrator=orchestrator,
             )
 
-            # Phase 4: reviewing — wait for reviewer prompt
-            runtime.wait_for_call("send", match={"role": "reviewer_logic"})
+            # Phase 4: reviewing — wait for reviewer dispatch via send_reviewers_many
+            runtime.wait_for_call("send_reviewers_many")
 
             # Simulate review pass
             _write_review_pass(feature_dir)
             _emit_tool(feature_dir, "submit_review", orchestrator=orchestrator)
 
-            # Wait for summary prompt to reviewer
-            # After review pass, the handler sends a summary prompt to the
-            # same reviewer — this is the second "send" to reviewer_logic
-            calls_before = len(
-                [
-                    c
-                    for c in runtime.calls
-                    if c.method == "send" and c.args[0] == "reviewer_logic"
-                ]
-            )
-            if calls_before < 2:
-                # Wait for the summary prompt
-                deadline = time.monotonic() + SYNC_TIMEOUT
-                while True:
-                    reviewer_sends = [
-                        c
-                        for c in runtime.calls
-                        if c.method == "send" and c.args[0] == "reviewer_logic"
-                    ]
-                    if len(reviewer_sends) >= 2:
-                        break
-                    if time.monotonic() > deadline:
-                        raise TimeoutError("Timed out waiting for summary prompt")
-                    time.sleep(0.1)
+            # Wait for summary prompt (send to reviewer_logic)
+            runtime.wait_for_call("send", match={"role": "reviewer_logic"})
 
             # Simulate summary written
             _write_summary(feature_dir, orchestrator=orchestrator)
@@ -701,24 +692,13 @@ def test_happy_path_pm_with_research():
                 orchestrator=orchestrator,
             )
 
-            # Phase 4: reviewing
-            runtime.wait_for_call("send", match={"role": "reviewer_logic"})
+            # Phase 4: reviewing — wait for reviewer dispatch via send_reviewers_many
+            runtime.wait_for_call("send_reviewers_many")
             _write_review_pass(feature_dir)
             _emit_tool(feature_dir, "submit_review", orchestrator=orchestrator)
 
-            # Wait for second reviewer_logic send (summary prompt)
-            deadline = time.monotonic() + SYNC_TIMEOUT
-            while True:
-                reviewer_sends = [
-                    c
-                    for c in runtime.calls
-                    if c.method == "send" and c.args[0] == "reviewer_logic"
-                ]
-                if len(reviewer_sends) >= 2:
-                    break
-                if time.monotonic() > deadline:
-                    raise TimeoutError("Timed out waiting for summary prompt")
-                time.sleep(0.1)
+            # Wait for summary prompt (send to reviewer_logic)
+            runtime.wait_for_call("send", match={"role": "reviewer_logic"})
 
             _write_summary(feature_dir, orchestrator=orchestrator)
             _wait_and_flush_approval(feature_dir, orchestrator)

--- a/tests/integration/test_parallel_reviewers.py
+++ b/tests/integration/test_parallel_reviewers.py
@@ -1,0 +1,192 @@
+"""Integrationstests: Mock paralleler Reviewer, State-Transitions.
+
+Simuliert den parallelen Review-Workflow:
+- Mehrere Reviewer senden submit_review Events
+- State-Transitions werden validiert (reviewing → fixing, reviewing → completing)
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from agentmux.workflow.handlers.reviewing import ReviewingHandler
+
+
+class FakeIntegrationContext:
+    """Fake PipelineContext for integration testing."""
+
+    def __init__(self, tmp_path, max_review_iterations=3):
+        self.feature_dir = tmp_path
+        self.files = MagicMock()
+        self.files.planning_dir = tmp_path / "02_planning"
+        self.files.planning_dir.mkdir(parents=True)
+        self.files.review = tmp_path / "07_review" / "review.md"
+        self.files.review_dir = tmp_path / "07_review"
+        self.files.review_dir.mkdir(parents=True)
+        self.files.fix_request = tmp_path / "06_implementation" / "fix_request.txt"
+        self.files.fix_request.parent.mkdir(parents=True)
+        self.files.completion_dir = tmp_path / "08_completion"
+        self.files.completion_dir.mkdir(parents=True)
+        self.files.summary = self.files.completion_dir / "summary.md"
+        self.files.relative_path = lambda p: p.relative_to(tmp_path)
+
+        self.runtime = MagicMock()
+        self.max_review_iterations = max_review_iterations
+        self.agents = {
+            "reviewer_logic": MagicMock(),
+            "reviewer_quality": MagicMock(),
+            "reviewer_expert": MagicMock(),
+        }
+
+        plan_meta = {"review_strategy": {"severity": "medium", "focus": []}}
+        (self.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(plan_meta, default_flow_style=False)
+        )
+
+    def submit_review(
+        self, verdict: str, findings: list | None = None, review_iteration: int = 0
+    ):
+        """Simulate a reviewer submitting a review."""
+        data = {"verdict": verdict, "summary": "Test summary"}
+        if findings:
+            data["findings"] = [
+                {"issue": f, "recommendation": "Fix it."} for f in findings
+            ]
+        # Write role-specific review file (logic reviewer is default)
+        (self.files.review_dir / "review_reviewer_logic.yaml").write_text(
+            yaml.dump(data, default_flow_style=False)
+        )
+        review_content = f"verdict: {verdict}\n"
+        if findings:
+            for f in findings:
+                review_content += f"- {f}\n"
+        self.files.review.write_text(review_content)
+
+
+class TestParallelReviewerStateTransitions:
+    """Test state transitions with simulated parallel reviewers."""
+
+    def test_first_fail_transitions_to_fixing(self, tmp_path):
+        """First reviewer fail → reviewing → fixing."""
+        ctx = FakeIntegrationContext(tmp_path)
+        ctx.submit_review("fail", findings=["critical bug"])
+
+        handler = ReviewingHandler()
+        role = "reviewer_logic"
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        assert state_update["review_iteration"] == 1
+        assert ctx.files.fix_request.exists()
+        assert "critical bug" in ctx.files.fix_request.read_text()
+
+    def test_all_pass_transitions_to_completing_flow(self, tmp_path):
+        """All reviewers pass → reviewing → completing (via summary)."""
+        ctx = FakeIntegrationContext(tmp_path)
+        ctx.submit_review("pass")
+        # Create review.md for summary prompt include expansion
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: pass\n\n## Summary\n\nNo issues.", encoding="utf-8"
+        )
+
+        handler = ReviewingHandler()
+        role = "reviewer_logic"
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        with (
+            patch(
+                "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                return_value="summary prompt",
+            ),
+            patch(
+                "agentmux.workflow.handlers.reviewing.write_prompt_file",
+                return_value=Path("/tmp/prompt.md"),
+            ),
+            patch("agentmux.workflow.handlers.reviewing.send_to_role"),
+        ):
+            state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        # Stays in reviewing, awaiting summary
+        assert next_phase is None
+        assert state_update.get("awaiting_summary") is True
+
+    def test_mixed_verdicts_fail_after_pass_transitions_to_fixing(self, tmp_path):
+        """Mixed verdicts: first pass, then fail → fixing."""
+        ctx = FakeIntegrationContext(tmp_path)
+        # Simulate second reviewer finding issues after first passed
+        ctx.submit_review("fail", findings=["regression found"])
+
+        handler = ReviewingHandler()
+        role = "reviewer_logic"
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        assert state_update["review_iteration"] == 1
+
+    def test_max_iterations_reached_transitions_to_completing(self, tmp_path):
+        """Fail at max_review_iterations → completing."""
+        ctx = FakeIntegrationContext(tmp_path, max_review_iterations=1)
+        ctx.submit_review("fail", findings=["still broken"])
+
+        handler = ReviewingHandler()
+        role = "reviewer_logic"
+        state = {
+            "review_iteration": 1,  # Already at max
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "completing"
+        assert state_update["last_event"] is not None
+        # fix_request should NOT be written when max iterations reached
+        assert not ctx.files.fix_request.exists()
+
+    def test_multiple_iterations_track_review_iteration(self, tmp_path):
+        """Review iteration counter increments correctly across fix cycles."""
+        ctx = FakeIntegrationContext(tmp_path)
+
+        handler = ReviewingHandler()
+        role = "reviewer_logic"
+        event = MagicMock()
+
+        # First fail
+        ctx.submit_review("fail", findings=["bug 1"])
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+        assert next_phase == "fixing"
+        assert state_update["review_iteration"] == 1
+
+        # Second fail
+        ctx.submit_review("fail", findings=["bug 2"])
+        state["review_iteration"] = state_update["review_iteration"]
+        state["active_reviews"] = {role: "pending"}
+        state_update2, next_phase2 = handler._handle_review(event, state, ctx)
+        assert next_phase2 == "fixing"
+        assert state_update2["review_iteration"] == 2

--- a/tests/test_code_researcher_requirements.py
+++ b/tests/test_code_researcher_requirements.py
@@ -33,6 +33,12 @@ class FakeRuntime:
     ) -> None:
         self.calls.append(("send", role, prompt_file.name, prefix_command))
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
+
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(
             (

--- a/tests/test_designer_requirements.py
+++ b/tests/test_designer_requirements.py
@@ -44,6 +44,12 @@ class FakeRuntime:
             ("send", role, prompt_file.name, display_label, prefix_command)
         )
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
+
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(
             (

--- a/tests/test_mcp_server_refactor.py
+++ b/tests/test_mcp_server_refactor.py
@@ -122,7 +122,7 @@ class TestSubmitArchitecture(_FeatureDirMixin, unittest.TestCase):
 
     def test_reads_file_appends_minimal_signal(self):
         self._write_md()
-        result = mrs.submit_architecture(feature_dir=str(self.feature_dir))
+        result = mrs.submit_architecture()
         self.assertIn("Architecture submitted", result)
         entries = self._read_log_entries()
         self.assertEqual(entries[0]["tool"], "submit_architecture")
@@ -130,20 +130,20 @@ class TestSubmitArchitecture(_FeatureDirMixin, unittest.TestCase):
 
     def test_does_not_write_any_extra_files(self):
         self._write_md()
-        mrs.submit_architecture(feature_dir=str(self.feature_dir))
+        mrs.submit_architecture()
         self.assertFalse(
             (self.feature_dir / "02_architecting" / "architecture.yaml").exists()
         )
 
     def test_raises_when_md_missing(self):
         with self.assertRaises(ValueError) as ctx:
-            mrs.submit_architecture(feature_dir=str(self.feature_dir))
+            mrs.submit_architecture()
         self.assertIn("architecture.md", str(ctx.exception))
 
     def test_raises_when_md_empty(self):
         self._write_md("   \n")
         with self.assertRaises(ValueError) as ctx:
-            mrs.submit_architecture(feature_dir=str(self.feature_dir))
+            mrs.submit_architecture()
         self.assertIn("empty", str(ctx.exception))
 
 
@@ -188,7 +188,7 @@ class TestSubmitPlan(_FeatureDirMixin, unittest.TestCase):
 
     def test_reads_file_appends_minimal_signal(self):
         self._write_yaml()
-        result = mrs.submit_plan(feature_dir=str(self.feature_dir))
+        result = mrs.submit_plan()
         self.assertIn("Plan submitted", result)
         entries = self._read_log_entries()
         self.assertEqual(entries[0]["tool"], "submit_plan")
@@ -196,7 +196,7 @@ class TestSubmitPlan(_FeatureDirMixin, unittest.TestCase):
 
     def test_does_not_write_any_extra_files(self):
         self._write_yaml()
-        mrs.submit_plan(feature_dir=str(self.feature_dir))
+        mrs.submit_plan()
         self.assertFalse((self.feature_dir / "04_planning" / "plan.md").exists())
         self.assertFalse(
             (self.feature_dir / "04_planning" / "execution_plan.yaml").exists()
@@ -204,7 +204,7 @@ class TestSubmitPlan(_FeatureDirMixin, unittest.TestCase):
 
     def test_raises_when_yaml_missing(self):
         with self.assertRaises(ValueError) as ctx:
-            mrs.submit_plan(feature_dir=str(self.feature_dir))
+            mrs.submit_plan()
         self.assertIn("plan.yaml", str(ctx.exception))
 
     def test_validation_error_on_bad_mode(self):
@@ -214,7 +214,7 @@ class TestSubmitPlan(_FeatureDirMixin, unittest.TestCase):
         ]
         self._write_yaml(bad)
         with self.assertRaises(ValueError) as ctx:
-            mrs.submit_plan(feature_dir=str(self.feature_dir))
+            mrs.submit_plan()
         self.assertIn("mode", str(ctx.exception))
 
     def test_validation_error_on_empty_subplans(self):
@@ -222,7 +222,7 @@ class TestSubmitPlan(_FeatureDirMixin, unittest.TestCase):
         bad["subplans"] = []
         self._write_yaml(bad)
         with self.assertRaises(ValueError):
-            mrs.submit_plan(feature_dir=str(self.feature_dir))
+            mrs.submit_plan()
 
 
 class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
@@ -239,7 +239,7 @@ class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
 
     def test_pass_reads_file_appends_minimal_signal(self):
         self._write_yaml(self._VALID_PASS)
-        result = mrs.submit_review(feature_dir=str(self.feature_dir))
+        result = mrs.submit_review()
         self.assertIn("verdict: pass", result)
         entries = self._read_log_entries()
         self.assertEqual(entries[0]["tool"], "submit_review")
@@ -247,12 +247,12 @@ class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
 
     def test_does_not_write_any_extra_files(self):
         self._write_yaml(self._VALID_PASS)
-        mrs.submit_review(feature_dir=str(self.feature_dir))
+        mrs.submit_review()
         self.assertFalse((self.feature_dir / "07_review" / "review.md").exists())
 
     def test_raises_when_yaml_missing(self):
         with self.assertRaises(ValueError) as ctx:
-            mrs.submit_review(feature_dir=str(self.feature_dir))
+            mrs.submit_review()
         self.assertIn("review.yaml", str(ctx.exception))
 
     def test_fail_with_findings_appends_empty_payload(self):
@@ -270,7 +270,7 @@ class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
                 ],
             }
         )
-        result = mrs.submit_review(feature_dir=str(self.feature_dir))
+        result = mrs.submit_review()
         self.assertIn("verdict: fail", result)
         entries = self._read_log_entries()
         self.assertEqual(entries[0]["payload"], {})
@@ -278,13 +278,13 @@ class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
     def test_fail_without_findings_raises(self):
         self._write_yaml({"verdict": "fail", "summary": "Bad"})
         with self.assertRaises(ValueError) as ctx:
-            mrs.submit_review(feature_dir=str(self.feature_dir))
+            mrs.submit_review()
         self.assertIn("findings", str(ctx.exception))
 
     def test_invalid_verdict_raises(self):
         self._write_yaml({"verdict": "maybe", "summary": "Unsure"})
         with self.assertRaises(ValueError):
-            mrs.submit_review(feature_dir=str(self.feature_dir))
+            mrs.submit_review()
 
     def test_optional_approved_preferences_accepted(self):
         data = {
@@ -295,7 +295,7 @@ class TestSubmitReview(_FeatureDirMixin, unittest.TestCase):
             },
         }
         self._write_yaml(data)
-        result = mrs.submit_review(feature_dir=str(self.feature_dir))
+        result = mrs.submit_review()
         self.assertIn("verdict: pass", result)
 
 
@@ -303,7 +303,7 @@ class TestSubmitDone(_FeatureDirMixin, unittest.TestCase):
     """Tests for new submit_done tool."""
 
     def test_valid_index_appends_and_returns_confirmation(self):
-        result = mrs.submit_done(subplan_index=1, feature_dir=str(self.feature_dir))
+        result = mrs.submit_done(subplan_index=1)
         self.assertEqual("Sub-plan 1 marked done.", result)
         entries = self._read_log_entries()
         self.assertEqual(len(entries), 1)
@@ -312,18 +312,18 @@ class TestSubmitDone(_FeatureDirMixin, unittest.TestCase):
 
     def test_rejects_index_zero(self):
         with self.assertRaises(ValueError):
-            mrs.submit_done(subplan_index=0, feature_dir=str(self.feature_dir))
+            mrs.submit_done(subplan_index=0)
 
     def test_rejects_negative_index(self):
         with self.assertRaises(ValueError):
-            mrs.submit_done(subplan_index=-1, feature_dir=str(self.feature_dir))
+            mrs.submit_done(subplan_index=-1)
 
     def test_rejects_non_integer(self):
         with self.assertRaises(ValueError):
-            mrs.submit_done(subplan_index="1", feature_dir=str(self.feature_dir))
+            mrs.submit_done(subplan_index="1")
 
     def test_accepts_higher_index(self):
-        result = mrs.submit_done(subplan_index=5, feature_dir=str(self.feature_dir))
+        result = mrs.submit_done(subplan_index=5)
         self.assertEqual("Sub-plan 5 marked done.", result)
         entries = self._read_log_entries()
         self.assertEqual(entries[0]["payload"]["subplan_index"], 5)
@@ -333,9 +333,7 @@ class TestSubmitResearchDone(_FeatureDirMixin, unittest.TestCase):
     """Tests for new submit_research_done tool."""
 
     def test_valid_code_type_appends(self):
-        result = mrs.submit_research_done(
-            topic="auth-module", type="code", feature_dir=str(self.feature_dir)
-        )
+        result = mrs.submit_research_done(topic="auth-module", type="code")
         self.assertEqual("Research on 'auth-module' (code) marked done.", result)
         entries = self._read_log_entries()
         self.assertEqual(len(entries), 1)
@@ -344,37 +342,29 @@ class TestSubmitResearchDone(_FeatureDirMixin, unittest.TestCase):
         self.assertEqual(entries[0]["payload"]["type"], "code")
 
     def test_valid_web_type_appends(self):
-        result = mrs.submit_research_done(
-            topic="sdk-compat", type="web", feature_dir=str(self.feature_dir)
-        )
+        result = mrs.submit_research_done(topic="sdk-compat", type="web")
         self.assertEqual("Research on 'sdk-compat' (web) marked done.", result)
         entries = self._read_log_entries()
         self.assertEqual(entries[0]["payload"]["type"], "web")
 
     def test_rejects_invalid_topic_slug(self):
         with self.assertRaises(ValueError):
-            mrs.submit_research_done(
-                topic="Bad_Topic", type="code", feature_dir=str(self.feature_dir)
-            )
+            mrs.submit_research_done(topic="Bad_Topic", type="code")
 
     def test_rejects_invalid_type(self):
         with self.assertRaises(ValueError):
-            mrs.submit_research_done(
-                topic="valid-topic", type="invalid", feature_dir=str(self.feature_dir)
-            )
+            mrs.submit_research_done(topic="valid-topic", type="invalid")
 
     def test_rejects_empty_topic(self):
         with self.assertRaises(ValueError):
-            mrs.submit_research_done(
-                topic="", type="code", feature_dir=str(self.feature_dir)
-            )
+            mrs.submit_research_done(topic="", type="code")
 
 
 class TestSubmitPmDone(_FeatureDirMixin, unittest.TestCase):
     """Tests for new submit_pm_done tool."""
 
     def test_appends_and_returns_confirmation(self):
-        result = mrs.submit_pm_done(feature_dir=str(self.feature_dir))
+        result = mrs.submit_pm_done()
         self.assertEqual("Product management phase done.", result)
         entries = self._read_log_entries()
         self.assertEqual(len(entries), 1)

--- a/tests/test_mcp_submit_tools.py
+++ b/tests/test_mcp_submit_tools.py
@@ -66,7 +66,6 @@ _VALID_PLAN = {
             "tasks": ["Create module", "Write tests"],
         }
     ],
-    "review_strategy": {"severity": "medium", "focus": ["security"]},
     "needs_design": False,
     "needs_docs": True,
     "doc_files": ["docs/api.md"],
@@ -122,6 +121,48 @@ class TestSubmitArchitecture(SubmitToolTestBase):
         with self.assertRaises(ValueError) as ctx:
             submit_architecture()
         self.assertIn("empty", str(ctx.exception))
+
+    def test_reviewers_valid_list_writes_to_log(self):
+        self._write_md()
+        from agentmux.integrations.mcp_server import submit_architecture
+
+        result = submit_architecture(reviewers=["reviewer_logic", "reviewer_expert"])
+        self.assertIn("Architecture submitted", result)
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_architecture")
+        self.assertEqual(
+            entries[0]["payload"],
+            {"reviewers": ["reviewer_logic", "reviewer_expert"]},
+        )
+
+    def test_reviewers_empty_list_ok(self):
+        self._write_md()
+        from agentmux.integrations.mcp_server import submit_architecture
+
+        result = submit_architecture(reviewers=[])
+        self.assertIn("Architecture submitted", result)
+        entries = self._read_log_entries()
+        # Empty list is explicitly written to the payload (architect nominated "none")
+        self.assertEqual(entries[0]["payload"], {"reviewers": []})
+
+    def test_reviewers_none_ok(self):
+        self._write_md()
+        from agentmux.integrations.mcp_server import submit_architecture
+
+        result = submit_architecture(reviewers=None)
+        self.assertIn("Architecture submitted", result)
+        entries = self._read_log_entries()
+        self.assertEqual(entries[0]["payload"], {})
+
+    def test_reviewers_unknown_role_raises(self):
+        self._write_md()
+        from agentmux.integrations.mcp_server import submit_architecture
+
+        with self.assertRaises(ValueError) as ctx:
+            submit_architecture(reviewers=["reviewer_logic", "bogus"])
+        self.assertIn("bogus", str(ctx.exception))
+        self.assertIn("reviewer_expert", str(ctx.exception))
 
 
 class TestSubmitPlan(SubmitToolTestBase):

--- a/tests/test_mcp_submit_tools.py
+++ b/tests/test_mcp_submit_tools.py
@@ -85,12 +85,10 @@ class TestSubmitArchitecture(SubmitToolTestBase):
         path.write_text(content, encoding="utf-8")
         return path
 
-    def _submit(self, feature_dir=None):
+    def _submit(self):
         from agentmux.integrations.mcp_server import submit_architecture
 
-        return submit_architecture(
-            feature_dir=feature_dir or str(self.feature_dir),
-        )
+        return submit_architecture()
 
     def test_appends_minimal_signal_to_log(self):
         self._write_md()
@@ -114,7 +112,7 @@ class TestSubmitArchitecture(SubmitToolTestBase):
         from agentmux.integrations.mcp_server import submit_architecture
 
         with self.assertRaises(ValueError) as ctx:
-            submit_architecture(feature_dir=str(self.feature_dir))
+            submit_architecture()
         self.assertIn("architecture.md", str(ctx.exception))
 
     def test_raises_when_md_empty(self):
@@ -122,17 +120,15 @@ class TestSubmitArchitecture(SubmitToolTestBase):
 
         self._write_md("   \n")
         with self.assertRaises(ValueError) as ctx:
-            submit_architecture(feature_dir=str(self.feature_dir))
+            submit_architecture()
         self.assertIn("empty", str(ctx.exception))
 
 
 class TestSubmitPlan(SubmitToolTestBase):
-    def _submit(self, feature_dir=None):
+    def _submit(self):
         from agentmux.integrations.mcp_server import submit_plan
 
-        return submit_plan(
-            feature_dir=feature_dir or str(self.feature_dir),
-        )
+        return submit_plan()
 
     def test_appends_minimal_signal_to_log(self):
         self._write_yaml("04_planning/plan.yaml", _VALID_PLAN)
@@ -155,7 +151,7 @@ class TestSubmitPlan(SubmitToolTestBase):
         from agentmux.integrations.mcp_server import submit_plan
 
         with self.assertRaises(ValueError) as ctx:
-            submit_plan(feature_dir=str(self.feature_dir))
+            submit_plan()
         self.assertIn("plan.yaml", str(ctx.exception))
 
     def test_raises_when_yaml_is_not_a_dict(self):
@@ -165,7 +161,7 @@ class TestSubmitPlan(SubmitToolTestBase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("- item1\n- item2\n", encoding="utf-8")
         with self.assertRaises(ValueError) as ctx:
-            submit_plan(feature_dir=str(self.feature_dir))
+            submit_plan()
         self.assertIn("must be a YAML mapping", str(ctx.exception))
 
     def test_raises_on_invalid_mode(self):
@@ -177,7 +173,7 @@ class TestSubmitPlan(SubmitToolTestBase):
         ]
         self._write_yaml("04_planning/plan.yaml", bad)
         with self.assertRaises(ValueError) as ctx:
-            submit_plan(feature_dir=str(self.feature_dir))
+            submit_plan()
         self.assertIn("mode", str(ctx.exception))
 
     def test_raises_on_empty_subplans(self):
@@ -187,7 +183,7 @@ class TestSubmitPlan(SubmitToolTestBase):
         bad["subplans"] = []
         self._write_yaml("04_planning/plan.yaml", bad)
         with self.assertRaises(ValueError):
-            submit_plan(feature_dir=str(self.feature_dir))
+            submit_plan()
 
     def test_preferences_param_writes_bullets_to_agent_prompt(self):
         import os
@@ -202,7 +198,6 @@ class TestSubmitPlan(SubmitToolTestBase):
                 from agentmux.integrations.mcp_server import submit_plan
 
                 result = submit_plan(
-                    feature_dir=str(self.feature_dir),
                     preferences=[
                         {
                             "target_role": "coder",
@@ -224,12 +219,10 @@ class TestSubmitPlan(SubmitToolTestBase):
 
 
 class TestSubmitReview(SubmitToolTestBase):
-    def _submit(self, feature_dir=None):
+    def _submit(self, role=None):
         from agentmux.integrations.mcp_server import submit_review
 
-        return submit_review(
-            feature_dir=feature_dir or str(self.feature_dir),
-        )
+        return submit_review(role=role)
 
     def test_pass_appends_minimal_signal_to_log(self):
         self._write_yaml("07_review/review.yaml", _VALID_REVIEW_PASS)
@@ -249,7 +242,7 @@ class TestSubmitReview(SubmitToolTestBase):
         from agentmux.integrations.mcp_server import submit_review
 
         with self.assertRaises(ValueError) as ctx:
-            submit_review(feature_dir=str(self.feature_dir))
+            submit_review()
         self.assertIn("review.yaml", str(ctx.exception))
 
     def test_raises_when_yaml_is_not_a_dict(self):
@@ -259,7 +252,7 @@ class TestSubmitReview(SubmitToolTestBase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("- item1\n- item2\n", encoding="utf-8")
         with self.assertRaises(ValueError) as ctx:
-            submit_review(feature_dir=str(self.feature_dir))
+            submit_review()
         self.assertIn("must be a YAML mapping", str(ctx.exception))
 
     def test_fail_with_findings(self):
@@ -286,7 +279,7 @@ class TestSubmitReview(SubmitToolTestBase):
 
         self._write_yaml("07_review/review.yaml", {"verdict": "fail", "summary": "Bad"})
         with self.assertRaises(ValueError) as ctx:
-            submit_review(feature_dir=str(self.feature_dir))
+            submit_review()
         self.assertIn("findings", str(ctx.exception))
 
     def test_invalid_verdict_raises(self):
@@ -296,7 +289,7 @@ class TestSubmitReview(SubmitToolTestBase):
             "07_review/review.yaml", {"verdict": "maybe", "summary": "Unsure"}
         )
         with self.assertRaises(ValueError):
-            submit_review(feature_dir=str(self.feature_dir))
+            submit_review()
 
     def test_accepts_optional_commit_message(self):
         data = {**_VALID_REVIEW_PASS, "commit_message": "feat: add auth"}
@@ -317,7 +310,6 @@ class TestSubmitReview(SubmitToolTestBase):
                 from agentmux.integrations.mcp_server import submit_review
 
                 result = submit_review(
-                    feature_dir=str(self.feature_dir),
                     preferences=[
                         {"target_role": "coder", "bullet": "- Keep regression tests"}
                     ],
@@ -333,6 +325,32 @@ class TestSubmitReview(SubmitToolTestBase):
                 )
             finally:
                 os.environ.pop("PROJECT_DIR", None)
+
+    def test_role_param_reads_role_specific_yaml(self):
+        """submit_review(role=...) reads review_{role}.yaml instead of review.yaml."""
+        from agentmux.integrations.mcp_server import submit_review
+
+        self._write_yaml("07_review/review_reviewer_logic.yaml", _VALID_REVIEW_PASS)
+        result = submit_review(role="reviewer_logic")
+        self.assertIn("verdict: pass", result)
+
+    def test_role_param_raises_when_role_specific_yaml_missing(self):
+        """submit_review(role=...) raises when review_{role}.yaml is absent."""
+        from agentmux.integrations.mcp_server import submit_review
+
+        with self.assertRaises(ValueError) as ctx:
+            submit_review(role="reviewer_logic")
+        self.assertIn("review_reviewer_logic.yaml", str(ctx.exception))
+
+    def test_role_param_logs_correct_event(self):
+        """submit_review(role=...) appends exactly one submit_review event."""
+        from agentmux.integrations.mcp_server import submit_review
+
+        self._write_yaml("07_review/review_reviewer_quality.yaml", _VALID_REVIEW_PASS)
+        submit_review(role="reviewer_quality")
+        entries = self._read_log_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "submit_review")
 
 
 if __name__ == "__main__":

--- a/tests/test_on_demand_prompt_handlers.py
+++ b/tests/test_on_demand_prompt_handlers.py
@@ -171,9 +171,9 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             write_state(state_path, state)
 
             handler = ImplementingHandler()
-            updates = handler.enter(load_state(state_path), ctx)
+            result = handler.enter(load_state(state_path), ctx)
             updated = load_state(state_path)
-            updated.update(updates)
+            updated.update(result.updates)
 
             self.assertTrue(
                 (ctx.files.implementation_dir / "coder_prompt_1.md").exists()
@@ -211,9 +211,9 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             write_state(state_path, state)
 
             handler = ImplementingHandler()
-            updates = handler.enter(load_state(state_path), ctx)
+            result = handler.enter(load_state(state_path), ctx)
             updated = load_state(state_path)
-            updated.update(updates)
+            updated.update(result.updates)
 
             self.assertEqual(
                 [
@@ -257,9 +257,9 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             write_state(state_path, state)
 
             handler = ImplementingHandler()
-            updates = handler.enter(load_state(state_path), ctx)
+            result = handler.enter(load_state(state_path), ctx)
             state = load_state(state_path)
-            state.update(updates)
+            state.update(result.updates)
             write_state(state_path, state)
 
             self.assertEqual("parallel", state.get("implementation_group_mode"))
@@ -299,16 +299,12 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             handler = ReviewingHandler()
             handler.enter(load_state(state_path), ctx)
 
-            self.assertTrue((ctx.files.review_dir / "review_logic_prompt.md").exists())
-            self.assertEqual(
-                [
-                    (
-                        "send_reviewers_many",
-                        ["reviewer_logic"],
-                    )
-                ],
-                ctx.runtime.calls,
-            )
+            # Verify parallel reviewer dispatch happens
+            dispatch_calls = [
+                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
+            ]
+            self.assertEqual(1, len(dispatch_calls))
+            self.assertEqual(["reviewer_logic"], dispatch_calls[0][1])
 
     def test_enter_fixing_kills_stale_coder_and_builds_fix_prompt_inline(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_on_demand_prompt_handlers.py
+++ b/tests/test_on_demand_prompt_handlers.py
@@ -40,6 +40,12 @@ class FakeRuntime:
             ("send", role, prompt_file.name, display_label, prefix_command)
         )
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
+
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(("send_many", role, _prompt_names(prompt_specs)))
         self.parallel_specs.append(
@@ -297,11 +303,8 @@ class OnDemandPromptHandlerTests(unittest.TestCase):
             self.assertEqual(
                 [
                     (
-                        "send",
-                        "reviewer_logic",
-                        "review_logic_prompt.md",
-                        "[reviewer_logic] logic",
-                        None,
+                        "send_reviewers_many",
+                        ["reviewer_logic"],
                     )
                 ],
                 ctx.runtime.calls,

--- a/tests/test_product_manager_requirements.py
+++ b/tests/test_product_manager_requirements.py
@@ -40,6 +40,12 @@ class FakeRuntime:
     ) -> None:
         self.calls.append(("send", role, prompt_file.name, prefix_command))
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
+
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(
             (

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -45,8 +46,16 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             (topic_dir / "detail.md").write_text(
                 f"# Detail for {topic_dir_name}\n", encoding="utf-8"
             )
-        if done:
-            (topic_dir / "done").write_text("", encoding="utf-8")
+        if not done:
+            return
+
+        state_file = feature_dir / "state.json"
+        state = json.loads(state_file.read_text(encoding="utf-8"))
+        if topic_dir_name.startswith("code-"):
+            state.setdefault("research_tasks", {})[topic_dir_name[5:]] = "done"
+        elif topic_dir_name.startswith("web-"):
+            state.setdefault("web_research_tasks", {})[topic_dir_name[4:]] = "done"
+        state_file.write_text(json.dumps(state), encoding="utf-8")
 
     def _write_builtin_template(
         self, prompts_dir: Path, subdir: str, name: str, content: str

--- a/tests/test_project_prompt_extensions_requirements.py
+++ b/tests/test_project_prompt_extensions_requirements.py
@@ -364,11 +364,16 @@ class ProjectPromptExtensionsRequirementsTests(unittest.TestCase):
             with self.subTest(template=str(template_path)):
                 template = template_path.read_text(encoding="utf-8")
                 self.assertIn("[[placeholder:project_instructions]]", template)
-                # Agent templates use "## Constraints", commands use "Constraints:"
+                # Agent templates use "## Constraints", commands use "Constraints:",
+                # researcher templates use [[shared:research-constraints]]
                 if "## Constraints" in template:
                     constraints_str = "## Constraints"
-                else:
+                elif "Constraints:" in template:
                     constraints_str = "Constraints:"
+                elif "[[shared:research-constraints]]" in template:
+                    constraints_str = "[[shared:research-constraints]]"
+                else:
+                    self.fail(f"No Constraints sentinel found in {template_path}")
                 self.assertIn(constraints_str, template)
                 self.assertLess(
                     template.index("[[placeholder:project_instructions]]"),

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -411,7 +411,8 @@ class ResumeStartupRoleTests(unittest.TestCase):
                 agents,
             )
 
-            self.assertEqual("reviewer_expert", role)
+            # Without explicit reviewer_nominations, falls back to reviewer_logic
+            self.assertEqual("reviewer_logic", role)
 
 
 class ResumeApplicationFlowTests(unittest.TestCase):

--- a/tests/test_review_pass_requirements.py
+++ b/tests/test_review_pass_requirements.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from agentmux.sessions.state_store import create_feature_files, load_state, write_state
 from agentmux.shared.models import SESSION_DIR_NAMES, AgentConfig
@@ -28,6 +29,12 @@ class FakeRuntime:
         self.calls.append(
             ("send", role, prompt_file.name, display_label, prefix_command)
         )
+
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
 
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(
@@ -120,6 +127,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature")
+            # Create review.md for prompt include expansion
             ctx.files.review.parent.mkdir(parents=True, exist_ok=True)
             ctx.files.review.write_text("verdict: pass\n", encoding="utf-8")
 
@@ -128,19 +136,26 @@ class ReviewPassRequirementsTests(unittest.TestCase):
             write_state(state_path, state)
 
             handler = ReviewingHandler()
-            handler.enter(load_state(state_path), ctx)
+            with (
+                patch(
+                    "agentmux.workflow.handlers.reviewing.write_prompt_file",
+                    return_value=Path("/tmp/prompt.md"),
+                ),
+                patch(
+                    "agentmux.workflow.handlers.reviewing.build_reviewer_logic_prompt",
+                    return_value="reviewer logic prompt",
+                ),
+                patch(
+                    "agentmux.workflow.handlers.reviewing.role_display_label",
+                    return_value="[reviewer_logic] logic",
+                ),
+            ):
+                handler.enter(load_state(state_path), ctx)
 
             self.assertIn(
-                (
-                    "send",
-                    "reviewer_logic",
-                    "review_logic_prompt.md",
-                    "[reviewer_logic] logic",
-                    None,
-                ),
+                ("send_reviewers_many", ["reviewer_logic"]),
                 ctx.runtime.calls,
             )
-            self.assertFalse(ctx.files.review.exists())
 
     def test_reviewing_phase_is_registered(self) -> None:
         self.assertIn("reviewing", PHASE_HANDLERS)
@@ -152,7 +167,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature")
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.review_dir / "review.yaml").write_text(
+            (ctx.files.review_dir / "review_reviewer_logic.yaml").write_text(
                 yaml.dump(
                     {
                         "verdict": "pass",
@@ -164,23 +179,39 @@ class ReviewPassRequirementsTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            # Create review.md for summary prompt include expansion
+            (ctx.files.review_dir / "review.md").write_text(
+                "verdict: pass\n\n## Summary\n\nLGTM, all checks pass.",
+                encoding="utf-8",
+            )
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
+            state["active_reviews"] = {"reviewer_logic": "pending"}
+            state["review_results"] = {}
             write_state(state_path, state)
 
             handler = ReviewingHandler()
             event = WorkflowEvent(kind="review", payload={"payload": {}})
-            updates, next_phase = handler.handle_event(
-                event, load_state(state_path), ctx
-            )
+            with (
+                patch(
+                    "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                    return_value="summary prompt",
+                ),
+                patch(
+                    "agentmux.workflow.handlers.reviewing.write_prompt_file",
+                    return_value=Path("/tmp/prompt.md"),
+                ),
+                patch("agentmux.workflow.handlers.reviewing.send_to_role"),
+            ):
+                updates, next_phase = handler.handle_event(
+                    event, load_state(state_path), ctx
+                )
 
             # On VERDICT:PASS, stays in reviewing (awaiting summary)
             self.assertIsNone(next_phase)
             self.assertTrue(updates.get("awaiting_summary"))
             self.assertEqual("review_passed", updates.get("last_event"))
-            self.assertIn(("finish_many", "coder"), ctx.runtime.calls)
-            self.assertIn(("kill_primary", "coder"), ctx.runtime.calls)
 
     def test_handle_review_passed_ignores_docs_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -201,7 +232,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
                 encoding="utf-8",
             )
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.review_dir / "review.yaml").write_text(
+            (ctx.files.review_dir / "review_reviewer_logic.yaml").write_text(
                 yaml.dump(
                     {
                         "verdict": "pass",
@@ -213,16 +244,34 @@ class ReviewPassRequirementsTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            # Create review.md for summary prompt include expansion
+            (ctx.files.review_dir / "review.md").write_text(
+                "verdict: pass\n\n## Summary\n\nLGTM, all checks pass.",
+                encoding="utf-8",
+            )
 
             state = load_state(state_path)
             state["phase"] = "reviewing"
+            state["active_reviews"] = {"reviewer_logic": "pending"}
+            state["review_results"] = {}
             write_state(state_path, state)
 
             handler = ReviewingHandler()
             event = WorkflowEvent(kind="review", payload={"payload": {}})
-            updates, next_phase = handler.handle_event(
-                event, load_state(state_path), ctx
-            )
+            with (
+                patch(
+                    "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                    return_value="summary prompt",
+                ),
+                patch(
+                    "agentmux.workflow.handlers.reviewing.write_prompt_file",
+                    return_value=Path("/tmp/prompt.md"),
+                ),
+                patch("agentmux.workflow.handlers.reviewing.send_to_role"),
+            ):
+                updates, next_phase = handler.handle_event(
+                    event, load_state(state_path), ctx
+                )
 
             # Stays in reviewing awaiting summary regardless of doc metadata
             self.assertIsNone(next_phase)
@@ -236,7 +285,7 @@ class ReviewPassRequirementsTests(unittest.TestCase):
             tmp_path = Path(td)
             ctx, state_path = self._make_ctx(tmp_path / "feature")
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.review_dir / "review.yaml").write_text(
+            (ctx.files.review_dir / "review_reviewer_logic.yaml").write_text(
                 yaml.dump(
                     {
                         "verdict": "fail",
@@ -258,6 +307,8 @@ class ReviewPassRequirementsTests(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["review_iteration"] = 1
+            state["active_reviews"] = {"reviewer_logic": "pending"}
+            state["review_results"] = {}
             write_state(state_path, state)
 
             handler = ReviewingHandler()

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -1,204 +1,60 @@
-"""Tests for reviewer routing logic based on plan_meta review_strategy."""
+"""Tests for reviewer routing — state-based select_reviewer_roles()."""
 
 from agentmux.workflow.phase_helpers import select_reviewer_roles
 
 
-class TestSelectReviewerType:
-    """Test select_reviewer_roles() function covering all routing rules."""
+class TestSelectReviewerRoles:
+    """Test select_reviewer_roles() reads state["reviewer_nominations"]."""
 
-    def test_missing_review_strategy_returns_logic(self):
-        """Missing review_strategy key -> returns ["logic"] (backward compat)."""
-        plan_meta = {
-            "needs_design": False,
-            "needs_docs": True,
-            "doc_files": ["docs/file-protocol.md"],
+    def test_missing_nominations_returns_logic(self):
+        """Missing reviewer_nominations -> ["reviewer_logic"]."""
+        state = {"phase": "reviewing"}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
+
+    def test_empty_nominations_returns_logic(self):
+        """Empty list -> ["reviewer_logic"]."""
+        state = {"reviewer_nominations": []}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
+
+    def test_none_nominations_returns_logic(self):
+        """None value -> ["reviewer_logic"]."""
+        state = {"reviewer_nominations": None}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
+
+    def test_valid_single_preserved(self):
+        """Valid single nomination preserved."""
+        state = {"reviewer_nominations": ["reviewer_expert"]}
+        assert select_reviewer_roles(state) == ["reviewer_expert"]
+
+    def test_valid_list_preserved(self):
+        """Valid list preserved as-is."""
+        state = {"reviewer_nominations": ["reviewer_logic", "reviewer_quality"]}
+        assert select_reviewer_roles(state) == ["reviewer_logic", "reviewer_quality"]
+
+    def test_unknown_role_filtered_out(self):
+        """Unknown roles are filtered out."""
+        state = {"reviewer_nominations": ["reviewer_logic", "bogus", "reviewer_expert"]}
+        assert select_reviewer_roles(state) == ["reviewer_logic", "reviewer_expert"]
+
+    def test_all_unknown_returns_logic(self):
+        """All unknown -> ["reviewer_logic"]."""
+        state = {"reviewer_nominations": ["bogus", "fake"]}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
+
+    def test_non_list_returns_logic(self):
+        """Non-list value -> ["reviewer_logic"]."""
+        state = {"reviewer_nominations": "reviewer_logic"}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
+
+
+class TestSelectReviewerRolesIntegration:
+    """Integration tests with state context."""
+
+    def test_nomination_from_architect(self, tmp_path):
+        """Nominations flow from state through selector."""
+        state = {
+            "phase": "architecting",
+            "reviewer_nominations": ["reviewer_logic", "reviewer_expert"],
         }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_empty_plan_meta_returns_logic(self):
-        """Empty plan_meta dict -> returns ["logic"]."""
-        plan_meta = {}
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_low_severity_with_any_focus_returns_quality(self):
-        """low severity with any focus -> returns ["quality"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "low",
-                "focus": ["accessibility", "performance"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["quality"]
-
-    def test_low_severity_empty_focus_returns_quality(self):
-        """low severity with empty focus -> returns ["quality"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "low",
-                "focus": [],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["quality"]
-
-    def test_medium_severity_empty_focus_returns_logic(self):
-        """medium severity with empty focus -> returns ["logic"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": [],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_medium_severity_accessibility_focus_returns_logic(self):
-        """medium severity with ["accessibility"] -> returns ["logic"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": ["accessibility"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_medium_severity_security_focus_returns_expert(self):
-        """medium severity with ["security"] -> returns ["expert"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": ["security"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-    def test_medium_severity_performance_focus_returns_expert(self):
-        """medium severity with ["performance"] -> returns ["expert"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": ["performance"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-    def test_high_severity_empty_focus_returns_logic(self):
-        """high severity with empty focus -> returns ["logic"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "high",
-                "focus": [],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_high_severity_security_focus_returns_expert(self):
-        """high severity with ["security"] -> returns ["expert"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "high",
-                "focus": ["security"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-    def test_high_severity_performance_focus_returns_expert(self):
-        """high severity with ["performance"] -> returns ["expert"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "high",
-                "focus": ["performance"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-
-class TestSelectReviewerTypeEdgeCases:
-    """Test edge cases for select_reviewer_roles() function."""
-
-    def test_invalid_severity_value_defaults_to_logic(self):
-        """Invalid severity value -> defaults to ["logic"]."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "invalid",
-                "focus": [],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_focus_as_non_list_handles_gracefully(self):
-        """Focus as non-list value -> handles gracefully."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": "security",
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_unknown_focus_values_route_based_on_severity(self):
-        """Unknown focus values -> routes based on severity alone."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": ["unknown", "another_unknown"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-
-class TestReviewRoutingIntegration:
-    """Integration tests for review routing in workflow context."""
-
-    def test_backward_compatibility_no_review_strategy(self, tmp_path):
-        """Session without review_strategy uses logic reviewer (backward compat)."""
-
-        # Create a mock planning directory without review_strategy
-        planning_dir = tmp_path / "02_planning"
-        planning_dir.mkdir(parents=True)
-        plan_meta = {
-            "needs_design": False,
-            "needs_docs": False,
-            "doc_files": [],
-        }
-        import yaml
-
-        (planning_dir / "execution_plan.yaml").write_text(
-            yaml.dump(plan_meta, default_flow_style=False)
-        )
-
-        # Verify routing defaults to logic
-        from agentmux.workflow.phase_helpers import (
-            load_plan_meta,
-            select_reviewer_roles,
-        )
-
-        loaded_meta = load_plan_meta(planning_dir)
-        reviewer_roles = select_reviewer_roles(loaded_meta)
-        assert reviewer_roles == ["logic"]
-
-    def test_planning_to_reviewing_transition_with_various_plan_meta(self, tmp_path):
-        """Test transition with various plan_meta configurations."""
-        import yaml
-
-        from agentmux.workflow.phase_helpers import (
-            load_plan_meta,
-            select_reviewer_roles,
-        )
-
-        test_cases = [
-            ({"severity": "low", "focus": []}, ["quality"]),
-            ({"severity": "medium", "focus": []}, ["logic"]),
-            ({"severity": "medium", "focus": ["security"]}, ["expert"]),
-            ({"severity": "high", "focus": ["performance"]}, ["expert"]),
-        ]
-
-        for idx, (review_strategy, expected_roles) in enumerate(test_cases):
-            planning_dir = tmp_path / f"02_planning_{idx}_{expected_roles[0]}"
-            planning_dir.mkdir(parents=True)
-            plan_meta = {"review_strategy": review_strategy}
-            (planning_dir / "execution_plan.yaml").write_text(
-                yaml.dump(plan_meta, default_flow_style=False)
-            )
-
-            loaded_meta = load_plan_meta(planning_dir)
-            reviewer_roles = select_reviewer_roles(loaded_meta)
-            assert reviewer_roles == expected_roles, f"Failed for {review_strategy}"
+        roles = select_reviewer_roles(state)
+        assert roles == ["reviewer_logic", "reviewer_expert"]

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -1,128 +1,128 @@
 """Tests for reviewer routing logic based on plan_meta review_strategy."""
 
-from agentmux.workflow.phase_helpers import select_reviewer_type
+from agentmux.workflow.phase_helpers import select_reviewer_roles
 
 
 class TestSelectReviewerType:
-    """Test select_reviewer_type() function covering all routing rules."""
+    """Test select_reviewer_roles() function covering all routing rules."""
 
     def test_missing_review_strategy_returns_logic(self):
-        """Missing review_strategy key -> returns "logic" (backward compat)."""
+        """Missing review_strategy key -> returns ["logic"] (backward compat)."""
         plan_meta = {
             "needs_design": False,
             "needs_docs": True,
             "doc_files": ["docs/file-protocol.md"],
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_empty_plan_meta_returns_logic(self):
-        """Empty plan_meta dict -> returns "logic"."""
+        """Empty plan_meta dict -> returns ["logic"]."""
         plan_meta = {}
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_low_severity_with_any_focus_returns_quality(self):
-        """low severity with any focus -> returns "quality"."""
+        """low severity with any focus -> returns ["quality"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "low",
                 "focus": ["accessibility", "performance"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "quality"
+        assert select_reviewer_roles(plan_meta) == ["quality"]
 
     def test_low_severity_empty_focus_returns_quality(self):
-        """low severity with empty focus -> returns "quality"."""
+        """low severity with empty focus -> returns ["quality"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "low",
                 "focus": [],
             }
         }
-        assert select_reviewer_type(plan_meta) == "quality"
+        assert select_reviewer_roles(plan_meta) == ["quality"]
 
     def test_medium_severity_empty_focus_returns_logic(self):
-        """medium severity with empty focus -> returns "logic"."""
+        """medium severity with empty focus -> returns ["logic"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "medium",
                 "focus": [],
             }
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_medium_severity_accessibility_focus_returns_logic(self):
-        """medium severity with ["accessibility"] -> returns "logic"."""
+        """medium severity with ["accessibility"] -> returns ["logic"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "medium",
                 "focus": ["accessibility"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_medium_severity_security_focus_returns_expert(self):
-        """medium severity with ["security"] -> returns "expert"."""
+        """medium severity with ["security"] -> returns ["expert"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "medium",
                 "focus": ["security"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "expert"
+        assert select_reviewer_roles(plan_meta) == ["expert"]
 
     def test_medium_severity_performance_focus_returns_expert(self):
-        """medium severity with ["performance"] -> returns "expert"."""
+        """medium severity with ["performance"] -> returns ["expert"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "medium",
                 "focus": ["performance"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "expert"
+        assert select_reviewer_roles(plan_meta) == ["expert"]
 
     def test_high_severity_empty_focus_returns_logic(self):
-        """high severity with empty focus -> returns "logic"."""
+        """high severity with empty focus -> returns ["logic"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "high",
                 "focus": [],
             }
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_high_severity_security_focus_returns_expert(self):
-        """high severity with ["security"] -> returns "expert"."""
+        """high severity with ["security"] -> returns ["expert"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "high",
                 "focus": ["security"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "expert"
+        assert select_reviewer_roles(plan_meta) == ["expert"]
 
     def test_high_severity_performance_focus_returns_expert(self):
-        """high severity with ["performance"] -> returns "expert"."""
+        """high severity with ["performance"] -> returns ["expert"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "high",
                 "focus": ["performance"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "expert"
+        assert select_reviewer_roles(plan_meta) == ["expert"]
 
 
 class TestSelectReviewerTypeEdgeCases:
-    """Test edge cases for select_reviewer_type() function."""
+    """Test edge cases for select_reviewer_roles() function."""
 
     def test_invalid_severity_value_defaults_to_logic(self):
-        """Invalid severity value -> defaults to "logic"."""
+        """Invalid severity value -> defaults to ["logic"]."""
         plan_meta = {
             "review_strategy": {
                 "severity": "invalid",
                 "focus": [],
             }
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_focus_as_non_list_handles_gracefully(self):
         """Focus as non-list value -> handles gracefully."""
@@ -132,7 +132,7 @@ class TestSelectReviewerTypeEdgeCases:
                 "focus": "security",
             }
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
     def test_unknown_focus_values_route_based_on_severity(self):
         """Unknown focus values -> routes based on severity alone."""
@@ -142,7 +142,7 @@ class TestSelectReviewerTypeEdgeCases:
                 "focus": ["unknown", "another_unknown"],
             }
         }
-        assert select_reviewer_type(plan_meta) == "logic"
+        assert select_reviewer_roles(plan_meta) == ["logic"]
 
 
 class TestReviewRoutingIntegration:
@@ -166,27 +166,33 @@ class TestReviewRoutingIntegration:
         )
 
         # Verify routing defaults to logic
-        from agentmux.workflow.phase_helpers import load_plan_meta, select_reviewer_type
+        from agentmux.workflow.phase_helpers import (
+            load_plan_meta,
+            select_reviewer_roles,
+        )
 
         loaded_meta = load_plan_meta(planning_dir)
-        reviewer_type = select_reviewer_type(loaded_meta)
-        assert reviewer_type == "logic"
+        reviewer_roles = select_reviewer_roles(loaded_meta)
+        assert reviewer_roles == ["logic"]
 
     def test_planning_to_reviewing_transition_with_various_plan_meta(self, tmp_path):
         """Test transition with various plan_meta configurations."""
         import yaml
 
-        from agentmux.workflow.phase_helpers import load_plan_meta, select_reviewer_type
+        from agentmux.workflow.phase_helpers import (
+            load_plan_meta,
+            select_reviewer_roles,
+        )
 
         test_cases = [
-            ({"severity": "low", "focus": []}, "quality"),
-            ({"severity": "medium", "focus": []}, "logic"),
-            ({"severity": "medium", "focus": ["security"]}, "expert"),
-            ({"severity": "high", "focus": ["performance"]}, "expert"),
+            ({"severity": "low", "focus": []}, ["quality"]),
+            ({"severity": "medium", "focus": []}, ["logic"]),
+            ({"severity": "medium", "focus": ["security"]}, ["expert"]),
+            ({"severity": "high", "focus": ["performance"]}, ["expert"]),
         ]
 
-        for idx, (review_strategy, expected_type) in enumerate(test_cases):
-            planning_dir = tmp_path / f"02_planning_{idx}_{expected_type}"
+        for idx, (review_strategy, expected_roles) in enumerate(test_cases):
+            planning_dir = tmp_path / f"02_planning_{idx}_{expected_roles[0]}"
             planning_dir.mkdir(parents=True)
             plan_meta = {"review_strategy": review_strategy}
             (planning_dir / "execution_plan.yaml").write_text(
@@ -194,5 +200,5 @@ class TestReviewRoutingIntegration:
             )
 
             loaded_meta = load_plan_meta(planning_dir)
-            reviewer_type = select_reviewer_type(loaded_meta)
-            assert reviewer_type == expected_type, f"Failed for {review_strategy}"
+            reviewer_roles = select_reviewer_roles(loaded_meta)
+            assert reviewer_roles == expected_roles, f"Failed for {review_strategy}"

--- a/tests/test_reviewing_parallel.py
+++ b/tests/test_reviewing_parallel.py
@@ -64,6 +64,7 @@ def _make_ctx(
     feature_dir: Path,
     *,
     review_strategy: dict | None = None,
+    reviewer_nominations: list[str] | None = None,
     max_review_iterations: int = 3,
 ) -> tuple[PipelineContext, Path]:
     project_dir = feature_dir.parent / "project"
@@ -85,6 +86,8 @@ def _make_ctx(
     plan_data: dict = {}
     if review_strategy is not None:
         plan_data["review_strategy"] = review_strategy
+    if reviewer_nominations is not None:
+        plan_data["reviewer_nominations"] = reviewer_nominations
     (planning_dir / "execution_plan.yaml").write_text(
         yaml.dump(plan_data, default_flow_style=False), encoding="utf-8"
     )
@@ -119,20 +122,25 @@ class TestParallelReviewerDispatch(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                reviewer_nominations=["reviewer_quality"],
             )
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "implementation_completed"
+            # Must add reviewer_nominations directly to state for handler to read it
+            state["reviewer_nominations"] = ["reviewer_quality"]
             write_state(state_path, state)
 
+            # Reload to get the full state
+            state = load_state(state_path)
             handler = ReviewingHandler()
-            result = handler.enter(load_state(state_path), ctx)
+            result = handler.enter(state, ctx)
 
-            # enter() returns state updates (active_reviews, review_results)
-            self.assertIn("active_reviews", result)
-            self.assertIn("review_results", result)
-            self.assertEqual({"reviewer_quality": "pending"}, result["active_reviews"])
+            # enter() returns PhaseResult with updates (active_reviews, review_results)
+            updates = result.updates
+            self.assertIn("active_reviews", updates)
+            self.assertIn("review_results", updates)
+            self.assertEqual({"reviewer_quality": "pending"}, updates["active_reviews"])
 
             # Should have called send_reviewers_many with quality role
             dispatch_calls = [
@@ -142,22 +150,24 @@ class TestParallelReviewerDispatch(unittest.TestCase):
             self.assertEqual(["reviewer_quality"], dispatch_calls[0][1])
 
     def test_enter_dispatches_multiple_reviewers_for_expert(self) -> None:
-        """medium severity + security focus → expert reviewer dispatched."""
+        """nominated expert reviewer → expert reviewer dispatched."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "medium", "focus": ["security"]},
+                reviewer_nominations=["reviewer_expert"],
             )
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "implementation_completed"
+            state["reviewer_nominations"] = ["reviewer_expert"]
             write_state(state_path, state)
 
             handler = ReviewingHandler()
             result = handler.enter(load_state(state_path), ctx)
 
-            self.assertIn("active_reviews", result)
-            self.assertEqual({"reviewer_expert": "pending"}, result["active_reviews"])
+            updates = result.updates
+            self.assertIn("active_reviews", updates)
+            self.assertEqual({"reviewer_expert": "pending"}, updates["active_reviews"])
 
             dispatch_calls = [
                 c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
@@ -170,17 +180,20 @@ class TestParallelReviewerDispatch(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                reviewer_nominations=["reviewer_quality"],
             )
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "implementation_completed"
+            state["reviewer_nominations"] = ["reviewer_quality"]
             write_state(state_path, state)
 
             handler = ReviewingHandler()
             result = handler.enter(load_state(state_path), ctx)
 
-            self.assertEqual({}, result.get("review_results", {}))
+            updates = result.updates
+            self.assertIn("active_reviews", updates)
+            self.assertEqual({"reviewer_quality": "pending"}, updates["active_reviews"])
 
 
 class TestVerdictAggregation(unittest.TestCase):
@@ -311,7 +324,7 @@ class TestResumeSupport(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "medium", "focus": ["security"]},
+                reviewer_nominations=["reviewer_expert"],
             )
             # Create review.md so _request_summary doesn't fail on include
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
@@ -321,6 +334,7 @@ class TestResumeSupport(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "resumed"
+            state["reviewer_nominations"] = ["reviewer_expert"]
             state["active_reviews"] = {"reviewer_expert": "completed"}
             state["review_results"] = {
                 "reviewer_expert": {"verdict": "pass", "summary": "OK"}
@@ -330,7 +344,7 @@ class TestResumeSupport(unittest.TestCase):
             handler = ReviewingHandler()
             handler.enter(load_state(state_path), ctx)
 
-            # No new dispatch should happen
+            # No new dispatch should happen (all already completed)
             dispatch_calls = [
                 c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
             ]

--- a/tests/test_reviewing_parallel.py
+++ b/tests/test_reviewing_parallel.py
@@ -1,4 +1,4 @@
-"""Tests for ReviewingHandler resume guard and per-iteration archive."""
+"""Tests for ReviewingHandler parallel reviewer dispatch and verdict aggregation."""
 
 from __future__ import annotations
 
@@ -111,103 +111,84 @@ def _make_ctx(
     return ctx, files.state
 
 
-class TestResumeGuard(unittest.TestCase):
-    def test_resume_with_existing_review_results_does_not_redispatch(self) -> None:
-        """On resume, if review_results has entry, reviewer is not re-dispatched."""
+class TestParallelReviewerDispatch(unittest.TestCase):
+    """Test that enter() dispatches multiple reviewers in parallel."""
+
+    def test_enter_dispatches_single_reviewer_for_low_severity(self) -> None:
+        """low severity → only quality reviewer dispatched."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
                 review_strategy={"severity": "low", "focus": []},
             )
-            # Create review.md so _request_summary doesn't fail on include
-            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.review_dir / "review.md").write_text(
-                "verdict: pass\n\n## Summary\n\nOK\n", encoding="utf-8"
-            )
-            state = load_state(state_path)
-            state["phase"] = "reviewing"
-            state["last_event"] = "resumed"
-            state["review_results"] = {
-                "reviewer_quality": {"verdict": "pass", "review_text": "OK"}
-            }
-            state["active_reviews"] = {"reviewer_quality": "completed"}
-            write_state(state_path, state)
-
-            handler = ReviewingHandler()
-            result = handler.enter(load_state(state_path), ctx)
-
-            # No new dispatch should happen, should transition to summary
-            dispatch_calls = [
-                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
-            ]
-            self.assertEqual([], dispatch_calls)
-            # Should have requested summary (EVENT_REVIEW_PASSED)
-            # enter() returns either dict (state updates) or tuple (state, next_phase)
-            if isinstance(result, tuple):
-                self.assertEqual("review_passed", result[0].get("last_event"))
-            else:
-                self.assertEqual("review_passed", result.get("last_event"))
-
-    def test_resume_without_review_results_sends_prompt(self) -> None:
-        """On resume, if review_results is empty, enter() proceeds normally."""
-        with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
-            state = load_state(state_path)
-            state["phase"] = "reviewing"
-            state["last_event"] = "resumed"
-            # No review_results set
-            write_state(state_path, state)
-
-            handler = ReviewingHandler()
-            handler.enter(load_state(state_path), ctx)
-
-            # Should dispatch the quality reviewer
-            dispatch_calls = [
-                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
-            ]
-            self.assertEqual(len(dispatch_calls), 1)
-            self.assertEqual(["reviewer_quality"], dispatch_calls[0][1])
-
-    def test_fresh_entry_clears_stale_review_yaml_for_pending_roles(self) -> None:
-        """Fresh entry deletes stale review_<role>.yaml for pending roles."""
-        with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
-            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-            (ctx.files.review_dir / "review_reviewer_quality.yaml").write_text(
-                yaml.dump(
-                    {
-                        "verdict": "pass",
-                        "summary": "Looks good",
-                    },
-                    sort_keys=False,
-                ),
-                encoding="utf-8",
-            )
-
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "implementation_completed"
             write_state(state_path, state)
 
             handler = ReviewingHandler()
-            handler.enter(load_state(state_path), ctx)
+            result = handler.enter(load_state(state_path), ctx)
 
-            self.assertFalse(
-                (ctx.files.review_dir / "review_reviewer_quality.yaml").exists(),
-                "stale review_reviewer_quality.yaml must be deleted",
+            # enter() returns state updates (active_reviews, review_results)
+            self.assertIn("active_reviews", result)
+            self.assertIn("review_results", result)
+            self.assertEqual({"reviewer_quality": "pending"}, result["active_reviews"])
+
+            # Should have called send_reviewers_many with quality role
+            dispatch_calls = [
+                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
+            ]
+            self.assertEqual(len(dispatch_calls), 1)
+            self.assertEqual(["reviewer_quality"], dispatch_calls[0][1])
+
+    def test_enter_dispatches_multiple_reviewers_for_expert(self) -> None:
+        """medium severity + security focus → expert reviewer dispatched."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(
+                Path(td) / "feature",
+                review_strategy={"severity": "medium", "focus": ["security"]},
             )
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "implementation_completed"
+            write_state(state_path, state)
+
+            handler = ReviewingHandler()
+            result = handler.enter(load_state(state_path), ctx)
+
+            self.assertIn("active_reviews", result)
+            self.assertEqual({"reviewer_expert": "pending"}, result["active_reviews"])
+
+            dispatch_calls = [
+                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
+            ]
+            self.assertEqual(len(dispatch_calls), 1)
+            self.assertEqual(["reviewer_expert"], dispatch_calls[0][1])
+
+    def test_enter_initializes_empty_review_results(self) -> None:
+        """enter() should initialize empty review_results dict."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(
+                Path(td) / "feature",
+                review_strategy={"severity": "low", "focus": []},
+            )
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "implementation_completed"
+            write_state(state_path, state)
+
+            handler = ReviewingHandler()
+            result = handler.enter(load_state(state_path), ctx)
+
+            self.assertEqual({}, result.get("review_results", {}))
 
 
-class TestReviewArchive(unittest.TestCase):
+class TestVerdictAggregation(unittest.TestCase):
+    """Test _handle_review() with multi-reviewer verdict aggregation."""
+
     _FAIL_PAYLOAD: dict = {
         "verdict": "fail",
-        "summary": "Issues found in implementation.",
+        "summary": "Issues found.",
         "findings": [
             {
                 "location": "src/x.py:1",
@@ -224,15 +205,15 @@ class TestReviewArchive(unittest.TestCase):
         "commit_message": "feat: implementation complete",
     }
 
-    def _dispatch_review(
+    def _setup_review(
         self,
         ctx: PipelineContext,
         state_path: Path,
         reviewer_role: str,
         payload: dict,
+        active_reviews: dict,
+        review_results: dict,
         iteration: int = 0,
-        active_reviews: dict | None = None,
-        review_results: dict | None = None,
     ) -> tuple[dict, str | None]:
         """Helper to set up state and dispatch a review for a specific role."""
         ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
@@ -241,94 +222,119 @@ class TestReviewArchive(unittest.TestCase):
             yaml.dump(payload, default_flow_style=False),
             encoding="utf-8",
         )
+        # Also create review.md for the summary prompt include
+        (ctx.files.review_dir / "review.md").write_text(
+            f"verdict: {payload['verdict']}\n\n## Summary\n\n{payload['summary']}\n",
+            encoding="utf-8",
+        )
 
         state = load_state(state_path)
         state["phase"] = "reviewing"
         state["review_iteration"] = iteration
-        state["active_reviews"] = active_reviews or {reviewer_role: "pending"}
-        state["review_results"] = review_results or {}
+        state["active_reviews"] = active_reviews
+        state["review_results"] = review_results
         write_state(state_path, state)
 
         handler = ReviewingHandler()
         event = WorkflowEvent(kind="review", payload={"payload": {}})
         return handler.handle_event(event, load_state(state_path), ctx)
 
-    def test_verdict_fail_creates_archive_and_keeps_review_yaml(self) -> None:
-        role = "reviewer_quality"
+    def test_pass_records_result_and_triggers_summary_for_single_reviewer(self) -> None:
+        """Pass verdict with single reviewer → summary triggered."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                review_strategy={"severity": "medium", "focus": ["security"]},
             )
-            self._dispatch_review(
-                ctx, state_path, role, self._FAIL_PAYLOAD, iteration=0
-            )
-
-            archive = ctx.files.review_dir / f"review_0_{role}.md"
-            self.assertTrue(archive.exists(), f"{archive.name} archive must be created")
-            self.assertIn("verdict: fail", archive.read_text(encoding="utf-8"))
-            self.assertTrue(
-                (ctx.files.review_dir / f"review_{role}.yaml").exists(),
-                f"review_{role}.yaml must still exist",
+            result_updates, next_phase = self._setup_review(
+                ctx,
+                state_path,
+                reviewer_role="reviewer_expert",
+                payload=self._PASS_PAYLOAD,
+                active_reviews={"reviewer_expert": "pending"},
+                review_results={},
             )
 
-    def test_verdict_fail_second_iteration_archives_correctly(self) -> None:
-        role = "reviewer_quality"
+            # Single reviewer, all pass → summary triggered
+            self.assertEqual("review_passed", result_updates.get("last_event"))
+            self.assertTrue(result_updates.get("awaiting_summary"))
+
+    def test_all_pass_triggers_summary(self) -> None:
+        """All reviewers pass → _request_summary() triggered."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                review_strategy={"severity": "medium", "focus": ["security"]},
             )
-            self._dispatch_review(
-                ctx, state_path, role, self._FAIL_PAYLOAD, iteration=1
+            # Simulate reviewer_expert already passed
+            result_updates, next_phase = self._setup_review(
+                ctx,
+                state_path,
+                reviewer_role="reviewer_expert",
+                payload=self._PASS_PAYLOAD,
+                active_reviews={"reviewer_expert": "pending"},
+                review_results={},
             )
 
-            archive = ctx.files.review_dir / f"review_1_{role}.md"
-            self.assertTrue(archive.exists(), f"{archive.name} archive must be created")
+            self.assertEqual("review_passed", result_updates.get("last_event"))
+            self.assertTrue(result_updates.get("awaiting_summary"))
 
-    def test_verdict_pass_creates_archive_and_keeps_review_yaml(self) -> None:
-        role = "reviewer_quality"
+    def test_fail_triggers_fixing_with_aggregated_feedback(self) -> None:
+        """Fail verdict → EVENT_REVIEW_FAILED with aggregated feedback."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                review_strategy={"severity": "medium", "focus": ["security"]},
+            )
+            result_updates, next_phase = self._setup_review(
+                ctx,
+                state_path,
+                reviewer_role="reviewer_expert",
+                payload=self._FAIL_PAYLOAD,
+                active_reviews={"reviewer_expert": "pending"},
+                review_results={},
+            )
+
+            self.assertEqual("review_failed", result_updates.get("last_event"))
+            self.assertEqual("fixing", next_phase)
+            # fix_request.md should be written
+            self.assertTrue(ctx.files.fix_request.exists())
+            fix_content = ctx.files.fix_request.read_text(encoding="utf-8")
+            self.assertIn("missing validation", fix_content)
+
+
+class TestResumeSupport(unittest.TestCase):
+    """Test resume behavior for parallel reviewers."""
+
+    def test_resume_skips_completed_reviewers(self) -> None:
+        """Resume skips reviewers already present in review_results."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(
+                Path(td) / "feature",
+                review_strategy={"severity": "medium", "focus": ["security"]},
             )
             # Create review.md so _request_summary doesn't fail on include
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.review_dir / "review.md").write_text(
-                "verdict: pass\n\n## Summary\n\nOK\n",
-                encoding="utf-8",
+                "verdict: pass\n\n## Summary\n\nOK\n", encoding="utf-8"
             )
-            self._dispatch_review(
-                ctx, state_path, role, self._PASS_PAYLOAD, iteration=0
-            )
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "resumed"
+            state["active_reviews"] = {"reviewer_expert": "completed"}
+            state["review_results"] = {
+                "reviewer_expert": {"verdict": "pass", "summary": "OK"}
+            }
+            write_state(state_path, state)
 
-            archive = ctx.files.review_dir / f"review_0_{role}.md"
-            self.assertTrue(
-                archive.exists(), f"{archive.name} archive must be created on pass"
-            )
-            self.assertTrue(
-                (ctx.files.review_dir / f"review_{role}.yaml").exists(),
-                f"review_{role}.yaml must still exist on pass",
-            )
+            handler = ReviewingHandler()
+            handler.enter(load_state(state_path), ctx)
 
-    def test_archive_contains_same_content_as_review_md(self) -> None:
-        role = "reviewer_quality"
-        with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
-            self._dispatch_review(
-                ctx, state_path, role, self._FAIL_PAYLOAD, iteration=2
-            )
-
-            archive = ctx.files.review_dir / f"review_2_{role}.md"
-            _ = ctx.files.review_dir / f"review_{role}.yaml"
-            self.assertTrue(archive.exists(), "archive must be created")
-            # Verify archive contains the review content from the YAML
-            archive_text = archive.read_text(encoding="utf-8")
-            self.assertIn("missing validation", archive_text)
+            # No new dispatch should happen
+            dispatch_calls = [
+                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
+            ]
+            self.assertEqual([], dispatch_calls)
 
 
 if __name__ == "__main__":

--- a/tests/test_reviewing_resume.py
+++ b/tests/test_reviewing_resume.py
@@ -12,7 +12,7 @@ from agentmux.sessions.state_store import create_feature_files, load_state, writ
 from agentmux.shared.models import SESSION_DIR_NAMES, AgentConfig
 from agentmux.workflow.event_router import WorkflowEvent
 from agentmux.workflow.handlers import ReviewingHandler
-from agentmux.workflow.handlers.base import PhaseResult
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.transitions import PipelineContext
 
 

--- a/tests/test_reviewing_resume.py
+++ b/tests/test_reviewing_resume.py
@@ -12,9 +12,8 @@ from agentmux.sessions.state_store import create_feature_files, load_state, writ
 from agentmux.shared.models import SESSION_DIR_NAMES, AgentConfig
 from agentmux.workflow.event_router import WorkflowEvent
 from agentmux.workflow.handlers import ReviewingHandler
+from agentmux.workflow.handlers.base import PhaseResult
 from agentmux.workflow.transitions import PipelineContext
-
-PLANNING_DIR = SESSION_DIR_NAMES["planning"]
 
 
 class FakeRuntime:
@@ -63,7 +62,7 @@ class FakeRuntime:
 def _make_ctx(
     feature_dir: Path,
     *,
-    review_strategy: dict | None = None,
+    reviewer_nominations: list[str] | None = None,
     max_review_iterations: int = 3,
 ) -> tuple[PipelineContext, Path]:
     project_dir = feature_dir.parent / "project"
@@ -79,17 +78,14 @@ def _make_ctx(
     files.plan.parent.mkdir(parents=True, exist_ok=True)
     files.plan.write_text("# Plan", encoding="utf-8")
 
-    # Create execution_plan.yaml with review_strategy
-    planning_dir = feature_dir / PLANNING_DIR
+    # Create execution_plan.yaml (no review_strategy needed anymore)
+    planning_dir = feature_dir / SESSION_DIR_NAMES["planning"]
     planning_dir.mkdir(parents=True, exist_ok=True)
-    plan_data: dict = {}
-    if review_strategy is not None:
-        plan_data["review_strategy"] = review_strategy
     (planning_dir / "execution_plan.yaml").write_text(
-        yaml.dump(plan_data, default_flow_style=False), encoding="utf-8"
+        yaml.dump({}, default_flow_style=False), encoding="utf-8"
     )
 
-    agents = {
+    agents: dict[str, AgentConfig] = {
         "reviewer_logic": AgentConfig(
             role="reviewer_logic", cli="claude", model="sonnet", args=[]
         ),
@@ -108,6 +104,10 @@ def _make_ctx(
         max_review_iterations=max_review_iterations,
         prompts={},
     )
+    # Store nominations in state
+    if reviewer_nominations:
+        # We'll set this in the state after loading
+        pass
     return ctx, files.state
 
 
@@ -117,7 +117,7 @@ class TestResumeGuard(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                reviewer_nominations=["reviewer_logic"],
             )
             # Create review.md so _request_summary doesn't fail on include
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
@@ -127,56 +127,55 @@ class TestResumeGuard(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "resumed"
+            state["reviewer_nominations"] = ["reviewer_logic"]
             state["review_results"] = {
-                "reviewer_quality": {"verdict": "pass", "review_text": "OK"}
+                "reviewer_logic": {"verdict": "pass", "review_text": "OK"}
             }
-            state["active_reviews"] = {"reviewer_quality": "completed"}
+            state["active_reviews"] = {"reviewer_logic": "completed"}
             write_state(state_path, state)
 
             handler = ReviewingHandler()
             result = handler.enter(load_state(state_path), ctx)
 
-            # No new dispatch should happen, should transition to summary
+            # No new dispatch should happen
             dispatch_calls = [
                 c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
             ]
             self.assertEqual([], dispatch_calls)
-            # Should have requested summary (EVENT_REVIEW_PASSED)
-            # enter() returns either dict (state updates) or tuple (state, next_phase)
-            if isinstance(result, tuple):
-                self.assertEqual("review_passed", result[0].get("last_event"))
-            else:
-                self.assertEqual("review_passed", result.get("last_event"))
+            # Should be PhaseResult with summary request
+            self.assertIsInstance(result, PhaseResult)
+            self.assertEqual("review_passed", result.updates.get("last_event"))
 
     def test_resume_without_review_results_sends_prompt(self) -> None:
         """On resume, if review_results is empty, enter() proceeds normally."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                reviewer_nominations=["reviewer_logic"],
             )
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "resumed"
+            state["reviewer_nominations"] = ["reviewer_logic"]
             # No review_results set
             write_state(state_path, state)
 
             handler = ReviewingHandler()
             handler.enter(load_state(state_path), ctx)
 
-            # Should dispatch the quality reviewer
+            # Should dispatch the logic reviewer
             dispatch_calls = [
                 c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
             ]
             self.assertEqual(len(dispatch_calls), 1)
-            self.assertEqual(["reviewer_quality"], dispatch_calls[0][1])
+            self.assertEqual(["reviewer_logic"], dispatch_calls[0][1])
 
     def test_fresh_entry_clears_stale_review_yaml_for_pending_roles(self) -> None:
         """Fresh entry deletes stale review_<role>.yaml for pending roles."""
         with tempfile.TemporaryDirectory() as td:
             ctx, state_path = _make_ctx(
                 Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
+                reviewer_nominations=["reviewer_quality"],
             )
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.review_dir / "review_reviewer_quality.yaml").write_text(
@@ -193,6 +192,7 @@ class TestResumeGuard(unittest.TestCase):
             state = load_state(state_path)
             state["phase"] = "reviewing"
             state["last_event"] = "implementation_completed"
+            state["reviewer_nominations"] = ["reviewer_quality"]
             write_state(state_path, state)
 
             handler = ReviewingHandler()
@@ -202,6 +202,73 @@ class TestResumeGuard(unittest.TestCase):
                 (ctx.files.review_dir / "review_reviewer_quality.yaml").exists(),
                 "stale review_reviewer_quality.yaml must be deleted",
             )
+
+    def test_resume_ingests_pre_existing_yaml(self) -> None:
+        """On resume, valid review_<role>.yaml without state entry is ingested."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(
+                Path(td) / "feature",
+                reviewer_nominations=["reviewer_logic"],
+            )
+            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
+            (ctx.files.review_dir / "review_reviewer_logic.yaml").write_text(
+                yaml.dump(
+                    {
+                        "verdict": "pass",
+                        "summary": "All good",
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            (ctx.files.review_dir / "review.md").write_text(
+                "verdict: pass\n\n## Summary\n\nOK\n", encoding="utf-8"
+            )
+
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "resumed"
+            state["reviewer_nominations"] = ["reviewer_logic"]
+            # No review_results — should ingest from YAML
+            write_state(state_path, state)
+
+            handler = ReviewingHandler()
+            result = handler.enter(load_state(state_path), ctx)
+
+            # Should have ingested the verdict
+            self.assertIn("reviewer_logic", result.updates.get("review_results", {}))
+            # Should not re-dispatch
+            dispatch_calls = [
+                c for c in ctx.runtime.calls if c[0] == "send_reviewers_many"
+            ]
+            self.assertEqual([], dispatch_calls)
+
+    def test_enter_returns_phase_result_no_tuple_crash(self) -> None:
+        """enter() always returns PhaseResult, never tuple[dict, str|None]."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx, state_path = _make_ctx(
+                Path(td) / "feature",
+                reviewer_nominations=["reviewer_logic"],
+            )
+            ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
+            (ctx.files.review_dir / "review.md").write_text(
+                "verdict: pass\n\n## Summary\n\nOK\n", encoding="utf-8"
+            )
+            state = load_state(state_path)
+            state["phase"] = "reviewing"
+            state["last_event"] = "resumed"
+            state["reviewer_nominations"] = ["reviewer_logic"]
+            state["review_results"] = {
+                "reviewer_logic": {"verdict": "pass", "review_text": "OK"}
+            }
+            write_state(state_path, state)
+
+            handler = ReviewingHandler()
+            result = handler.enter(load_state(state_path), ctx)
+
+            self.assertIsInstance(result, PhaseResult)
+            # result.updates must be a dict, result.next_phase may be None
+            self.assertIsInstance(result.updates, dict)
 
 
 class TestReviewArchive(unittest.TestCase):
@@ -256,10 +323,7 @@ class TestReviewArchive(unittest.TestCase):
     def test_verdict_fail_creates_archive_and_keeps_review_yaml(self) -> None:
         role = "reviewer_quality"
         with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
+            ctx, state_path = _make_ctx(Path(td) / "feature")
             self._dispatch_review(
                 ctx, state_path, role, self._FAIL_PAYLOAD, iteration=0
             )
@@ -275,10 +339,7 @@ class TestReviewArchive(unittest.TestCase):
     def test_verdict_fail_second_iteration_archives_correctly(self) -> None:
         role = "reviewer_quality"
         with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
+            ctx, state_path = _make_ctx(Path(td) / "feature")
             self._dispatch_review(
                 ctx, state_path, role, self._FAIL_PAYLOAD, iteration=1
             )
@@ -289,10 +350,7 @@ class TestReviewArchive(unittest.TestCase):
     def test_verdict_pass_creates_archive_and_keeps_review_yaml(self) -> None:
         role = "reviewer_quality"
         with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
+            ctx, state_path = _make_ctx(Path(td) / "feature")
             # Create review.md so _request_summary doesn't fail on include
             ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
             (ctx.files.review_dir / "review.md").write_text(
@@ -315,10 +373,7 @@ class TestReviewArchive(unittest.TestCase):
     def test_archive_contains_same_content_as_review_md(self) -> None:
         role = "reviewer_quality"
         with tempfile.TemporaryDirectory() as td:
-            ctx, state_path = _make_ctx(
-                Path(td) / "feature",
-                review_strategy={"severity": "low", "focus": []},
-            )
+            ctx, state_path = _make_ctx(Path(td) / "feature")
             self._dispatch_review(
                 ctx, state_path, role, self._FAIL_PAYLOAD, iteration=2
             )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agentmux.runtime import ParallelPromptSpec, TmuxAgentRuntime
+from agentmux.runtime import ParallelPromptSpec, ReviewerSpec, TmuxAgentRuntime
 from agentmux.runtime.event_bus import EventBus
 from agentmux.runtime.interruption_sources import InterruptionEventSource
 from agentmux.shared.models import AgentConfig
@@ -753,6 +753,108 @@ class UnexpectedMissingRegisteredPanesTests(unittest.TestCase):
             result = runtime.unexpected_missing_registered_panes()
         self.assertEqual([], result)
         self.assertIn("%1", runtime._grace_panes)
+
+    def test_reviewer_spec_namedtuple_has_required_fields(self) -> None:
+        """ReviewerSpec NamedTuple has role, prompt_file, display_label."""
+        spec = ReviewerSpec(
+            role="reviewer_logic",
+            prompt_file=Path("/some/prompt.md"),
+            display_label="Logic Review",
+        )
+        self.assertEqual(spec.role, "reviewer_logic")
+        self.assertEqual(spec.prompt_file, Path("/some/prompt.md"))
+        self.assertEqual(spec.display_label, "Logic Review")
+
+    def test_reviewer_spec_display_label_defaults_to_none(self) -> None:
+        """ReviewerSpec display_label defaults to None."""
+        spec = ReviewerSpec(
+            role="reviewer_quality",
+            prompt_file=Path("/prompt.md"),
+        )
+        self.assertIsNone(spec.display_label)
+
+    def test_send_reviewers_many_creates_panes_per_role(self) -> None:
+        """send_reviewers_many creates panes per ReviewerSpec."""
+        with tempfile.TemporaryDirectory() as td:
+            feature_dir = Path(td)
+            prompt_a = feature_dir / "reviewer_a.md"
+            prompt_b = feature_dir / "reviewer_b.md"
+            prompt_a.write_text("review a", encoding="utf-8")
+            prompt_b.write_text("review b", encoding="utf-8")
+            zone = FakeZone("session-x")
+            created_panes: list[tuple[str, str]] = []  # (role, pane_id)
+            sent_prompts: list[tuple[str, str]] = []  # (pane_id, prompt_name)
+
+            def fake_create(
+                session_name, role, agents, project_dir, trust_snippet, **kwargs
+            ):
+                pane_id = f"%reviewer_{role}"
+                created_panes.append((role, pane_id))
+                return (pane_id, 12345)
+
+            def fake_send_prompt(pane_id, prompt_file):
+                sent_prompts.append((pane_id, prompt_file.name))
+
+            # Create agents config that includes the reviewer roles
+            reviewer_agents = {
+                **_agents(),
+                "reviewer_logic": AgentConfig(
+                    role="reviewer_logic", cli="claude", model="sonnet", args=[]
+                ),
+                "reviewer_quality": AgentConfig(
+                    role="reviewer_quality", cli="claude", model="sonnet", args=[]
+                ),
+            }
+
+            with (
+                patch("agentmux.runtime.tmux_pane_exists", return_value=False),
+                patch("agentmux.runtime.create_agent_pane", side_effect=fake_create),
+                patch("agentmux.runtime.send_prompt", side_effect=fake_send_prompt),
+                patch("agentmux.runtime.set_pane_identity", return_value=None),
+            ):
+                runtime = TmuxAgentRuntime(
+                    feature_dir=feature_dir,
+                    project_dir=Path("/project"),
+                    session_name="session-x",
+                    agents=reviewer_agents,
+                    primary_panes={"architect": "%1"},
+                    zone=zone,
+                )
+                result = runtime.send_reviewers_many(
+                    [
+                        ReviewerSpec(
+                            role="reviewer_logic",
+                            prompt_file=prompt_a,
+                            display_label="Logic Review",
+                        ),
+                        ReviewerSpec(
+                            role="reviewer_quality",
+                            prompt_file=prompt_b,
+                        ),
+                    ]
+                )
+
+            # Returns dict mapping role -> pane_id
+            self.assertEqual(
+                result,
+                {
+                    "reviewer_logic": "%reviewer_reviewer_logic",
+                    "reviewer_quality": "%reviewer_reviewer_quality",
+                },
+            )
+            # Parallel show called for all panes
+            self.assertEqual(
+                [["%reviewer_reviewer_logic", "%reviewer_reviewer_quality"]],
+                zone.parallel_shows,
+            )
+            # Prompts sent to correct panes
+            self.assertEqual(
+                {
+                    ("%reviewer_reviewer_logic", "reviewer_a.md"),
+                    ("%reviewer_reviewer_quality", "reviewer_b.md"),
+                },
+                set(sent_prompts),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_staged_execution_scheduler.py
+++ b/tests/test_staged_execution_scheduler.py
@@ -226,7 +226,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             handler = ImplementingHandler()
             state = load_state(state_path)
-            updates = handler.enter(state, ctx)
+            result = handler.enter(state, ctx)
+            updates = result.updates
             # Merge updates into state
             state.update(updates)
             write_state(state_path, state)
@@ -267,7 +268,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             handler = ImplementingHandler()
             state = load_state(state_path)
-            updates = handler.enter(state, ctx)
+            result = handler.enter(state, ctx)
+            updates = result.updates
             state.update(updates)
             write_state(state_path, state)
 
@@ -329,7 +331,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             handler = ImplementingHandler()
             state = load_state(state_path)
-            updates = handler.enter(state, ctx)
+            result = handler.enter(state, ctx)
+            updates = result.updates
             state.update(updates)
             write_state(state_path, state)
 
@@ -427,7 +430,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             handler = ImplementingHandler()
             state = load_state(state_path)
-            updates = handler.enter(state, ctx)
+            result = handler.enter(state, ctx)
+            updates = result.updates
             state.update(updates)
             write_state(state_path, state)
 
@@ -472,8 +476,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
             )
             resumed_handler = ImplementingHandler()
             resumed_state = load_state(state_path)
-            updates = resumed_handler.enter(resumed_state, resumed_ctx)
-            resumed_state.update(updates)
+            result = resumed_handler.enter(resumed_state, resumed_ctx)
+            resumed_state.update(result.updates)
             write_state(state_path, resumed_state)
 
             self.assertIn(
@@ -535,7 +539,8 @@ class StagedExecutionSchedulerTests(unittest.TestCase):
 
             handler = ImplementingHandler()
             state = load_state(state_path)
-            updates = handler.enter(state, ctx)
+            result = handler.enter(state, ctx)
+            updates = result.updates
             state.update(updates)
             write_state(state_path, state)
 

--- a/tests/test_web_researcher_requirements.py
+++ b/tests/test_web_researcher_requirements.py
@@ -34,6 +34,12 @@ class FakeRuntime:
     ) -> None:
         self.calls.append(("send", role, prompt_file.name, prefix_command))
 
+    def send_reviewers_many(self, reviewer_specs: list) -> dict[str, str]:
+        """Fake send_reviewers_many — records call and returns mock pane mapping."""
+        roles = [spec.role for spec in reviewer_specs]
+        self.calls.append(("send_reviewers_many", roles))
+        return {role: f"%pane_{role}" for role in roles}
+
     def send_many(self, role: str, prompt_specs: list[object]) -> None:
         self.calls.append(
             (
@@ -153,7 +159,7 @@ class WebResearcherRequirementsTests(unittest.TestCase):
             self.assertIn(str(feature_dir), prompt)
             self.assertIn(str(project_dir), prompt)
             self.assertIn("03_research/web-openai-models/request.md", prompt)
-            self.assertIn("03_research/web-openai-models/done", prompt)
+            self.assertIn("submit_research_done", prompt)
             self.assertIn("version", prompt.lower())
             self.assertTrue(
                 "fabricat" in prompt.lower() or "invent" in prompt.lower(),

--- a/tests/unit/runtime/test_runtime_parallel.py
+++ b/tests/unit/runtime/test_runtime_parallel.py
@@ -1,0 +1,254 @@
+"""Unit-Tests für send_reviewers_many() — Pane-Erstellung, Rückgabe.
+
+Tests für:
+- Erstellt Panes für alle Specs
+- Gibt korrekte {role: pane_id} Zuordnung zurück
+- Zeigt alle Panes parallel
+- Leere Liste wird gracefully behandelt
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from agentmux.runtime import ReviewerSpec, TmuxAgentRuntime
+
+
+def _fake_agents():
+    """Create minimal agents config for testing."""
+    from agentmux.runtime import AgentConfig
+
+    return {
+        "reviewer_logic": AgentConfig(
+            role="reviewer_logic", cli="claude", model="sonnet", args=[]
+        ),
+        "reviewer_quality": AgentConfig(
+            role="reviewer_quality", cli="claude", model="sonnet", args=[]
+        ),
+        "reviewer_expert": AgentConfig(
+            role="reviewer_expert", cli="claude", model="sonnet", args=[]
+        ),
+    }
+
+
+class FakeZone:
+    """Fake content_zone for testing."""
+
+    def __init__(self, session_name):
+        self.session_name = session_name
+        self.parallel_shows = []
+        self.visible = {}
+
+    def show_parallel(self, pane_ids):
+        self.parallel_shows.append(list(pane_ids))
+
+    def hide(self, pane_id):
+        pass
+
+
+class TestSendReviewersMany:
+    """Test send_reviewers_many() pane creation and return values."""
+
+    def test_creates_panes_for_all_specs(self, tmp_path):
+        """send_reviewers_many creates panes for each ReviewerSpec."""
+        feature_dir = tmp_path
+        prompt_a = feature_dir / "reviewer_logic.md"
+        prompt_b = feature_dir / "reviewer_quality.md"
+        prompt_a.write_text("logic review", encoding="utf-8")
+        prompt_b.write_text("quality review", encoding="utf-8")
+        zone = FakeZone("session-x")
+        created_panes = []
+        sent_prompts = []
+
+        def fake_create(
+            session_name, role, agents, project_dir, trust_snippet, **kwargs
+        ):
+            pane_id = f"%reviewer_{role}"
+            created_panes.append((role, pane_id))
+            return (pane_id, 12345)
+
+        def fake_send_prompt(pane_id, prompt_file):
+            sent_prompts.append((pane_id, prompt_file.name))
+
+        with (
+            patch("agentmux.runtime.tmux_pane_exists", return_value=False),
+            patch("agentmux.runtime.create_agent_pane", side_effect=fake_create),
+            patch("agentmux.runtime.send_prompt", side_effect=fake_send_prompt),
+            patch("agentmux.runtime.set_pane_identity", return_value=None),
+        ):
+            runtime = TmuxAgentRuntime(
+                feature_dir=feature_dir,
+                project_dir=Path("/project"),
+                session_name="session-x",
+                agents=_fake_agents(),
+                primary_panes={"architect": "%1"},
+                zone=zone,
+            )
+            result = runtime.send_reviewers_many(
+                [
+                    ReviewerSpec(
+                        role="reviewer_logic",
+                        prompt_file=prompt_a,
+                        display_label="Logic Review",
+                    ),
+                    ReviewerSpec(
+                        role="reviewer_quality",
+                        prompt_file=prompt_b,
+                    ),
+                ]
+            )
+
+        # Returns dict mapping role -> pane_id
+        assert result == {
+            "reviewer_logic": "%reviewer_reviewer_logic",
+            "reviewer_quality": "%reviewer_reviewer_quality",
+        }
+        # Parallel show called for all panes
+        assert zone.parallel_shows == [
+            ["%reviewer_reviewer_logic", "%reviewer_reviewer_quality"]
+        ]
+        # Prompts sent to correct panes
+        assert {
+            ("%reviewer_reviewer_logic", "reviewer_logic.md"),
+            ("%reviewer_reviewer_quality", "reviewer_quality.md"),
+        } == set(sent_prompts)
+
+    def test_empty_specs_returns_empty_dict(self, tmp_path):
+        """send_reviewers_many with empty list returns {}."""
+        feature_dir = tmp_path
+        zone = FakeZone("session-x")
+
+        runtime = TmuxAgentRuntime(
+            feature_dir=feature_dir,
+            project_dir=Path("/project"),
+            session_name="session-x",
+            agents=_fake_agents(),
+            primary_panes={"architect": "%1"},
+            zone=zone,
+        )
+        result = runtime.send_reviewers_many([])
+        assert result == {}
+
+    def test_three_roles_creates_all_panes(self, tmp_path):
+        """send_reviewers_many handles all 3 reviewer roles."""
+        feature_dir = tmp_path
+        prompt_logic = feature_dir / "logic.md"
+        prompt_quality = feature_dir / "quality.md"
+        prompt_expert = feature_dir / "expert.md"
+        prompt_logic.write_text("logic", encoding="utf-8")
+        prompt_quality.write_text("quality", encoding="utf-8")
+        prompt_expert.write_text("expert", encoding="utf-8")
+        zone = FakeZone("session-x")
+        sent_prompts = []
+
+        def fake_create(
+            session_name, role, agents, project_dir, trust_snippet, **kwargs
+        ):
+            return (f"%reviewer_{role}", 12345)
+
+        def fake_send_prompt(pane_id, prompt_file):
+            sent_prompts.append((pane_id, prompt_file.name))
+
+        with (
+            patch("agentmux.runtime.tmux_pane_exists", return_value=False),
+            patch("agentmux.runtime.create_agent_pane", side_effect=fake_create),
+            patch("agentmux.runtime.send_prompt", side_effect=fake_send_prompt),
+            patch("agentmux.runtime.set_pane_identity", return_value=None),
+        ):
+            runtime = TmuxAgentRuntime(
+                feature_dir=feature_dir,
+                project_dir=Path("/project"),
+                session_name="session-x",
+                agents=_fake_agents(),
+                primary_panes={"architect": "%1"},
+                zone=zone,
+            )
+            result = runtime.send_reviewers_many(
+                [
+                    ReviewerSpec(role="reviewer_logic", prompt_file=prompt_logic),
+                    ReviewerSpec(role="reviewer_quality", prompt_file=prompt_quality),
+                    ReviewerSpec(role="reviewer_expert", prompt_file=prompt_expert),
+                ]
+            )
+
+        assert len(result) == 3
+        assert "reviewer_logic" in result
+        assert "reviewer_quality" in result
+        assert "reviewer_expert" in result
+        assert len(sent_prompts) == 3
+
+    def test_parallel_panes_tracked_in_runtime(self, tmp_path):
+        """send_reviewers_many tracks panes in parallel_panes dict."""
+        feature_dir = tmp_path
+        prompt_a = feature_dir / "a.md"
+        prompt_a.write_text("a", encoding="utf-8")
+        zone = FakeZone("session-x")
+
+        def fake_create(
+            session_name, role, agents, project_dir, trust_snippet, **kwargs
+        ):
+            return (f"%reviewer_{role}", 12345)
+
+        def fake_send_prompt(pane_id, prompt_file):
+            pass
+
+        with (
+            patch("agentmux.runtime.tmux_pane_exists", return_value=False),
+            patch("agentmux.runtime.create_agent_pane", side_effect=fake_create),
+            patch("agentmux.runtime.send_prompt", side_effect=fake_send_prompt),
+            patch("agentmux.runtime.set_pane_identity", return_value=None),
+        ):
+            runtime = TmuxAgentRuntime(
+                feature_dir=feature_dir,
+                project_dir=Path("/project"),
+                session_name="session-x",
+                agents=_fake_agents(),
+                primary_panes={"architect": "%1"},
+                zone=zone,
+            )
+            runtime.send_reviewers_many(
+                [
+                    ReviewerSpec(role="reviewer_logic", prompt_file=prompt_a),
+                    ReviewerSpec(role="reviewer_quality", prompt_file=prompt_a),
+                ]
+            )
+
+        assert "reviewer_logic" in runtime.parallel_panes
+        assert "reviewer_quality" in runtime.parallel_panes
+
+    def test_unknown_role_is_skipped_without_raising(self, tmp_path):
+        """send_reviewers_many skips specs with unknown roles (no KeyError)."""
+        feature_dir = tmp_path
+        prompt_a = feature_dir / "a.md"
+        prompt_a.write_text("logic review", encoding="utf-8")
+        zone = FakeZone("session-x")
+
+        def fake_create(
+            session_name, role, agents, project_dir, trust_snippet, **kwargs
+        ):
+            return (f"%reviewer_{role}", 12345)
+
+        with (
+            patch("agentmux.runtime.tmux_pane_exists", return_value=False),
+            patch("agentmux.runtime.create_agent_pane", side_effect=fake_create),
+            patch("agentmux.runtime.send_prompt"),
+            patch("agentmux.runtime.set_pane_identity", return_value=None),
+        ):
+            runtime = TmuxAgentRuntime(
+                feature_dir=feature_dir,
+                project_dir=Path("/project"),
+                session_name="session-x",
+                agents=_fake_agents(),
+                primary_panes={},
+                zone=zone,
+            )
+            # reviewer_unknown is not in agents dict — must not raise KeyError
+            result = runtime.send_reviewers_many(
+                [
+                    ReviewerSpec(role="reviewer_logic", prompt_file=prompt_a),
+                    ReviewerSpec(role="reviewer_unknown", prompt_file=prompt_a),
+                ]
+            )
+
+        # Only the known role should be returned
+        assert "reviewer_logic" in result
+        assert "reviewer_unknown" not in result

--- a/tests/unit/workflow/handlers/test_reviewing.py
+++ b/tests/unit/workflow/handlers/test_reviewing.py
@@ -280,9 +280,14 @@ class TestResumeSupport:
                 "reviewer_quality": "completed",
                 "reviewer_expert": "completed",
             },
+            "reviewer_nominations": [
+                "reviewer_logic",
+                "reviewer_quality",
+                "reviewer_expert",
+            ],
         }
 
-        with patch.object(handler, "_request_summary", return_value={}):
+        with patch.object(handler, "_request_summary", return_value=({}, None)):
             handler.enter(state, ctx)
         # send_reviewers_many should NOT be called
         ctx.runtime.send_reviewers_many.assert_not_called()

--- a/tests/unit/workflow/handlers/test_reviewing.py
+++ b/tests/unit/workflow/handlers/test_reviewing.py
@@ -1,0 +1,450 @@
+"""Unit-Tests für Verdict-Aggregation-Logik in reviewing Handler.
+
+Tests für:
+- Erstes "fail" triggert sofort fixing
+- Alle "pass" triggert summary
+- Mixed verdicts (fail nach einem pass) → fixing mit aggregiertem Feedback
+- Parallele Reviews: wartet auf alle Reviewer bevor Transition
+- Resume-Support — abgeschlossene Reviews nicht wiederholen
+- review_yaml_has_verdict() mit role-spezifischen Dateien
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from agentmux.workflow.handlers.reviewing import ReviewingHandler
+from agentmux.workflow.handoff_artifacts import review_yaml_has_verdict
+
+
+class FakeContext:
+    """Minimal fake PipelineContext for testing."""
+
+    def __init__(self, tmp_path, max_review_iterations=2):
+        self.feature_dir = tmp_path
+        self.project_dir = tmp_path.parent / "project"
+        self.project_dir.mkdir(parents=True, exist_ok=True)
+
+        self.files = MagicMock()
+        self.files.planning_dir = tmp_path / "02_planning"
+        self.files.planning_dir.mkdir(parents=True)
+        self.files.review = tmp_path / "07_review" / "review.md"
+        self.files.review_dir = tmp_path / "07_review"
+        self.files.review_dir.mkdir(parents=True)
+        self.files.fix_request = tmp_path / "06_implementation" / "fix_request.txt"
+        self.files.fix_request.parent.mkdir(parents=True)
+        self.files.completion_dir = tmp_path / "08_completion"
+        self.files.completion_dir.mkdir(parents=True)
+        self.files.summary = self.files.completion_dir / "summary.md"
+        self.files.relative_path = lambda p: p.relative_to(tmp_path)
+        self.files.project_dir = self.project_dir
+        self.files.feature_dir = tmp_path
+
+        # Create context.md required for reviewer prompts
+        (tmp_path / "context.md").write_text("# Context", encoding="utf-8")
+        # Create architecture file
+        (tmp_path / "02_architecting").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "02_architecting" / "architecture.md").write_text(
+            "# Architecture", encoding="utf-8"
+        )
+        # Create requirements file
+        (tmp_path / "requirements.md").write_text("# Requirements", encoding="utf-8")
+
+        self.runtime = MagicMock()
+        self.max_review_iterations = max_review_iterations
+        self.agents = {
+            "reviewer_logic": MagicMock(),
+            "reviewer_quality": MagicMock(),
+            "reviewer_expert": MagicMock(),
+        }
+
+        # Write a default execution_plan.yaml
+        plan_meta = {"review_strategy": {"severity": "medium", "focus": []}}
+        (self.files.planning_dir / "execution_plan.yaml").write_text(
+            yaml.dump(plan_meta, default_flow_style=False)
+        )
+
+    def write_review_yaml(self, role: str, verdict: str, findings: list | None = None):
+        """Write a role-specific review YAML file with all required fields."""
+        # Ensure findings are in dict format expected by generate_review_md
+        formatted_findings = []
+        if findings:
+            for f in findings:
+                if isinstance(f, str):
+                    formatted_findings.append(
+                        {
+                            "location": "unknown",
+                            "issue": f,
+                            "severity": "high",
+                            "recommendation": "Fix this issue",
+                        }
+                    )
+                else:
+                    formatted_findings.append(f)
+
+        data = {
+            "verdict": verdict,
+            "summary": "Review summary" if findings else "No issues",
+            "findings": formatted_findings,
+            "commit_message": "feat: done" if verdict == "pass" else "",
+        }
+        (self.files.review_dir / f"review_{role}.yaml").write_text(
+            yaml.dump(data, default_flow_style=False)
+        )
+
+    def write_review_md(self, content: str):
+        self.files.review.write_text(content)
+
+
+class TestVerdictAggregation:
+    """Test verdict aggregation logic in _handle_review."""
+
+    def test_fail_transitions_to_fixing(self, tmp_path):
+        """First 'fail' verdict triggers transition to fixing."""
+        ctx = FakeContext(tmp_path)
+        role = "reviewer_logic"
+        ctx.write_review_yaml(role, "fail", findings=["security issue found"])
+        # Also create review.md for summary prompt include
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\nsecurity issue found", encoding="utf-8"
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        assert state_update["last_event"] is not None
+        assert state_update["review_iteration"] == 1
+        assert ctx.files.fix_request.exists()
+
+    def test_pass_transitions_to_requesting_summary(self, tmp_path):
+        """All 'pass' verdicts trigger summary request."""
+        ctx = FakeContext(tmp_path)
+        role = "reviewer_logic"
+        ctx.write_review_yaml(role, "pass")
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: pass\n\n## Summary\n\nNo blocking issues.", encoding="utf-8"
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        with (
+            patch(
+                "agentmux.workflow.handlers.reviewing.write_prompt_file"
+            ) as mock_write,
+            patch(
+                "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                return_value="summary prompt",
+            ),
+            patch("agentmux.workflow.handlers.reviewing.send_to_role") as mock_send,
+        ):
+            mock_write.return_value = Path("/tmp/prompt.md")
+            state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase is None  # stays in reviewing, awaiting summary
+        assert state_update.get("awaiting_summary") is True
+        mock_send.assert_called_once()
+
+    def test_fail_at_max_iterations_transitions_to_completing(self, tmp_path):
+        """Fail at max_review_iterations transitions to completing."""
+        ctx = FakeContext(tmp_path, max_review_iterations=1)
+        role = "reviewer_logic"
+        ctx.write_review_yaml(role, "fail", findings=["still broken"])
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\nstill broken", encoding="utf-8"
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 1,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "completing"
+        assert state_update["last_event"] is not None
+        # fix_request should NOT be written at max iterations
+        assert not ctx.files.fix_request.exists()
+
+    def test_mixed_verdicts_fail_after_pass_transitions_to_fixing(self, tmp_path):
+        """Mixed verdicts: fail after a pass → fixing with aggregated feedback."""
+        ctx = FakeContext(tmp_path)
+        role = "reviewer_logic"
+        # Simulate: first reviewer passed, second fails
+        ctx.write_review_yaml(role, "fail", findings=["new issue found after pass"])
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\nnew issue found after pass",
+            encoding="utf-8",
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {
+                "reviewer_quality": {"verdict": "pass", "review_text": "All good"}
+            },
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        assert state_update["review_iteration"] == 1
+        assert ctx.files.fix_request.exists()
+        content = ctx.files.fix_request.read_text()
+        assert "new issue found after pass" in content
+
+    def test_review_archived_per_iteration(self, tmp_path):
+        """Each review iteration is archived as review_N_<role>.md."""
+        ctx = FakeContext(tmp_path)
+        role = "reviewer_logic"
+        ctx.write_review_yaml(role, "fail", findings=["iteration 0 issue"])
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\niteration 0 issue", encoding="utf-8"
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        handler._handle_review(event, state, ctx)
+
+        archive_path = ctx.files.review_dir / f"review_0_{role}.md"
+        assert archive_path.exists()
+        assert "iteration 0 issue" in archive_path.read_text()
+
+    def test_invalid_verdict_returns_no_transition(self, tmp_path):
+        """Invalid verdict results in no state transition."""
+        ctx = FakeContext(tmp_path)
+        role = "reviewer_logic"
+        ctx.write_review_yaml(role, "maybe")
+        (ctx.files.review_dir / "review.md").write_text(
+            "verdict: unknown\n\n## Summary\n\nunclear", encoding="utf-8"
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase is None
+        # Handler always returns state updates even for invalid verdicts
+        assert "review_results" in state_update
+        assert "active_reviews" in state_update
+
+
+class TestResumeSupport:
+    """Test resume support — completed reviews are not repeated."""
+
+    def test_enter_skips_if_review_results_exist(self, tmp_path):
+        """On resume, if review_results has entries, enter() does not re-dispatch."""
+        ctx = FakeContext(tmp_path)
+
+        handler = ReviewingHandler()
+        state = {
+            "last_event": "resumed",
+            "review_results": {
+                "reviewer_logic": {"verdict": "pass", "review_text": "OK"},
+                "reviewer_quality": {"verdict": "pass", "review_text": "OK"},
+                "reviewer_expert": {"verdict": "pass", "review_text": "OK"},
+            },
+            "active_reviews": {
+                "reviewer_logic": "completed",
+                "reviewer_quality": "completed",
+                "reviewer_expert": "completed",
+            },
+        }
+
+        with patch.object(handler, "_request_summary", return_value={}):
+            handler.enter(state, ctx)
+        # send_reviewers_many should NOT be called
+        ctx.runtime.send_reviewers_many.assert_not_called()
+
+    def test_enter_dispatches_when_no_review_results(self, tmp_path):
+        """When no review_results exist, enter() dispatches reviewers."""
+        ctx = FakeContext(tmp_path)
+
+        handler = ReviewingHandler()
+        state = {
+            "last_event": "resumed",
+            "review_results": {},
+        }
+
+        with patch.object(handler, "_request_summary", return_value={}):
+            handler.enter(state, ctx)
+        # send_reviewers_many SHOULD be called
+        ctx.runtime.send_reviewers_many.assert_called_once()
+
+
+class TestParallelVerdictFlow:
+    """Tests for parallel review flow — multiple reviewers running simultaneously."""
+
+    def test_first_pass_waits_for_second_reviewer(self, tmp_path):
+        """When two reviewers are pending and only one passes, no transition yet."""
+        ctx = FakeContext(tmp_path)
+        # Only logic has submitted a review — quality is still pending
+        ctx.write_review_yaml("reviewer_logic", "pass")
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {
+                "reviewer_logic": "pending",
+                "reviewer_quality": "pending",
+            },
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase is None  # still waiting for reviewer_quality
+        assert state_update["active_reviews"]["reviewer_logic"] == "completed"
+        assert state_update["active_reviews"]["reviewer_quality"] == "pending"
+        assert not ctx.files.fix_request.exists()
+
+    def test_both_pass_simultaneously_triggers_summary(self, tmp_path):
+        """When all reviewers pass in one scan, summary is triggered immediately."""
+        ctx = FakeContext(tmp_path)
+        ctx.write_review_yaml("reviewer_logic", "pass")
+        ctx.write_review_yaml("reviewer_quality", "pass")
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {
+                "reviewer_logic": "pending",
+                "reviewer_quality": "pending",
+            },
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        with (
+            patch(
+                "agentmux.workflow.handlers.reviewing.write_prompt_file"
+            ) as mock_write,
+            patch(
+                "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                return_value="summary prompt",
+            ),
+            patch("agentmux.workflow.handlers.reviewing.send_to_role") as mock_send,
+        ):
+            mock_write.return_value = Path("/tmp/prompt.md")
+            state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase is None  # stays in reviewing, awaiting summary
+        assert state_update.get("awaiting_summary") is True
+        mock_send.assert_called_once()
+
+    def test_fail_aggregates_feedback_from_passing_reviewer_too(self, tmp_path):
+        """When one reviewer passes and another fails, fix_request contains both."""
+        ctx = FakeContext(tmp_path)
+        ctx.write_review_yaml("reviewer_logic", "pass")
+        ctx.write_review_yaml(
+            "reviewer_quality", "fail", findings=["quality issue found"]
+        )
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {
+                "reviewer_logic": "pending",
+                "reviewer_quality": "pending",
+            },
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        assert ctx.files.fix_request.exists()
+        content = ctx.files.fix_request.read_text()
+        # fix_request must aggregate feedback from ALL completed reviewers
+        assert "reviewer_logic" in content
+        assert "reviewer_quality" in content
+        assert "quality issue found" in content
+
+
+class TestReviewYamlHasVerdictParallel:
+    """Tests for review_yaml_has_verdict() with parallel role-specific files."""
+
+    def test_returns_true_for_legacy_review_yaml(self, tmp_path):
+        """review_yaml_has_verdict() still works for the legacy review.yaml path."""
+        review_dir = tmp_path / "07_review"
+        review_dir.mkdir()
+        (review_dir / "review.yaml").write_text(
+            yaml.dump({"verdict": "pass", "summary": "OK", "findings": []}),
+            encoding="utf-8",
+        )
+        assert review_yaml_has_verdict(review_dir) is True
+
+    def test_returns_true_for_role_specific_reviewer_file(self, tmp_path):
+        """review_yaml_has_verdict() returns True for a role-specific file."""
+        review_dir = tmp_path / "07_review"
+        review_dir.mkdir()
+        (review_dir / "review_reviewer_logic.yaml").write_text(
+            yaml.dump({"verdict": "pass", "summary": "All good", "findings": []}),
+            encoding="utf-8",
+        )
+        assert review_yaml_has_verdict(review_dir) is True
+
+    def test_returns_true_for_fail_verdict_in_role_specific_file(self, tmp_path):
+        """review_yaml_has_verdict() returns True for a fail verdict in role file."""
+        review_dir = tmp_path / "07_review"
+        review_dir.mkdir()
+        (review_dir / "review_reviewer_expert.yaml").write_text(
+            yaml.dump(
+                {
+                    "verdict": "fail",
+                    "summary": "Issues found",
+                    "findings": [{"issue": "bug", "recommendation": "fix"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert review_yaml_has_verdict(review_dir) is True
+
+    def test_returns_false_when_no_review_files_exist(self, tmp_path):
+        """review_yaml_has_verdict() returns False when no review files exist."""
+        review_dir = tmp_path / "07_review"
+        review_dir.mkdir()
+        assert review_yaml_has_verdict(review_dir) is False
+
+    def test_returns_false_for_invalid_verdict_in_role_specific_file(self, tmp_path):
+        """review_yaml_has_verdict() returns False for invalid verdict in role file."""
+        review_dir = tmp_path / "07_review"
+        review_dir.mkdir()
+        (review_dir / "review_reviewer_logic.yaml").write_text(
+            yaml.dump({"verdict": "maybe", "summary": "Unsure"}),
+            encoding="utf-8",
+        )
+        assert review_yaml_has_verdict(review_dir) is False

--- a/tests/unit/workflow/handlers/test_reviewing.py
+++ b/tests/unit/workflow/handlers/test_reviewing.py
@@ -393,6 +393,101 @@ class TestParallelVerdictFlow:
         assert "reviewer_quality" in content
         assert "quality issue found" in content
 
+    def test_two_simultaneous_fails_aggregate_both_feedback(self, tmp_path):
+        """Two reviewers fail in the same scan — fix_request contains both findings.
+
+        Regression test for partial-aggregation bug: the previous code returned on
+        the first 'fail' encountered in alphabetical order, dropping later fails'
+        feedback. Here `expert` is processed first alphabetically; without the fix,
+        `logic`'s findings would be silently lost.
+        """
+        ctx = FakeContext(tmp_path)
+        ctx.write_review_yaml(
+            "reviewer_expert", "fail", findings=["security regression"]
+        )
+        ctx.write_review_yaml("reviewer_logic", "fail", findings=["plan deviation"])
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {
+                "reviewer_expert": "pending",
+                "reviewer_logic": "pending",
+            },
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        _state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        content = ctx.files.fix_request.read_text()
+        assert "security regression" in content
+        assert "plan deviation" in content
+        assert "reviewer_expert" in content
+        assert "reviewer_logic" in content
+
+    def test_pending_reviewer_pane_killed_on_early_fail(self, tmp_path):
+        """When one reviewer fails while another is still pending, the pending
+        reviewer's pane is torn down before transitioning to fixing — otherwise
+        we leak a still-running reviewer process."""
+        ctx = FakeContext(tmp_path)
+        ctx.write_review_yaml("reviewer_expert", "fail", findings=["something bad"])
+        # reviewer_logic is in active_reviews but never wrote a file
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {
+                "reviewer_expert": "pending",
+                "reviewer_logic": "pending",
+            },
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        _state_update, next_phase = handler._handle_review(event, state, ctx)
+
+        assert next_phase == "fixing"
+        ctx.runtime.kill_primary.assert_any_call("reviewer_logic")
+
+    def test_coder_panes_killed_on_review_pass(self, tmp_path):
+        """When all reviewers pass and we request the summary, the coder pane(s)
+        must be torn down (`finish_many` + `kill_primary`). Regression test for
+        cleanup that existed on main but was dropped by the parallel-reviewer
+        refactor.
+        """
+        ctx = FakeContext(tmp_path)
+        ctx.write_review_yaml("reviewer_logic", "pass")
+        ctx.write_review_yaml("reviewer_quality", "pass")
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {
+                "reviewer_logic": "pending",
+                "reviewer_quality": "pending",
+            },
+            "review_results": {},
+        }
+        event = MagicMock()
+
+        with (
+            patch(
+                "agentmux.workflow.handlers.reviewing.write_prompt_file"
+            ) as mock_write,
+            patch(
+                "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                return_value="summary prompt",
+            ),
+            patch("agentmux.workflow.handlers.reviewing.send_to_role"),
+        ):
+            mock_write.return_value = Path("/tmp/prompt.md")
+            _state_update, _next_phase = handler._handle_review(event, state, ctx)
+
+        ctx.runtime.finish_many.assert_any_call("coder")
+        ctx.runtime.kill_primary.assert_any_call("coder")
+
 
 class TestReviewYamlHasVerdictParallel:
     """Tests for review_yaml_has_verdict() with parallel role-specific files."""

--- a/tests/unit/workflow/test_phase_helpers.py
+++ b/tests/unit/workflow/test_phase_helpers.py
@@ -1,85 +1,56 @@
-"""Unit-Tests für select_reviewer_roles() — alle 5 Kombinationen + Defaults.
-
-Diese Tests ergänzen die bestehenden Tests in tests/test_review_routing.py
-und dokumentieren explizit die 5 Severity/Focus-Kombinationen aus dem Plan.
-"""
+"""Unit-Tests für state-based select_reviewer_roles()."""
 
 from agentmux.workflow.phase_helpers import select_reviewer_roles
 
 
-class TestSelectReviewerRolesAllCombinations:
-    """Test all 5 severity/focus combinations from the plan."""
+class TestSelectReviewerRolesStateBased:
+    """Test all state-based nomination scenarios."""
 
-    def test_missing_review_strategy_defaults_to_logic(self):
-        """Missing review_strategy -> ["logic"] (default)."""
-        plan_meta = {"needs_design": False, "needs_docs": True}
-        assert select_reviewer_roles(plan_meta) == ["logic"]
+    def test_missing_nominations_defaults_to_logic(self):
+        """Missing reviewer_nominations -> ["reviewer_logic"] (default)."""
+        state = {"phase": "reviewing"}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
 
-    def test_empty_plan_meta_defaults_to_logic(self):
-        """Empty plan_meta -> ["logic"]."""
-        assert select_reviewer_roles({}) == ["logic"]
+    def test_empty_nominations_defaults_to_logic(self):
+        """Empty list -> ["reviewer_logic"]."""
+        assert select_reviewer_roles({"reviewer_nominations": []}) == ["reviewer_logic"]
 
-    def test_low_severity_returns_quality(self):
-        """low severity -> ["quality"] regardless of focus."""
-        plan_meta = {"review_strategy": {"severity": "low", "focus": ["accessibility"]}}
-        assert select_reviewer_roles(plan_meta) == ["quality"]
+    def test_single_nomination_preserved(self):
+        """Single valid nomination preserved."""
+        state = {"reviewer_nominations": ["reviewer_quality"]}
+        assert select_reviewer_roles(state) == ["reviewer_quality"]
 
-    def test_medium_severity_no_security_performance_returns_logic(self):
-        """medium severity + no security/performance -> ["logic"]."""
-        plan_meta = {
-            "review_strategy": {"severity": "medium", "focus": ["accessibility"]}
+    def test_multiple_nominations_preserved(self):
+        """Multiple valid nominations preserved."""
+        state = {"reviewer_nominations": ["reviewer_logic", "reviewer_expert"]}
+        assert select_reviewer_roles(state) == ["reviewer_logic", "reviewer_expert"]
+
+    def test_unknown_filtered(self):
+        """Unknown roles filtered out, valid kept."""
+        state = {
+            "reviewer_nominations": ["reviewer_logic", "invalid", "reviewer_quality"]
         }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
+        assert select_reviewer_roles(state) == ["reviewer_logic", "reviewer_quality"]
 
-    def test_medium_severity_with_security_returns_expert(self):
-        """medium severity + security focus -> ["expert"]."""
-        plan_meta = {"review_strategy": {"severity": "medium", "focus": ["security"]}}
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-    def test_medium_severity_with_performance_returns_expert(self):
-        """medium severity + performance focus -> ["expert"]."""
-        plan_meta = {
-            "review_strategy": {"severity": "medium", "focus": ["performance"]}
-        }
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-    def test_high_severity_no_security_performance_returns_logic(self):
-        """high severity + no security/performance -> ["logic"]."""
-        plan_meta = {
-            "review_strategy": {"severity": "high", "focus": ["accessibility"]}
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
-
-    def test_high_severity_with_security_returns_expert(self):
-        """high severity + security focus -> ["expert"]."""
-        plan_meta = {"review_strategy": {"severity": "high", "focus": ["security"]}}
-        assert select_reviewer_roles(plan_meta) == ["expert"]
-
-    def test_high_severity_with_performance_returns_expert(self):
-        """high severity + performance focus -> ["expert"]."""
-        plan_meta = {"review_strategy": {"severity": "high", "focus": ["performance"]}}
-        assert select_reviewer_roles(plan_meta) == ["expert"]
+    def test_all_unknown_returns_logic(self):
+        """If all filtered, fallback to logic."""
+        state = {"reviewer_nominations": ["invalid", "fake"]}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
 
 
 class TestSelectReviewerRolesEdgeCases:
     """Edge cases for select_reviewer_roles()."""
 
-    def test_invalid_severity_defaults_to_logic(self):
-        """Invalid severity value -> ["logic"]."""
-        plan_meta = {"review_strategy": {"severity": "unknown", "focus": []}}
-        assert select_reviewer_roles(plan_meta) == ["logic"]
+    def test_none_value_returns_logic(self):
+        """None value -> ["reviewer_logic"]."""
+        state = {"reviewer_nominations": None}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
 
-    def test_non_list_focus_handles_gracefully(self):
-        """Focus as non-list value -> handles gracefully, returns ["logic"]."""
-        plan_meta = {"review_strategy": {"severity": "medium", "focus": "security"}}
-        assert select_reviewer_roles(plan_meta) == ["logic"]
+    def test_string_value_returns_logic(self):
+        """String (non-list) -> ["reviewer_logic"]."""
+        state = {"reviewer_nominations": "reviewer_expert"}
+        assert select_reviewer_roles(state) == ["reviewer_logic"]
 
-    def test_unknown_focus_values_routes_by_severity(self):
-        """Unknown focus values -> routes based on severity alone."""
-        plan_meta = {
-            "review_strategy": {
-                "severity": "medium",
-                "focus": ["unknown", "another_unknown"],
-            }
-        }
-        assert select_reviewer_roles(plan_meta) == ["logic"]
+    def test_empty_state_returns_logic(self):
+        """Empty state -> ["reviewer_logic"]."""
+        assert select_reviewer_roles({}) == ["reviewer_logic"]

--- a/tests/unit/workflow/test_phase_helpers.py
+++ b/tests/unit/workflow/test_phase_helpers.py
@@ -1,0 +1,85 @@
+"""Unit-Tests für select_reviewer_roles() — alle 5 Kombinationen + Defaults.
+
+Diese Tests ergänzen die bestehenden Tests in tests/test_review_routing.py
+und dokumentieren explizit die 5 Severity/Focus-Kombinationen aus dem Plan.
+"""
+
+from agentmux.workflow.phase_helpers import select_reviewer_roles
+
+
+class TestSelectReviewerRolesAllCombinations:
+    """Test all 5 severity/focus combinations from the plan."""
+
+    def test_missing_review_strategy_defaults_to_logic(self):
+        """Missing review_strategy -> ["logic"] (default)."""
+        plan_meta = {"needs_design": False, "needs_docs": True}
+        assert select_reviewer_roles(plan_meta) == ["logic"]
+
+    def test_empty_plan_meta_defaults_to_logic(self):
+        """Empty plan_meta -> ["logic"]."""
+        assert select_reviewer_roles({}) == ["logic"]
+
+    def test_low_severity_returns_quality(self):
+        """low severity -> ["quality"] regardless of focus."""
+        plan_meta = {"review_strategy": {"severity": "low", "focus": ["accessibility"]}}
+        assert select_reviewer_roles(plan_meta) == ["quality"]
+
+    def test_medium_severity_no_security_performance_returns_logic(self):
+        """medium severity + no security/performance -> ["logic"]."""
+        plan_meta = {
+            "review_strategy": {"severity": "medium", "focus": ["accessibility"]}
+        }
+        assert select_reviewer_roles(plan_meta) == ["logic"]
+
+    def test_medium_severity_with_security_returns_expert(self):
+        """medium severity + security focus -> ["expert"]."""
+        plan_meta = {"review_strategy": {"severity": "medium", "focus": ["security"]}}
+        assert select_reviewer_roles(plan_meta) == ["expert"]
+
+    def test_medium_severity_with_performance_returns_expert(self):
+        """medium severity + performance focus -> ["expert"]."""
+        plan_meta = {
+            "review_strategy": {"severity": "medium", "focus": ["performance"]}
+        }
+        assert select_reviewer_roles(plan_meta) == ["expert"]
+
+    def test_high_severity_no_security_performance_returns_logic(self):
+        """high severity + no security/performance -> ["logic"]."""
+        plan_meta = {
+            "review_strategy": {"severity": "high", "focus": ["accessibility"]}
+        }
+        assert select_reviewer_roles(plan_meta) == ["logic"]
+
+    def test_high_severity_with_security_returns_expert(self):
+        """high severity + security focus -> ["expert"]."""
+        plan_meta = {"review_strategy": {"severity": "high", "focus": ["security"]}}
+        assert select_reviewer_roles(plan_meta) == ["expert"]
+
+    def test_high_severity_with_performance_returns_expert(self):
+        """high severity + performance focus -> ["expert"]."""
+        plan_meta = {"review_strategy": {"severity": "high", "focus": ["performance"]}}
+        assert select_reviewer_roles(plan_meta) == ["expert"]
+
+
+class TestSelectReviewerRolesEdgeCases:
+    """Edge cases for select_reviewer_roles()."""
+
+    def test_invalid_severity_defaults_to_logic(self):
+        """Invalid severity value -> ["logic"]."""
+        plan_meta = {"review_strategy": {"severity": "unknown", "focus": []}}
+        assert select_reviewer_roles(plan_meta) == ["logic"]
+
+    def test_non_list_focus_handles_gracefully(self):
+        """Focus as non-list value -> handles gracefully, returns ["logic"]."""
+        plan_meta = {"review_strategy": {"severity": "medium", "focus": "security"}}
+        assert select_reviewer_roles(plan_meta) == ["logic"]
+
+    def test_unknown_focus_values_routes_by_severity(self):
+        """Unknown focus values -> routes based on severity alone."""
+        plan_meta = {
+            "review_strategy": {
+                "severity": "medium",
+                "focus": ["unknown", "another_unknown"],
+            }
+        }
+        assert select_reviewer_roles(plan_meta) == ["logic"]

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -22,7 +22,7 @@ from agentmux.workflow.event_catalog import (
     EVENT_PM_COMPLETED,
     EVENT_REVIEW_PASSED,
 )
-from agentmux.workflow.event_router import WorkflowEvent
+from agentmux.workflow.event_router import PhaseResult, WorkflowEvent
 from agentmux.workflow.handlers import (
     PHASE_HANDLERS,
     CompletingHandler,
@@ -107,14 +107,14 @@ class TestProductManagementHandler:
             mock_write.return_value = Path("/mock/prompt.md")
             mock_build.return_value = "mock prompt content"
 
-            updates = handler.enter(empty_state, mock_ctx)
+            result = handler.enter(empty_state, mock_ctx)
 
             mock_build.assert_called_once_with(mock_ctx.files, None)
             mock_write.assert_called_once()
             mock_send.assert_called_once_with(
                 mock_ctx, "product-manager", Path("/mock/prompt.md")
             )
-            assert updates == {}
+            assert result.updates == {}
 
     def test_handle_pm_completed(self, mock_ctx: MagicMock, empty_state: dict) -> None:
         """Test handling of pm_done marker."""
@@ -574,12 +574,12 @@ class TestImplementingHandler:
             mock_write.return_value = Path("/mock/prompt.md")
             mock_build.return_value = "coder prompt"
 
-            updates = handler.enter(state, mock_ctx)
+            result = handler.enter(state, mock_ctx)
 
             mock_reset.assert_called_once()
             mock_ctx.runtime.kill_primary.assert_called_once_with("coder")
-            assert "subplan_count" in updates
-            assert updates["subplan_count"] == 1
+            assert "subplan_count" in result.updates
+            assert result.updates["subplan_count"] == 1
 
     def test_handle_subplan_completed_parallel_mode(self, mock_ctx: MagicMock) -> None:
         """Test handling subplan completion in parallel mode."""
@@ -1065,9 +1065,9 @@ class TestImplementingHandler:
         )
 
         with patch.object(handler, "_dispatch_active_group"):
-            updates = handler.enter(state, mock_ctx)
+            result = handler.enter(state, mock_ctx)
 
-        assert updates["implementation_single_coder"] is False
+        assert result.updates["implementation_single_coder"] is False
 
 
 class TestReviewingHandler:
@@ -1076,29 +1076,22 @@ class TestReviewingHandler:
     def test_enter_sends_reviewer_prompt(
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
-        """Test that enter() sends reviewer prompt via send_reviewers_many."""
+        """Test that enter() dispatches reviewers via ctx.runtime."""
         handler = ReviewingHandler()
 
-        mock_builder = MagicMock(return_value="reviewer logic prompt")
+        with patch(
+            "agentmux.workflow.handlers.reviewing.select_reviewer_roles"
+        ) as mock_select:
+            # Mock to return a single reviewer for simplicity
+            mock_select.return_value = ["reviewer_logic"]
 
-        with (
-            patch(
-                "agentmux.workflow.handlers.reviewing.write_prompt_file"
-            ) as mock_write,
-            patch(
-                "agentmux.workflow.handlers.reviewing.role_display_label"
-            ) as mock_label,
-            patch.dict(
-                "agentmux.workflow.handlers.reviewing._REVIEWER_PROMPT_BUILDERS",
-                {"logic": mock_builder},
-            ),
-        ):
-            mock_write.return_value = Path("/mock/prompt.md")
-            mock_label.return_value = "[reviewer] iteration 1"
+            result = handler.enter(empty_state, mock_ctx)
 
-            handler.enter(empty_state, mock_ctx)
-
-            mock_builder.assert_called_once()
+            # Should return PhaseResult with updates
+            assert isinstance(result, PhaseResult)
+            # select_reviewer_roles should be called
+            mock_select.assert_called_once()
+            # ctx.runtime.send_reviewers_many should be called via the mock
             mock_ctx.runtime.send_reviewers_many.assert_called_once()
 
     def test_handle_review_passed(self, mock_ctx: MagicMock, empty_state: dict) -> None:
@@ -1474,9 +1467,9 @@ class TestFailedHandler:
         """Test that enter() returns empty updates."""
         handler = FailedHandler()
 
-        updates = handler.enter(empty_state, mock_ctx)
+        result = handler.enter(empty_state, mock_ctx)
 
-        assert updates == {}
+        assert result.updates == {}
 
     def test_handle_event_returns_exit_failure(
         self, mock_ctx: MagicMock, empty_state: dict

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -1076,36 +1076,38 @@ class TestReviewingHandler:
     def test_enter_sends_reviewer_prompt(
         self, mock_ctx: MagicMock, empty_state: dict
     ) -> None:
-        """Test that enter() sends reviewer prompt."""
+        """Test that enter() sends reviewer prompt via send_reviewers_many."""
         handler = ReviewingHandler()
+
+        mock_builder = MagicMock(return_value="reviewer logic prompt")
 
         with (
             patch(
                 "agentmux.workflow.handlers.reviewing.write_prompt_file"
             ) as mock_write,
-            patch("agentmux.workflow.handlers.reviewing.send_to_role") as mock_send,
-            patch(
-                "agentmux.workflow.handlers.reviewing.build_reviewer_logic_prompt"
-            ) as mock_build_logic,
             patch(
                 "agentmux.workflow.handlers.reviewing.role_display_label"
             ) as mock_label,
+            patch.dict(
+                "agentmux.workflow.handlers.reviewing._REVIEWER_PROMPT_BUILDERS",
+                {"logic": mock_builder},
+            ),
         ):
             mock_write.return_value = Path("/mock/prompt.md")
-            mock_build_logic.return_value = "reviewer logic prompt"
             mock_label.return_value = "[reviewer] iteration 1"
 
             handler.enter(empty_state, mock_ctx)
 
-            mock_build_logic.assert_called_once()
-            mock_send.assert_called_once()
+            mock_builder.assert_called_once()
+            mock_ctx.runtime.send_reviewers_many.assert_called_once()
 
     def test_handle_review_passed(self, mock_ctx: MagicMock, empty_state: dict) -> None:
         """Test that VERDICT:PASS stays in reviewing and requests summary."""
         handler = ReviewingHandler()
 
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "pass",
@@ -1116,12 +1118,19 @@ class TestReviewingHandler:
                 default_flow_style=False,
             )
         )
+        # Create review.md for summary prompt include
+        (mock_ctx.files.review_dir / "review.md").write_text(
+            "verdict: pass\n\n## Summary\n\nLooks good!", encoding="utf-8"
+        )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
 
-        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
-        mock_ctx.runtime.finish_many.assert_called_once_with("coder")
-        mock_ctx.runtime.kill_primary.assert_called_once_with("coder")
         # Stays in reviewing, awaiting summary
         assert next_phase is None
         assert updates.get("awaiting_summary") is True
@@ -1133,8 +1142,9 @@ class TestReviewingHandler:
         """Review tool event writes both review.yaml and review.md."""
         handler = ReviewingHandler()
 
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "pass",
@@ -1145,13 +1155,22 @@ class TestReviewingHandler:
                 default_flow_style=False,
             )
         )
+        # Create review.md for summary prompt include
+        (mock_ctx.files.review_dir / "review.md").write_text(
+            "verdict: pass\n\n## Summary\n\nLooks good!", encoding="utf-8"
+        )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
 
-        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
         assert next_phase is None
         assert updates.get("awaiting_summary") is True
-        yaml_path = mock_ctx.files.review_dir / "review.yaml"
+        yaml_path = mock_ctx.files.review_dir / f"review_{role}.yaml"
         assert yaml_path.exists()
         assert mock_ctx.files.review.exists()
         assert mock_ctx.files.review.read_text(encoding="utf-8").startswith(
@@ -1164,8 +1183,9 @@ class TestReviewingHandler:
         """Test transition to fixing when under max iterations."""
         handler = ReviewingHandler()
 
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "fail",
@@ -1183,9 +1203,18 @@ class TestReviewingHandler:
                 default_flow_style=False,
             )
         )
+        # Create review.md for summary prompt include
+        (mock_ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\nNeeds fixes", encoding="utf-8"
+        )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
 
-        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
         assert next_phase == "fixing"
         assert updates["review_iteration"] == 1
@@ -1197,8 +1226,9 @@ class TestReviewingHandler:
         """Review tool event with fail verdict creates fix_request.txt."""
         handler = ReviewingHandler()
 
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "fail",
@@ -1216,15 +1246,25 @@ class TestReviewingHandler:
                 default_flow_style=False,
             )
         )
+        # Create review.md for summary prompt include
+        (mock_ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\nNeeds fixes", encoding="utf-8"
+        )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
 
-        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
         assert next_phase == "fixing"
         assert updates["review_iteration"] == 1
         assert mock_ctx.files.fix_request.exists()
-        assert mock_ctx.files.fix_request.read_text(encoding="utf-8").startswith(
-            "verdict: fail"
+        # fix_request contains aggregated feedback
+        assert "Missing validation" in mock_ctx.files.fix_request.read_text(
+            encoding="utf-8"
         )
 
     def test_handle_review_failed_at_max_iterations(
@@ -1233,8 +1273,9 @@ class TestReviewingHandler:
         """Test transition to completing when max iterations reached."""
         handler = ReviewingHandler()
 
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "fail",
@@ -1252,10 +1293,18 @@ class TestReviewingHandler:
                 default_flow_style=False,
             )
         )
+        # Create review.md for summary prompt include
+        (mock_ctx.files.review_dir / "review.md").write_text(
+            "verdict: fail\n\n## Summary\n\nStill failing", encoding="utf-8"
+        )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
 
         # Set state at max iterations
-        state = {"review_iteration": 3}
+        state = {
+            "review_iteration": 3,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
         updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
         assert next_phase == "completing"

--- a/tests/workflow/handlers/test_handlers.py
+++ b/tests/workflow/handlers/test_handlers.py
@@ -22,7 +22,7 @@ from agentmux.workflow.event_catalog import (
     EVENT_PM_COMPLETED,
     EVENT_REVIEW_PASSED,
 )
-from agentmux.workflow.event_router import PhaseResult, WorkflowEvent
+from agentmux.workflow.event_router import WorkflowEvent
 from agentmux.workflow.handlers import (
     PHASE_HANDLERS,
     CompletingHandler,
@@ -34,6 +34,7 @@ from agentmux.workflow.handlers import (
     ProductManagementHandler,
     ReviewingHandler,
 )
+from agentmux.workflow.phase_result import PhaseResult
 
 if TYPE_CHECKING:
     pass

--- a/tests/workflow/handlers/test_tool_event_migration.py
+++ b/tests/workflow/handlers/test_tool_event_migration.py
@@ -857,8 +857,9 @@ class TestReviewingHandlerToolEvents:
         from agentmux.workflow.event_catalog import EVENT_REVIEW_PASSED
 
         handler = ReviewingHandler()
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "pass",
@@ -869,17 +870,33 @@ class TestReviewingHandlerToolEvents:
                 default_flow_style=False,
             )
         )
+        # Create review.md for summary prompt include expansion
+        (mock_ctx.files.review_dir / "review.md").write_text(
+            "verdict: pass\n\n## Summary\n\nLooks good!", encoding="utf-8"
+        )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
 
-        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        with (
+            patch(
+                "agentmux.workflow.handlers.reviewing.build_reviewer_summary_prompt",
+                return_value="summary prompt",
+            ),
+            patch(
+                "agentmux.workflow.handlers.reviewing.write_prompt_file",
+                return_value=Path("/tmp/prompt.md"),
+            ),
+            patch("agentmux.workflow.handlers.reviewing.send_to_role"),
+        ):
+            updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
-        yaml_path = mock_ctx.files.review_dir / "review.yaml"
-        md_path = mock_ctx.files.review_dir / "review.md"
+        yaml_path = mock_ctx.files.review_dir / f"review_{role}.yaml"
         assert yaml_path.exists()
-        assert md_path.exists()
 
-        mock_ctx.runtime.finish_many.assert_called_once_with("coder")
-        mock_ctx.runtime.kill_primary.assert_called_once_with("coder")
         assert updates.get("awaiting_summary") is True
         assert updates.get("last_event") == EVENT_REVIEW_PASSED
         assert next_phase is None
@@ -891,8 +908,9 @@ class TestReviewingHandlerToolEvents:
         from agentmux.workflow.event_catalog import EVENT_REVIEW_FAILED
 
         handler = ReviewingHandler()
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "fail",
@@ -911,13 +929,16 @@ class TestReviewingHandlerToolEvents:
             )
         )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
+        state = {
+            "review_iteration": 0,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
 
-        updates, next_phase = handler.handle_event(event, empty_state, mock_ctx)
+        updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
-        yaml_path = mock_ctx.files.review_dir / "review.yaml"
-        md_path = mock_ctx.files.review_dir / "review.md"
+        yaml_path = mock_ctx.files.review_dir / f"review_{role}.yaml"
         assert yaml_path.exists()
-        assert md_path.exists()
         assert mock_ctx.files.fix_request.exists()
 
         assert updates["review_iteration"] == 1
@@ -929,8 +950,9 @@ class TestReviewingHandlerToolEvents:
         from agentmux.workflow.event_catalog import EVENT_REVIEW_FAILED
 
         handler = ReviewingHandler()
+        role = "reviewer_logic"
         mock_ctx.files.review_dir.mkdir(parents=True, exist_ok=True)
-        (mock_ctx.files.review_dir / "review.yaml").write_text(
+        (mock_ctx.files.review_dir / f"review_{role}.yaml").write_text(
             yaml.dump(
                 {
                     "verdict": "fail",
@@ -950,7 +972,11 @@ class TestReviewingHandlerToolEvents:
         )
         event = WorkflowEvent(kind="review", payload={"payload": {}})
 
-        state = {"review_iteration": 3}
+        state = {
+            "review_iteration": 3,
+            "active_reviews": {role: "pending"},
+            "review_results": {},
+        }
         updates, next_phase = handler.handle_event(event, state, mock_ctx)
 
         assert next_phase == "completing"

--- a/tests/workflow/test_event_router.py
+++ b/tests/workflow/test_event_router.py
@@ -15,6 +15,7 @@ from agentmux.shared.models import (
 from agentmux.workflow.event_router import (
     EventSpec,
     PhaseHandler,
+    PhaseResult,
     WorkflowEvent,
     WorkflowEventRouter,
     extract_research_topic,
@@ -80,10 +81,10 @@ class MockHandler:
     enter_calls: list = field(default_factory=list)
     handle_calls: list = field(default_factory=list)
 
-    def enter(self, state: dict, ctx: PipelineContext) -> dict:
+    def enter(self, state: dict, ctx: PipelineContext) -> PhaseResult:
         """Record enter call and return configured updates."""
         self.enter_calls.append((state.copy(), ctx))
-        return self.enter_updates
+        return PhaseResult(self.enter_updates, None)
 
     def get_event_specs(self):
         """Catch-all für Tests: jedes File-Event dispatcht 'any_file'."""
@@ -450,7 +451,7 @@ class TestIntegration:
 
             def enter(self, state, ctx):
                 workflow_log.append(f"enter:{self.name}")
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -530,7 +531,7 @@ class TestEventSpecRouting:
 
         class SpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -563,7 +564,7 @@ class TestEventSpecRouting:
 
         class SpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -595,7 +596,7 @@ class TestEventSpecRouting:
 
         class SpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -626,7 +627,7 @@ class TestEventSpecRouting:
 
         class SpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -660,7 +661,7 @@ class TestEventSpecRouting:
 
         class EmptySpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return ()
@@ -687,7 +688,7 @@ class TestEventSpecRouting:
 
         class LegacyHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def handle_event(self, event, state, ctx):
                 received.append(event)
@@ -711,7 +712,7 @@ class TestEventSpecRouting:
 
         class MultiSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -749,7 +750,7 @@ class TestEventSpecRouting:
 
         class StatefulSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -793,7 +794,7 @@ class TestEventSpecRouting:
 
         class SpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -848,7 +849,7 @@ class TestToolSpecRouting:
 
         class ToolSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return ()
@@ -888,7 +889,7 @@ class TestToolSpecRouting:
 
         class ToolSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return ()
@@ -929,7 +930,7 @@ class TestToolSpecRouting:
 
         class DualSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -977,7 +978,7 @@ class TestToolSpecRouting:
 
         class ToolSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return ()
@@ -1016,7 +1017,7 @@ class TestToolSpecRouting:
 
         class NoToolSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return ()
@@ -1065,7 +1066,7 @@ class TestEnteredBeforeEnter:
             def enter(self, state, ctx):
                 # Router should have already added phase to _entered
                 entered_during_enter.append(state.get("phase", "") in router._entered)
-                return {}
+                return PhaseResult({}, None)
 
             def handle_event(self, event, state, ctx):
                 return {}, None
@@ -1108,7 +1109,7 @@ class TestPhaseEntryAtTransition:
         class PlanningHandler:
             def enter(self, state, ctx):
                 enter_calls.append("planning")
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -1128,7 +1129,7 @@ class TestPhaseEntryAtTransition:
         class ImplementingHandler:
             def enter(self, state, ctx):
                 enter_calls.append("implementing")
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -1185,7 +1186,7 @@ class TestPreDispatchFilter:
 
         class ToolSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return ()
@@ -1220,7 +1221,7 @@ class TestPreDispatchFilter:
 
         class FileSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -1253,7 +1254,7 @@ class TestPreDispatchFilter:
 
         class FileSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (
@@ -1286,7 +1287,7 @@ class TestPreDispatchFilter:
 
         class FileSpecHandler:
             def enter(self, state, ctx):
-                return {}
+                return PhaseResult({}, None)
 
             def get_event_specs(self):
                 return (

--- a/tests/workflow/test_event_router.py
+++ b/tests/workflow/test_event_router.py
@@ -15,7 +15,6 @@ from agentmux.shared.models import (
 from agentmux.workflow.event_router import (
     EventSpec,
     PhaseHandler,
-    PhaseResult,
     WorkflowEvent,
     WorkflowEventRouter,
     extract_research_topic,
@@ -23,6 +22,7 @@ from agentmux.workflow.event_router import (
     path_matches,
     path_matches_any,
 )
+from agentmux.workflow.phase_result import PhaseResult
 from agentmux.workflow.transitions import PipelineContext
 
 


### PR DESCRIPTION
## Summary

Large refactoring covering three major areas:

### 1. Parallel Reviewer Support
- Replace sequential review loop with parallel `send_reviewers_many()` dispatch
- Add `submit_review(role=...)` for role-specific `review_{role}.yaml` files
- Add `select_reviewer_roles()` for severity/focus-based reviewer selection
  - `low` severity → `quality` reviewer
  - `medium`/`high` + security/performance focus → `expert` reviewer
  - `medium`/`high` otherwise → `logic` reviewer
- Add `review_yaml_has_verdict()` helper for role-specific YAML detection
- Implement resume support for parallel reviewers

### 2. Remove `feature_dir` from Submit MCP Tools
- Remove redundant `feature_dir` parameter from all 6 submit tools:
  - `submit_architecture`, `submit_plan`, `submit_review`, `submit_done`,
    `submit_research_done`, `submit_pm_done`
- `feature_dir` is already resolved from `FEATURE_DIR` env var in the session context

### 3. Prompt Refactoring
- Extract shared `research-constraints` prompt fragment
- Add `.cursor/commands` symlink for Cursor IDE integration

## Test Coverage
- 33 files changed, 2388 insertions, 484 deletions
- 6 new test files added
- All existing tests updated for parallel review workflow