### PR TITLE
fix: compact review follow-up prompt for iterations > 0 (#119)

### DIFF
--- a/.agentmux/config.yaml
+++ b/.agentmux/config.yaml
@@ -2,12 +2,11 @@ version: 2
 
 defaults:
   session_name: agentmux
-  provider: qwen
+  provider: copilot
+  model: gpt-5.4
   max_review_iterations: 3
 
 roles:
-  architect:
-    provider: copilot
   web-researcher:
     provider: opencode
   code-researcher:

--- a/docs/phases/07_review.md
+++ b/docs/phases/07_review.md
@@ -63,4 +63,5 @@ See [Artifact: review.yaml](../artifacts/review-yaml.md) for the full schema and
 
 - If `review.md` is missing when downstream prompts need it, AgentMux materializes it automatically from `review.yaml`.
 - The reviewer also writes `08_completion/summary.md` after a pass verdict (while still in `reviewing` phase with `awaiting_summary: true` in state), before the pipeline transitions to `completing`.
+- **Post-fix follow-up prompt**: When re-entering `reviewing` after a `fixing` iteration (`review_iteration > 0`) and the previous iteration's role-specific archive `review_{prev}_{pane_role}.md` exists, the handler dispatches a compact follow-up prompt built from `prompts/commands/review_followup.md` instead of the full initial prompt. It references only the reviewer's own prior archive and the aggregated `fix_request.md` — no `context.md`, `architecture.md`, or `plan.md` includes. If the archive is missing (e.g. the previous round was killed), the handler falls back to the initial prompt.
 - See [Handoff Contracts](../handoff-contracts.md#review) for full validation rules applied to `review.yaml`.

--- a/src/agentmux/prompts/commands/review_followup.md
+++ b/src/agentmux/prompts/commands/review_followup.md
@@ -4,11 +4,7 @@ You are still [[placeholder:review_role]] for this pipeline run.
 The coder has addressed the findings from your previous review. Re-check
 only whether those findings are resolved. Do not re-read the architecture,
 plan, or context files — they have not changed. Do not expand scope.
-
-Your previous findings (role-specific):
-<file path="[[placeholder:previous_review_file]]">
-[[include:[[placeholder:previous_review_file]]]]
-</file>
+Your previous findings are still in your session context.
 
 Aggregated fix request the coder worked from:
 <file path="[[placeholder:fix_request_file]]">

--- a/src/agentmux/prompts/commands/review_followup.md
+++ b/src/agentmux/prompts/commands/review_followup.md
@@ -1,0 +1,29 @@
+Follow-up Review — iteration [[placeholder:review_iteration]]
+
+You are still [[placeholder:review_role]] for this pipeline run.
+The coder has addressed the findings from your previous review. Re-check
+only whether those findings are resolved. Do not re-read the architecture,
+plan, or context files — they have not changed. Do not expand scope.
+
+Your previous findings (role-specific):
+<file path="[[placeholder:previous_review_file]]">
+[[include:[[placeholder:previous_review_file]]]]
+</file>
+
+Aggregated fix request the coder worked from:
+<file path="[[placeholder:fix_request_file]]">
+[[include:[[placeholder:fix_request_file]]]]
+</file>
+
+Task:
+1. Verify whether each of your previous findings is now resolved.
+2. Do not open issues outside your role's scope.
+3. Write `07_review/review_[[placeholder:review_role]].yaml` with `verdict: pass` or `verdict: fail`.
+   On `fail`, list only the findings that are still unresolved (or newly introduced by the fix).
+4. FINAL STEP ONLY — once the YAML is fully written, call `mcp__agentmux__submit_review()` to signal completion.
+
+[[placeholder:project_instructions]]
+
+Constraints:
+- Communicate only through files in the shared feature directory.
+- Do not modify project files or re-run unchanged checks against other roles.

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -162,12 +162,10 @@ class ReviewingHandler(BaseToolHandler):
             prev_archive = ctx.files.review_dir / f"review_{prev_iter}_{pane_role}.md"
             fix_request = ctx.files.fix_request
             if prev_archive.is_file() and fix_request.is_file():
-                previous_review_rel = str(ctx.files.relative_path(prev_archive))
                 fix_request_rel = str(ctx.files.relative_path(fix_request))
                 return build_reviewer_followup_prompt(
                     ctx.files,
                     pane_role=pane_role,
-                    previous_review_rel=previous_review_rel,
                     fix_request_rel=fix_request_rel,
                     review_iteration=review_iteration,
                     agent=ctx.agents.get(pane_role),

--- a/src/agentmux/workflow/handlers/reviewing.py
+++ b/src/agentmux/workflow/handlers/reviewing.py
@@ -24,6 +24,7 @@ from agentmux.workflow.phase_helpers import (
 )
 from agentmux.workflow.prompts import (
     build_reviewer_expert_prompt,
+    build_reviewer_followup_prompt,
     build_reviewer_logic_prompt,
     build_reviewer_prompt,
     build_reviewer_quality_prompt,
@@ -143,6 +144,44 @@ class ReviewingHandler(BaseToolHandler):
             "review_results": review_results,
         }
 
+    def _build_single_reviewer_prompt(
+        self,
+        role_suffix: str,
+        pane_role: str,
+        review_iteration: int,
+        ctx: PipelineContext,
+    ) -> str:
+        """Return the prompt text for one reviewer role.
+
+        Picks the compact follow-up prompt when we are past the first review
+        iteration AND the previous iteration's archived review for this role
+        exists. Falls back to the initial role-specific prompt otherwise.
+        """
+        if review_iteration > 0:
+            prev_iter = review_iteration - 1
+            prev_archive = ctx.files.review_dir / f"review_{prev_iter}_{pane_role}.md"
+            fix_request = ctx.files.fix_request
+            if prev_archive.is_file() and fix_request.is_file():
+                previous_review_rel = str(ctx.files.relative_path(prev_archive))
+                fix_request_rel = str(ctx.files.relative_path(fix_request))
+                return build_reviewer_followup_prompt(
+                    ctx.files,
+                    pane_role=pane_role,
+                    previous_review_rel=previous_review_rel,
+                    fix_request_rel=fix_request_rel,
+                    review_iteration=review_iteration,
+                    agent=ctx.agents.get(pane_role),
+                )
+
+        prompt_builder = _REVIEWER_PROMPT_BUILDERS.get(role_suffix)
+        if prompt_builder is None:
+            agent_prompt = build_reviewer_prompt(
+                ctx.files, agent=ctx.agents.get(pane_role)
+            )
+            command_prompt = build_reviewer_prompt(ctx.files, is_review=True)
+            return f"{agent_prompt}\n\n{command_prompt}"
+        return prompt_builder(ctx.files, ctx.agents.get(pane_role))
+
     def _build_reviewer_specs(
         self,
         reviewer_roles: list[str],
@@ -150,23 +189,24 @@ class ReviewingHandler(BaseToolHandler):
         ctx: PipelineContext,
         state: dict,
     ) -> list[ReviewerSpec]:
-        """Build ReviewerSpec list for roles that still need reviewing."""
+        """Build ReviewerSpec list for roles that still need reviewing.
+
+        When ``state['review_iteration'] > 0`` and the previous iteration's
+        archived review for this role exists, dispatch a compact follow-up
+        prompt (Issue #119) instead of the full initial prompt. Otherwise —
+        and as a defensive fallback when the archive is missing — use the
+        initial reviewer prompt.
+        """
+        review_iteration = int(state.get("review_iteration", 0))
         specs: list[ReviewerSpec] = []
         for role_suffix in reviewer_roles:
             pane_role = _REVIEWER_ROLE_MAP[role_suffix]
             if active_reviews.get(pane_role) != "pending":
                 continue
 
-            prompt_builder = _REVIEWER_PROMPT_BUILDERS.get(role_suffix)
-            if prompt_builder is None:
-                # Fallback: generic reviewer
-                agent_prompt = build_reviewer_prompt(
-                    ctx.files, agent=ctx.agents.get(pane_role)
-                )
-                command_prompt = build_reviewer_prompt(ctx.files, is_review=True)
-                full_prompt = f"{agent_prompt}\n\n{command_prompt}"
-            else:
-                full_prompt = prompt_builder(ctx.files, ctx.agents.get(pane_role))
+            full_prompt = self._build_single_reviewer_prompt(
+                role_suffix, pane_role, review_iteration, ctx
+            )
 
             # Write the prompt to a role-specific file
             prompt_filename = f"review_{role_suffix}_prompt.md"

--- a/src/agentmux/workflow/prompts.py
+++ b/src/agentmux/workflow/prompts.py
@@ -307,7 +307,6 @@ def build_reviewer_expert_prompt(
 def build_reviewer_followup_prompt(
     files: RuntimeFiles,
     pane_role: str,
-    previous_review_rel: str,
     fix_request_rel: str,
     review_iteration: int,
     agent: AgentConfig | None = None,
@@ -316,8 +315,8 @@ def build_reviewer_followup_prompt(
 
     Unlike `build_reviewer_<role>_prompt`, this deliberately omits the big
     initial includes (context.md, architecture.md, plan.md). It only references
-    the reviewer's own previous archived review and the aggregated fix_request,
-    so the reviewer can focus on whether their prior findings were resolved.
+    the aggregated fix_request so the reviewer can focus on whether their prior
+    findings (still in session context) were resolved.
     """
     del agent  # reserved for future per-agent tweaks; unused today
     rendered = _render_template(
@@ -329,7 +328,6 @@ def build_reviewer_followup_prompt(
         {
             "review_role": pane_role,
             "review_iteration": str(review_iteration),
-            "previous_review_file": previous_review_rel,
             "fix_request_file": fix_request_rel,
         },
     )

--- a/src/agentmux/workflow/prompts.py
+++ b/src/agentmux/workflow/prompts.py
@@ -304,6 +304,38 @@ def build_reviewer_expert_prompt(
     return _expand_session_includes(rendered, files.feature_dir)
 
 
+def build_reviewer_followup_prompt(
+    files: RuntimeFiles,
+    pane_role: str,
+    previous_review_rel: str,
+    fix_request_rel: str,
+    review_iteration: int,
+    agent: AgentConfig | None = None,
+) -> str:
+    """Build a compact follow-up prompt for a reviewer after a fix iteration.
+
+    Unlike `build_reviewer_<role>_prompt`, this deliberately omits the big
+    initial includes (context.md, architecture.md, plan.md). It only references
+    the reviewer's own previous archived review and the aggregated fix_request,
+    so the reviewer can focus on whether their prior findings were resolved.
+    """
+    del agent  # reserved for future per-agent tweaks; unused today
+    rendered = _render_template(
+        _load_template(
+            "commands",
+            "review_followup",
+            project_dir=files.project_dir,
+        ),
+        {
+            "review_role": pane_role,
+            "review_iteration": str(review_iteration),
+            "previous_review_file": previous_review_rel,
+            "fix_request_file": fix_request_rel,
+        },
+    )
+    return _expand_session_includes(rendered, files.feature_dir)
+
+
 def build_reviewer_summary_prompt(
     files: RuntimeFiles, agent: AgentConfig | None = None
 ) -> str:

--- a/tests/unit/workflow/handlers/test_reviewing.py
+++ b/tests/unit/workflow/handlers/test_reviewing.py
@@ -543,3 +543,109 @@ class TestReviewYamlHasVerdictParallel:
             encoding="utf-8",
         )
         assert review_yaml_has_verdict(review_dir) is False
+
+
+class TestFollowupPromptAfterFix:
+    """Post-fix follow-up prompt dispatch (Issue #119)."""
+
+    def test_initial_prompt_used_on_first_iteration(self, tmp_path):
+        """review_iteration == 0 → initial reviewer prompt (full context)."""
+        ctx = FakeContext(tmp_path)
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 0,
+            "last_event": "implementation_completed",
+            "review_results": {},
+        }
+        handler.enter(state, ctx)
+
+        prompt_path = ctx.files.review_dir / "review_logic_prompt.md"
+        assert prompt_path.exists()
+        prompt_content = prompt_path.read_text(encoding="utf-8")
+        # Initial prompt includes architecture.md content via [[include:...]]
+        assert "# Architecture" in prompt_content
+        # Initial prompt identifies this role
+        assert "Logic" in prompt_content or "logic" in prompt_content
+        # Not a follow-up prompt
+        assert "Follow-up" not in prompt_content
+
+    def test_followup_prompt_used_after_fix(self, tmp_path):
+        """review_iteration > 0 + prior archive exists → compact follow-up prompt."""
+        ctx = FakeContext(tmp_path)
+
+        # Previous iteration's archive — what the reviewer wrote last round.
+        prev_archive = ctx.files.review_dir / "review_0_reviewer_logic.md"
+        prev_archive.write_text(
+            "# Previous findings\n\n- Logic bug in handler X\n",
+            encoding="utf-8",
+        )
+        # Aggregated fix request the coder worked from.
+        fix_request_path = ctx.files.review_dir / "fix_request.md"
+        fix_request_path.write_text(
+            "## Review: reviewer_logic (verdict: fail)\n\n- Logic bug in handler X\n",
+            encoding="utf-8",
+        )
+        ctx.files.fix_request = fix_request_path
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 1,
+            "last_event": "implementation_completed",
+            "review_results": {},
+        }
+        handler.enter(state, ctx)
+
+        prompt_path = ctx.files.review_dir / "review_logic_prompt.md"
+        assert prompt_path.exists()
+        content = prompt_path.read_text(encoding="utf-8")
+
+        # Must reference the previous review archive (content or path).
+        assert "Logic bug in handler X" in content
+        # Follow-up marker must be present.
+        assert "Follow-up" in content
+        # Must include the aggregated fix_request content.
+        assert "Review: reviewer_logic" in content
+        # Must NOT re-include the big initial-prompt fragments.
+        assert "# Architecture" not in content
+        assert "# Context" not in content
+        # Iteration number is shown so the reviewer knows it's a re-review.
+        assert "iteration" in content.lower()
+
+    def test_followup_falls_back_to_initial_when_archive_missing(self, tmp_path):
+        """Fallback: no prior archive → initial prompt is used (no crash)."""
+        ctx = FakeContext(tmp_path)
+
+        handler = ReviewingHandler()
+        state = {
+            "review_iteration": 1,
+            "last_event": "implementation_completed",
+            "review_results": {},
+        }
+        # No review_0_reviewer_logic.md exists.
+        handler.enter(state, ctx)
+
+        prompt_path = ctx.files.review_dir / "review_logic_prompt.md"
+        assert prompt_path.exists()
+        content = prompt_path.read_text(encoding="utf-8")
+        # Fallback to initial prompt (contains architecture.md include).
+        assert "# Architecture" in content
+        assert "Follow-up" not in content
+
+    def test_resume_path_still_skips_completed(self, tmp_path):
+        """Resume with all-completed reviews must NOT trigger a dispatch."""
+        ctx = FakeContext(tmp_path)
+
+        handler = ReviewingHandler()
+        state = {
+            "last_event": "resumed",
+            "review_iteration": 1,
+            "review_results": {
+                "reviewer_logic": {"verdict": "pass", "review_text": "OK"},
+            },
+            "active_reviews": {"reviewer_logic": "completed"},
+        }
+
+        with patch.object(handler, "_request_summary", return_value={}):
+            handler.enter(state, ctx)
+        ctx.runtime.send_reviewers_many.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `review_followup.md` template for compact post-fix follow-up prompts
- Update reviewing handler to dispatch the follow-up prompt when re-entering `reviewing` after a `fixing` iteration (`review_iteration > 0`)
- Fall back to the full initial prompt if the previous iteration's archive is missing
- Update docs (07_review.md) and add unit tests
- Simplify config.yaml defaults (remove architect provider override)
- Remove previous_review_file from follow-up prompt (reviewer has prior findings in session context)

## Context
Closes #119 — reduces prompt overhead in multi-iteration review cycles by sending only the aggregated `fix_request.md` instead of full context. The reviewer's own prior findings remain in session context and don't need to be re-included.